### PR TITLE
Adopt starfield framelib for coordinate transforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,86 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,10 +92,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -24,10 +128,146 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -55,10 +295,174 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -72,10 +476,399 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -90,6 +883,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "log"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,10 +911,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
 
 [[package]]
 name = "nalgebra"
@@ -134,6 +1007,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +1071,12 @@ dependencies = [
  "num-traits",
  "serde",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -153,11 +1088,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-rational"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -173,6 +1120,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "p9-2016-constraints"
 version = "0.1.0"
 dependencies = [
@@ -180,7 +1188,7 @@ dependencies = [
  "nalgebra",
  "p9-2016-evidence",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "rayon",
  "serde",
@@ -194,7 +1202,7 @@ dependencies = [
  "approx",
  "nalgebra",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "rayon",
  "serde",
@@ -208,7 +1216,7 @@ dependencies = [
  "approx",
  "nalgebra",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "rayon",
  "serde",
@@ -232,7 +1240,7 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "serde_json",
@@ -245,7 +1253,7 @@ dependencies = [
  "approx",
  "nalgebra",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "serde_json",
@@ -257,7 +1265,7 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "serde_json",
@@ -269,7 +1277,7 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "serde_json",
@@ -281,7 +1289,7 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "serde_json",
@@ -293,7 +1301,7 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "serde_json",
@@ -306,7 +1314,7 @@ dependencies = [
  "approx",
  "nalgebra",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "serde_json",
@@ -318,7 +1326,7 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "serde_json",
@@ -331,7 +1339,7 @@ dependencies = [
  "approx",
  "nalgebra",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "serde_json",
@@ -344,7 +1352,7 @@ dependencies = [
  "approx",
  "p9-2021-orbit",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "serde_json",
@@ -355,9 +1363,10 @@ name = "p9-2022-des"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "nalgebra",
  "p9-2021-orbit",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "serde_json",
@@ -369,7 +1378,7 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "serde_json",
@@ -381,7 +1390,7 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "serde_json",
@@ -396,7 +1405,7 @@ dependencies = [
  "p9-2021-ztf",
  "p9-2022-des",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "serde_json",
@@ -407,8 +1416,9 @@ name = "p9-2025-clustering"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "nalgebra",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "serde_json",
@@ -420,7 +1430,7 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "serde_json",
@@ -432,7 +1442,7 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "p9-core",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "serde",
  "serde_json",
@@ -444,11 +1454,12 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "nalgebra",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "rayon",
  "serde",
  "serde_json",
+ "starfield",
 ]
 
 [[package]]
@@ -462,12 +1473,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -480,6 +1562,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,14 +1577,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -506,7 +1616,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -515,7 +1635,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -525,7 +1654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -555,6 +1684,150 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "safe_arch"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +1835,44 @@ checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -607,6 +1918,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sgp4"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9467b9a7be8485ed8be0f336d399c8f32c0fcd60686e7dd2ed3dab75c9a73eb3"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "simba"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,6 +1960,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "starfield"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065d0a9a42dae2090524cb239a24d6805f7f3d27cb43b0f81c2f06d7dd070abd"
+dependencies = [
+ "base64",
+ "byteorder",
+ "chrono",
+ "clap",
+ "flate2",
+ "image",
+ "indicatif",
+ "lazy_static",
+ "log",
+ "md5",
+ "memmap2",
+ "nalgebra",
+ "ndarray",
+ "num",
+ "once_cell",
+ "rand 0.9.4",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sgp4",
+ "thiserror",
+ "time",
+ "uom",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,10 +2049,236 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1aa89044e7786ffb2ec017acb22cb7de5b0be46d0f21aea2b224b8561e5db2"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -643,10 +2287,204 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "uom"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd5cfe7d84f6774726717f358a37f5bca8fca273bed4de40604ad129d1107b49"
+dependencies = [
+ "num-traits",
+ "typenum",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.123"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "wide"
@@ -656,6 +2494,290 @@ checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
 dependencies = [
  "bytemuck",
  "safe_arch",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -679,7 +2801,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -138,8 +138,9 @@ derived quantities:
   can fire at extreme states (reproduced at a = 800 AU, e = 0.95, M ≈ 5.97, dt = 4e5 d).
   p9-2021-oort-cloud sidesteps it with an element-space drift via `solve_kepler`. A proper fix
   (Stumpff-series Newton with bracketing on the universal anomaly) belongs in p9-core.
-- p9-core still lacks an ecliptic↔equatorial transform; `p9-2022-des/src/sky.rs` (shared with
-  p9-2024-panstarrs) and `p9-2021-ztf/src/sky.rs` carry local documented conversions that should
-  eventually consolidate into `p9_core::coords`.
+- ~~p9-core still lacks an ecliptic↔equatorial transform~~ — resolved: `p9_core::coords::sky`
+  wraps starfield's framelib (ECLIPJ2000/GALACTIC SPICE matrices); the local conversions in
+  `p9-2022-des/src/sky.rs`, `p9-2021-ztf/src/sky.rs`, `p9-2025-iras-akari` and the hand-rolled
+  galactic pole in `p9-core/src/forces/galactic_tide.rs` were deleted in favor of it.
 - No shared simulation snapshot driver in p9-core; the 2016-crate run loops were harmonized in
   place but remain three copies.

--- a/STARFIELD_INTEGRATION.md
+++ b/STARFIELD_INTEGRATION.md
@@ -1,0 +1,223 @@
+# Starfield ↔ Planet9 Integration Notes
+
+Cross-map between this repo and `starfield` v0.13 (~/repos/starfield, the Rust
+skyfield port) plus its `starfield-datasources` workspace. Two directions:
+where starfield tooling would improve planet9's modeling, and where planet9
+machinery would be generally useful upstream in starfield.
+
+---
+
+## Part 1 — Planet9 improvements available from starfield
+
+Ordered by leverage.
+
+### 1.1 Coordinate frames: replace every hand-rolled transform
+
+The single biggest win. Planet9 currently carries **four local coordinate
+conversions**, all flagged in REPRODUCTION_NOTES.md as consolidation debt:
+
+| Planet9 location | What it hand-rolls | Starfield replacement |
+|---|---|---|
+| `p9-2022-des/src/sky.rs` (shared with p9-2024-panstarrs) | ecliptic→equatorial for declination cuts | `framelib::ECLIPTIC_J2000` / `ICRS` frame matrices |
+| `p9-2021-ztf/src/sky.rs` | elements→ecliptic λ/β→declination | same |
+| `p9-2025-iras-akari/src/orbital_constraints.rs` | local equatorial↔ecliptic | same |
+| `p9-core/src/forces/galactic_tide.rs` | galactic-pole orientation (~60.2° literal) | `framelib::GALACTIC` matrix (SPICE-derived) |
+
+Starfield's transforms come with IAU 2006 precession (`precessionlib`) and
+full IAU 2000A nutation (1,365 terms, `nutationlib`), validated against
+skyfield/astropy to ~1e-8 per matrix element. The survey-footprint findings
+(P2: "declination/ecliptic-latitude conflation") exist precisely because
+planet9 lacked this; `coordinates::{Equatorial, Ecliptic, Galactic}` with
+`From` impls make those bugs unrepresentable.
+
+Also relevant: `p9-2025-clustering`'s orbital-pole / Laplace-plane geometry
+could use `Cartesian3::angular_distance` and the frame machinery instead of
+its local spherical-distance helper.
+
+### 1.2 Earth position & geocentric apparent positions (IRAS/AKARI, DES, PS1)
+
+`p9-2025-iras-akari` models geocentric parallax with a **documented
+circular-Earth approximation**; `p9-2022-des/sky.rs` approximates parallactic
+motion similarly. Starfield gives the exact chain:
+
+- `Loader::open("de421.bsp")` → `SpiceKernel` (auto-downloaded, mmap-backed)
+- `kernel.at("earth", &t)` → barycentric Earth at the true survey epochs
+- `Position::observe(...)` → `.apparent(...)` adds light-time iteration,
+  relativistic aberration, and gravitational deflection — all currently
+  ignored in planet9's survey models. At 500–700 AU, light-time alone is
+  ~3–4 days; for the 1983→2006 IRAS/AKARI epoch pair that's a real (if small)
+  systematic on the proper-motion window.
+
+The epochs themselves should become `time::Time` values (TT/TDB-aware)
+instead of raw year floats — `Timescale::utc((1983, ...))` etc.
+
+### 1.3 Giant-planet states from real ephemerides
+
+`p9-core/src/initial_conditions/planets.rs` hard-codes J2000 state vectors.
+`planetlib::Ephemeris::get_state(Body::Neptune, &t)` (DE440/441) gives exact
+states at **any** epoch — better initial conditions, exact Laplace-plane
+references, and the ability to start integrations at survey/discovery epochs
+rather than J2000 only.
+
+### 1.4 Kepler solver and element conversions
+
+- p9-core's `kepler_drift` universal-variable iteration has a **known
+  convergence edge case** (a≈800 AU, e≈0.95, long dt — see
+  REPRODUCTION_NOTES.md "Known numerical issues"). Starfield's `keplerlib`
+  carries a SPICE `prop2b` port (universal variables + Stumpff) and an
+  eccentric-anomaly solver (elliptic *and* hyperbolic, arXiv:2108.03215),
+  both parity-tested against skyfield. Replacing or cross-validating
+  p9-core's drift against it would close that issue.
+- `elementslib::OsculatingElements` is a robust element extractor handling
+  elliptic/parabolic/hyperbolic with explicit `inf` semantics — exactly the
+  edge cases (e≈0, i≈0, retrograde, hyperbolic) where p9-core's
+  `cartesian_to_elements` had bugs. Worth adopting or at least
+  property-testing against.
+
+### 1.5 Live small-body data instead of hand-vetted tables
+
+The fabricated-TNO-table finding (N1: a near-Earth asteroid listed as a
+110 AU TNO) happened because planet9 transcribes elements by hand.
+Starfield's `SbdbClient::query(SbdbQueryParams)` can express the
+p9-2024-neptune-crossing selection directly (a > 100 AU, q < 30 AU,
+i < 40°, numbered/multi-opposition) and return `SmallBodyOrbit` records with
+epochs, arcs, and condition codes. `starfield-mpc` parses MPCORB for the
+same offline. The right architecture: `p9_core::data::etno` keeps the
+frozen, provenance-commented snapshot used by regression tests, plus an
+optional refresh path through SbdbClient that diffs against the snapshot —
+catching both transcription errors and element drift.
+
+`HorizonsClient::generate_spk_kernel` also covers the discovery-circumstance
+gap (N2's documented r ≈ 1.15q approximation): real discovery-epoch
+distances for each sample object.
+
+### 1.6 Photometry cross-validation
+
+- `starfield-mpc::hg_apparent_magnitude(h, g, phase)` is the proper IAU H–G
+  phase law; p9-core's `apparent_magnitude` omits the phase function
+  (negligible at opposition for P9, but the DES/PS1 models integrate over
+  epochs where it isn't exactly zero).
+- `magnitudelib::planetary_magnitude` (Mallama & Hilton 2018) covers
+  Neptune — the natural validation anchor for
+  `photometry::planet_apparent_magnitude`, which is already tested against
+  Neptune's H ≈ −6.87 with our own formula. An independent cross-check test
+  would pin both.
+
+### 1.7 Event finding for survey models
+
+`searchlib::{find_discrete, find_maxima}` plus
+`almanac::oppositions_conjunctions` would let the DES/PS1/ZTF models compute
+**when** a synthetic P9 is at opposition / inside a footprint, instead of
+quantizing onto night grids by hand. Lower priority — the current
+k-of-n-night models are adequate — but it's the principled version of the
+`night_usability` calibration knob.
+
+### 1.8 Shared constants
+
+`starfield::constants` (AU_KM = 149,597,870.700, GM_SUN in km³/s², C_AUDAY,
+J2000) and p9-core `constants.rs` should agree to full precision; today they
+are independently transcribed. If p9-core takes starfield as a dependency,
+re-export rather than redefine.
+
+### Suggested adoption order
+
+1. Add `starfield` as a p9-core dependency; replace the three local `sky.rs`
+   conversions + galactic-tide orientation with `framelib` (deletes code,
+   fixes nothing visible — pure de-risking).
+2. Cross-validate / replace `kepler_drift` and `cartesian_to_elements`
+   against `keplerlib`/`elementslib` (closes the known numerical issue).
+3. Earth-from-ephemeris in IRAS/AKARI parallax + survey epoch handling via
+   `time::Time`.
+4. SBDB refresh path for `data::etno` with snapshot diffing.
+5. Giant-planet initial conditions from `planetlib` at arbitrary epochs.
+
+---
+
+## Part 2 — Planet9 machinery generally useful upstream in starfield
+
+Starfield's survey confirms: **no N-body or perturbed propagation exists
+anywhere in it** (two-body Kepler, SGP4, SPK lookup only), and nothing in the
+statistics/dynamics space. Planet9 built exactly that. Candidates, ordered by
+generality:
+
+### 2.1 N-body integrator stack → `starfield-nbody` (or `starfield::nbodylib`)
+
+The headline contribution. p9-core now has:
+- symplectic Wisdom–Holman in democratic-heliocentric coordinates (DLL98),
+  with energy/angular-momentum diagnostics and dt-scaling tests
+- Bulirsch–Stoer with step-size control
+- Chambers (1999) hybrid switching with smooth changeover and
+  minimum-separation encounter prediction
+- the `ExtraForce` composable perturbation hook (J2 secular field, galactic
+  tide, custom closures)
+
+This fills starfield's documented gap and is already validated by 600+ tests.
+As a companion crate (`starfield-nbody` in the datasources-style pattern) it
+could consume starfield's `Time`, frames, and ephemerides for initial
+conditions — the integration is symmetric with Part 1.3.
+
+### 2.2 Secular / resonance dynamics toolkit
+
+`p9_core::analysis::{secular, resonance, hansen}`:
+- quadrupole + octupole secular Hamiltonians and numerical Gauss-ring double
+  averaging (valid in the non-hierarchical regime where series diverge)
+- Hansen coefficients with convergence-controlled quadrature
+- canonical mean-motion resonance widths, Chirikov overlap, critical
+  perihelion, resonant-angle/libration detection on time series
+
+No equivalent exists in starfield or, to my knowledge, anywhere in the Rust
+ecosystem. Useful to anyone doing long-term small-body dynamics (Kozai/vZLK,
+resonance sticking, Oort-cloud work).
+
+### 2.3 Circular statistics
+
+`p9_core::analysis::circular` — circular mean/std, mean resultant length,
+Rayleigh test with the small-n series correction, Kuiper test. Generic
+directional statistics with astronomy-grade tests; natural fit for a
+starfield statistics module (skyfield has no equivalent either — this would
+be a differentiator).
+
+### 2.4 Generic small-body photometry
+
+p9-core's `photometry` (mass-radius relation for Neptunian bodies,
+H from radius+albedo, reflected-light apparent magnitude) complements
+starfield's `magnitudelib`, which only covers the 8 known planets via
+Mallama–Hilton. A "hypothetical body" API (mass/radius/albedo → V at r, Δ)
+is useful for occultation prediction, survey planning, and population
+synthesis. Combine with `starfield-mpc`'s H–G phase law for the full picture.
+
+### 2.5 Survey detection/completeness modeling
+
+The per-orbit survey machinery built for ZTF/DES/PS1 — footprint membership,
+per-epoch magnitude-dependent efficiency, k-of-n-night linking via exact
+Poisson-binomial tails, per-orbit OR combination across surveys — generalizes
+to any "would survey X have seen object Y" question. Fits the
+`starfield-datasources` pattern (alongside `starfield-rubin`) as a
+`starfield-surveysim` crate. The Poisson-binomial tail helper alone
+(`p9-2022-des`) is a reusable numerical primitive.
+
+### 2.6 Synthetic small-body populations
+
+`p9_core::initial_conditions` (scattered-disk generators with documented
+distributions, deterministic-N resampling, seeded) complements starfield's
+synthetic *star* catalogs — same idea, solar-system flavored. Useful for
+injection/recovery testing against any of the datasource crates.
+
+### 2.7 Smaller pieces
+
+- MSD-based diffusion estimator with multi-origin averaging
+  (`p9-2025-clustering/src/diffusion.rs`) — time-series analysis primitive.
+- The pyo3 parity-testing pattern flows the other way: starfield's
+  `python-tests` harness (validating against skyfield/astropy) is a model
+  planet9 should eventually adopt for validating the integrators against
+  rebound.
+
+---
+
+## Non-overlaps (no action)
+
+- Starfield's star catalogs (Gaia/Hipparcos), SGP4/satellite work, eclipses,
+  almanac, image/star-finder tooling have no planet9 counterpart or need.
+- Planet9's paper-specific crates (everything outside p9-core) are
+  reproductions, not library material; only p9-core contents are upstream
+  candidates.

--- a/crates/p9-2021-ztf/src/sky.rs
+++ b/crates/p9-2021-ztf/src/sky.rs
@@ -2,18 +2,14 @@
 //!
 //! Heliocentric ecliptic longitude/latitude come from the Cartesian state of
 //! the orbital elements (p9-core conversion); equatorial declination follows
-//! from a rotation by the obliquity of the ecliptic. For the distant-object
-//! footprint question (hundreds of AU) the parallax between heliocentric and
-//! geocentric directions is < 0.2 degrees and is neglected.
-//!
-//! (p9-core's coords module currently only provides democratic-heliocentric
-//! transforms, so the ecliptic → equatorial step lives here.)
+//! from p9-core's `coords::sky` ecliptic → equatorial transform (starfield's
+//! ECLIPJ2000 frame matrix). For the distant-object footprint question
+//! (hundreds of AU) the parallax between heliocentric and geocentric
+//! directions is < 0.2 degrees and is neglected.
 
 use p9_core::constants::{DEG2RAD, GM_SUN};
+use p9_core::coords::sky::ecliptic_vec_declination;
 use p9_core::types::OrbitalElements;
-
-/// Obliquity of the ecliptic, J2000 (radians).
-pub const OBLIQUITY: f64 = 23.439_291 * DEG2RAD;
 
 /// Heliocentric ecliptic longitude, latitude (radians) and distance (AU)
 /// for orbital elements at their stored mean anomaly.
@@ -25,21 +21,16 @@ pub fn ecliptic_position(elem: &OrbitalElements) -> (f64, f64, f64) {
     (lambda, beta, r)
 }
 
-/// Equatorial declination (radians) from ecliptic longitude/latitude:
-/// sin δ = sin β cos ε + cos β sin ε sin λ.
-pub fn declination(lambda: f64, beta: f64) -> f64 {
-    (beta.sin() * OBLIQUITY.cos() + beta.cos() * OBLIQUITY.sin() * lambda.sin()).asin()
-}
-
 /// Declination (degrees) of an orbit's current sky position.
 pub fn declination_deg(elem: &OrbitalElements) -> f64 {
-    let (lambda, beta, _) = ecliptic_position(elem);
-    declination(lambda, beta) / DEG2RAD
+    let state = elem.to_state_vector(GM_SUN);
+    ecliptic_vec_declination(&state.pos) / DEG2RAD
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use p9_core::coords::sky::ecliptic_to_equatorial;
 
     fn elem(i_deg: f64, omega_deg: f64, omega_big_deg: f64, m_deg: f64) -> OrbitalElements {
         OrbitalElements {
@@ -60,9 +51,9 @@ mod tests {
             let d = declination_deg(&elem(0.0, 0.0, 0.0, m));
             assert!(d.abs() <= 23.44 + 1e-6, "δ = {d:.2} for M = {m}");
         }
-        // λ = 90° (perihelion at omega 90 from node... use M=90 on circularish orbit)
-        let d_max = declination(90.0 * DEG2RAD, 0.0) / DEG2RAD;
-        assert!((d_max - 23.439).abs() < 1e-3);
+        // At λ = 90°, β = 0 the declination equals the obliquity.
+        let (_, dec) = ecliptic_to_equatorial(90.0 * DEG2RAD, 0.0);
+        assert!((dec / DEG2RAD - 23.439).abs() < 1e-3);
     }
 
     #[test]

--- a/crates/p9-2022-des/Cargo.toml
+++ b/crates/p9-2022-des/Cargo.toml
@@ -11,3 +11,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 approx = { workspace = true }
 p9-2021-orbit = { version = "0.1.0", path = "../p9-2021-orbit" }
+nalgebra.workspace = true

--- a/crates/p9-2022-des/src/sky.rs
+++ b/crates/p9-2022-des/src/sky.rs
@@ -2,39 +2,22 @@
 //!
 //! The footprint of `survey_model` is defined in *equatorial* coordinates
 //! (RA/dec), so orbital sky positions must be rotated from the heliocentric
-//! ecliptic frame by the obliquity of the ecliptic before any footprint
-//! test (the analogous fix to p9-2021-ztf's `sky.rs`; substituting ecliptic
-//! latitude for declination misclassifies exactly the survey-boundary
-//! regions that drive unique-coverage estimates).
+//! ecliptic frame to the equatorial frame before any footprint test (the
+//! analogous fix to p9-2021-ztf's `sky.rs`; substituting ecliptic latitude
+//! for declination misclassifies exactly the survey-boundary regions that
+//! drive unique-coverage estimates). The rotation itself comes from
+//! p9-core's `coords::sky` (starfield's ECLIPJ2000 frame matrix).
 //!
 //! Apparent (geocentric) positions are computed per observing night: the
 //! geocentric vector is the heliocentric vector minus Earth's (circular,
 //! coplanar) orbital position, which captures both the annual parallactic
 //! oscillation (~1/r radians, i.e. +/-0.14 deg at 400 AU) and the slow
 //! orbital drift of the object across the 6-year survey baseline.
-//!
-//! (p9-core's coords module only provides democratic-heliocentric
-//! transforms, so the ecliptic -> equatorial step lives here.)
 
-use p9_core::constants::{DEG2RAD, GM_SUN, YEAR_DAYS};
+use nalgebra::Vector3;
+use p9_core::constants::{GM_SUN, YEAR_DAYS};
+use p9_core::coords::sky::ecliptic_vec_to_equatorial_deg;
 use p9_core::types::OrbitalElements;
-
-/// Obliquity of the ecliptic, J2000 (radians).
-pub const OBLIQUITY: f64 = 23.439_291 * DEG2RAD;
-
-/// Equatorial (RA, dec) in degrees from a Cartesian vector in heliocentric
-/// (or geocentric) *ecliptic* coordinates.
-pub fn ecliptic_vec_to_equatorial_deg(x: f64, y: f64, z: f64) -> (f64, f64) {
-    let (sin_eps, cos_eps) = OBLIQUITY.sin_cos();
-    // Rotate about the x-axis (vernal equinox) by the obliquity.
-    let x_eq = x;
-    let y_eq = y * cos_eps - z * sin_eps;
-    let z_eq = y * sin_eps + z * cos_eps;
-    let r = (x_eq * x_eq + y_eq * y_eq + z_eq * z_eq).sqrt();
-    let ra = y_eq.atan2(x_eq).rem_euclid(std::f64::consts::TAU) / DEG2RAD;
-    let dec = (z_eq / r).asin() / DEG2RAD;
-    (ra, dec)
-}
 
 /// Apparent geocentric equatorial (RA, dec) in degrees of an orbit
 /// `t_days` after its stored epoch, plus the heliocentric distance (AU).
@@ -51,29 +34,28 @@ pub fn apparent_position_deg(elem: &OrbitalElements, t_days: f64) -> (f64, f64, 
 
     let theta = std::f64::consts::TAU * t_days / YEAR_DAYS;
     let (sin_t, cos_t) = theta.sin_cos();
-    let gx = state.pos.x - cos_t;
-    let gy = state.pos.y - sin_t;
-    let gz = state.pos.z;
+    let geo = state.pos - Vector3::new(cos_t, sin_t, 0.0);
 
-    let (ra, dec) = ecliptic_vec_to_equatorial_deg(gx, gy, gz);
+    let (ra, dec) = ecliptic_vec_to_equatorial_deg(&geo);
     (ra, dec, r_helio)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use p9_core::constants::DEG2RAD;
 
     #[test]
     fn test_ecliptic_pole_maps_to_obliquity_complement() {
-        // The north ecliptic pole sits at dec = 90 - 23.44 = 66.56 deg.
-        let (_, dec) = ecliptic_vec_to_equatorial_deg(0.0, 0.0, 1.0);
-        assert!((dec - (90.0 - 23.439_291)).abs() < 1e-9, "dec = {dec}");
+        // The north ecliptic pole sits at dec = 90 - 23.4393 = 66.56 deg.
+        let (_, dec) = ecliptic_vec_to_equatorial_deg(&Vector3::new(0.0, 0.0, 1.0));
+        assert!((dec - (90.0 - 23.439_291)).abs() < 1e-6, "dec = {dec}");
     }
 
     #[test]
     fn test_equinox_direction_unchanged() {
         // The vernal-equinox direction is shared by both frames.
-        let (ra, dec) = ecliptic_vec_to_equatorial_deg(1.0, 0.0, 0.0);
+        let (ra, dec) = ecliptic_vec_to_equatorial_deg(&Vector3::new(1.0, 0.0, 0.0));
         assert!(ra.abs() < 1e-9 && dec.abs() < 1e-9);
     }
 
@@ -82,7 +64,8 @@ mod tests {
         // Positions in the ecliptic plane reach at most |dec| = obliquity.
         for k in 0..36 {
             let lambda = k as f64 * 10.0 * DEG2RAD;
-            let (_, dec) = ecliptic_vec_to_equatorial_deg(lambda.cos(), lambda.sin(), 0.0);
+            let (_, dec) =
+                ecliptic_vec_to_equatorial_deg(&Vector3::new(lambda.cos(), lambda.sin(), 0.0));
             assert!(dec.abs() <= 23.44 + 1e-9, "dec = {dec}");
         }
     }

--- a/crates/p9-2025-clustering/Cargo.toml
+++ b/crates/p9-2025-clustering/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 description = "Reproduction of Pichierri & Batygin (2025) 'Measuring the Degree of Clustering and Diffusion of TNOs'"
 
 [dependencies]
+nalgebra.workspace = true
 p9-core = { path = "../p9-core" }
 rand = { workspace = true }
 rand_distr = { workspace = true }

--- a/crates/p9-2025-clustering/src/orbital_poles.rs
+++ b/crates/p9-2025-clustering/src/orbital_poles.rs
@@ -6,13 +6,17 @@
 //!
 //!   n̂ = (sin i sin Ω, −sin i cos Ω, cos i),
 //!
-//! not as 2D distances in the (i cosΩ, i sinΩ) plane (which conflates a
-//! 90° node difference at i = 17° with a 90° pole separation). The
-//! reference Laplace plane is *computed* from the giant planets' total
-//! orbital angular momentum (J2000 states from p9-core) — at ETNO
-//! distances the Laplace plane asymptotes to the invariable plane.
+//! (via p9-core's `coords::sky::angular_distance`, i.e. starfield's
+//! `Cartesian3::angular_distance`), not as 2D distances in the
+//! (i cosΩ, i sinΩ) plane (which conflates a 90° node difference at i = 17°
+//! with a 90° pole separation). The reference Laplace plane is *computed*
+//! from the giant planets' total orbital angular momentum (J2000 states from
+//! p9-core) — at ETNO distances the Laplace plane asymptotes to the
+//! invariable plane.
 
+use nalgebra::Vector3;
 use p9_core::constants::GM_SUN;
+use p9_core::coords::sky::angular_distance;
 use p9_core::initial_conditions::planets::giant_planets_j2000;
 use p9_core::types::cartesian_to_elements;
 use serde::{Deserialize, Serialize};
@@ -49,10 +53,10 @@ impl OrbitalPole {
 
     /// Unit vector of the orbit normal in ecliptic coordinates:
     /// n̂ = (sin i sin Ω, −sin i cos Ω, cos i).
-    pub fn unit_vector(&self) -> [f64; 3] {
+    pub fn unit_vector(&self) -> Vector3<f64> {
         let i = self.inclination();
         let node = self.omega_big();
-        [i.sin() * node.sin(), -i.sin() * node.cos(), i.cos()]
+        Vector3::new(i.sin() * node.sin(), -i.sin() * node.cos(), i.cos())
     }
 }
 
@@ -60,10 +64,7 @@ impl OrbitalPole {
 ///
 ///   cos d = cos i₁ cos i₂ + sin i₁ sin i₂ cos(Ω₁ − Ω₂)
 pub fn misalignment(pole: &OrbitalPole, reference: &OrbitalPole) -> f64 {
-    let a = pole.unit_vector();
-    let b = reference.unit_vector();
-    let dot = a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
-    dot.clamp(-1.0, 1.0).acos()
+    angular_distance(&pole.unit_vector(), &reference.unit_vector())
 }
 
 /// Reference pole of the giant-planet (Laplace/invariable) plane,
@@ -71,18 +72,14 @@ pub fn misalignment(pole: &OrbitalPole, reference: &OrbitalPole) -> f64 {
 /// the four giants at J2000 (p9-core DE440 states). Inclination to the
 /// ecliptic ≈ 1.58°.
 pub fn laplace_pole() -> OrbitalPole {
-    let mut l = [0.0_f64; 3];
+    let mut l = Vector3::zeros();
     for body in giant_planets_j2000() {
-        let r = body.state.pos;
-        let v = body.state.vel;
-        l[0] += body.mass * (r.y * v.z - r.z * v.y);
-        l[1] += body.mass * (r.z * v.x - r.x * v.z);
-        l[2] += body.mass * (r.x * v.y - r.y * v.x);
+        l += body.mass * body.state.pos.cross(&body.state.vel);
     }
-    let norm = (l[0] * l[0] + l[1] * l[1] + l[2] * l[2]).sqrt();
-    let i = (l[2] / norm).clamp(-1.0, 1.0).acos();
+    let n = l.normalize();
+    let i = n.z.clamp(-1.0, 1.0).acos();
     // n̂ = (sin i sin Ω, −sin i cos Ω, cos i) → Ω = atan2(n_x, −n_y)
-    let omega_big = (l[0] / norm).atan2(-(l[1] / norm));
+    let omega_big = n.x.atan2(-n.y);
     OrbitalPole::from_elements("Laplace plane", i, omega_big)
 }
 

--- a/crates/p9-2025-iras-akari/src/orbital_constraints.rs
+++ b/crates/p9-2025-iras-akari/src/orbital_constraints.rs
@@ -188,29 +188,10 @@ pub fn explore_orbit_space(
         .collect()
 }
 
-/// Ecliptic coordinates (approximate) from RA/Dec.
-///
-/// Uses the obliquity of the ecliptic ε = 23.4393° to convert
-/// equatorial coordinates to ecliptic coordinates. (p9-core provides no
-/// equatorial↔ecliptic transform; kept local.)
-pub fn equatorial_to_ecliptic(ra_deg: f64, dec_deg: f64) -> (f64, f64) {
-    let eps = 23.4393_f64.to_radians();
-    let ra = ra_deg.to_radians();
-    let dec = dec_deg.to_radians();
-
-    let sin_lambda = ra.sin() * eps.cos() + dec.tan() * eps.sin();
-    let cos_lambda = ra.cos();
-    let lambda = sin_lambda.atan2(cos_lambda);
-
-    let sin_beta = dec.sin() * eps.cos() - dec.cos() * eps.sin() * ra.sin();
-    let beta = sin_beta.asin();
-
-    (lambda.to_degrees().rem_euclid(360.0), beta.to_degrees())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use p9_core::coords::sky::equatorial_to_ecliptic_deg;
 
     #[test]
     fn candidate_separation_matches_paper() {
@@ -324,7 +305,7 @@ mod tests {
         // Midpoint position
         let mid_ra = (pair.iras_ra_deg + pair.akari_ra_deg) / 2.0;
         let mid_dec = (pair.iras_dec_deg + pair.akari_dec_deg) / 2.0;
-        let (ecl_lon, ecl_lat) = equatorial_to_ecliptic(mid_ra, mid_dec);
+        let (ecl_lon, ecl_lat) = equatorial_to_ecliptic_deg(mid_ra, mid_dec);
         // At RA~35.5°, Dec~-48.9°, ecliptic latitude should be far from
         // the ecliptic plane (|β| >> 0), consistent with P9's predicted
         // high-inclination orbit

--- a/crates/p9-core/Cargo.toml
+++ b/crates/p9-core/Cargo.toml
@@ -11,6 +11,7 @@ rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 rayon = { workspace = true }
+starfield = "0.13.0"
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/crates/p9-core/src/constants.rs
+++ b/crates/p9-core/src/constants.rs
@@ -5,6 +5,11 @@ pub const G_AU3_MSUN_DAY2: f64 = 2.959122082855911e-4;
 
 /// GM values in AU^3/day^2 (heliocentric gravitational parameters)
 /// Source: JPL DE440 / Park et al. (2021)
+///
+/// Note: starfield's `GM_SUN` is in km^3/s^2 and from a slightly older
+/// determination (1.32712440042e20 vs DE440's 1.32712440041279419e20 m^3/s^2,
+/// a 5.4e-12 relative difference); p9-core keeps the DE440 value in its
+/// AU^3/day^2 convention. The agreement is pinned by a test below.
 pub const GM_SUN: f64 = 2.959122082855911e-4;
 pub const GM_MERCURY: f64 = 4.912_486_6e-11;
 pub const GM_VENUS: f64 = 7.243_452_5e-10;
@@ -50,20 +55,19 @@ pub const J4_SATURN: f64 = -9.35e-4;
 pub const J4_URANUS: f64 = -3.21e-5;
 pub const J4_NEPTUNE: f64 = -3.48e-5;
 
-/// Unit conversions
-pub const AU_M: f64 = 1.495_978_707e11;
-pub const AU_KM: f64 = 1.495_978_707e8;
-pub const DAY_S: f64 = 86_400.0;
+/// Unit conversions. AU_M, AU_KM, and DAY_S are re-exported from starfield
+/// (IAU 2012 AU = 149_597_870_700 m exactly) so the two crates cannot drift.
+pub use starfield::constants::{AU_KM, AU_M, DAY_S};
 pub const YEAR_DAYS: f64 = 365.25;
 pub const GYR_DAYS: f64 = 365.25e9;
 
-/// J2000.0 epoch (Julian Date, TT)
-pub const J2000: f64 = 2_451_545.0;
+/// J2000.0 epoch (Julian Date, TT); re-exported from starfield.
+pub use starfield::constants::J2000;
 
-/// Mathematical constants
-pub const TWO_PI: f64 = 2.0 * std::f64::consts::PI;
-pub const DEG2RAD: f64 = std::f64::consts::PI / 180.0;
-pub const RAD2DEG: f64 = 180.0 / std::f64::consts::PI;
+/// Mathematical constants; re-exported from starfield where they overlap
+/// (TAU is starfield's name for 2π).
+pub use starfield::constants::TAU as TWO_PI;
+pub use starfield::constants::{DEG2RAD, RAD2DEG};
 
 /// Neptune's semi-major axis in AU (single source for the resonance/Hansen
 /// machinery; several paper crates previously re-defined this inconsistently)
@@ -88,3 +92,34 @@ pub const PC_AU: f64 = 206_264.806;
 
 /// km/s to AU/day
 pub const KMS_TO_AUDAY: f64 = DAY_S / AU_KM;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gm_sun_au3_day2_matches_starfield_km3_s2() {
+        // starfield's GM_SUN (km^3/s^2) converted to p9-core's AU^3/day^2
+        // convention. The underlying solar GM determinations differ by
+        // 5.4e-12 (DE440 vs starfield's older value), so agreement is pinned
+        // at 1e-11 relative rather than full f64 precision.
+        let starfield_au3_day2 =
+            starfield::constants::GM_SUN * DAY_S * DAY_S / (AU_KM * AU_KM * AU_KM);
+        let rel = ((starfield_au3_day2 - GM_SUN) / GM_SUN).abs();
+        assert!(rel < 1e-11, "relative difference = {rel:e}");
+    }
+
+    #[test]
+    fn test_g_au3_msun_day2_consistent_with_gm_sun() {
+        // G in AU^3/(M_sun day^2) is numerically GM_sun in AU^3/day^2.
+        assert_eq!(G_AU3_MSUN_DAY2, GM_SUN);
+    }
+
+    #[test]
+    fn test_au_conversions_self_consistent() {
+        // Re-exported starfield values: AU_M and AU_KM describe the same
+        // IAU 2012 astronomical unit.
+        assert_eq!(AU_M, 149_597_870_700.0);
+        assert_eq!(AU_KM * 1_000.0, AU_M);
+    }
+}

--- a/crates/p9-core/src/coords/mod.rs
+++ b/crates/p9-core/src/coords/mod.rs
@@ -1,1 +1,2 @@
 pub mod democratic_helio;
+pub mod sky;

--- a/crates/p9-core/src/coords/sky.rs
+++ b/crates/p9-core/src/coords/sky.rs
@@ -1,0 +1,260 @@
+//! Sky-frame transforms (ecliptic ↔ equatorial ↔ galactic, J2000), backed by
+//! starfield's `framelib` rotation matrices.
+//!
+//! Planet9's native representation is heliocentric ecliptic-J2000 Cartesian
+//! (nalgebra `Vector3<f64>`); these helpers convert to/from equatorial and
+//! galactic frames at the boundary. All matrices come from starfield's SPICE
+//! frame table (`ECLIPJ2000`, `GALACTIC`), replacing the obliquity and
+//! galactic-pole literals that were previously hand-rolled in the survey
+//! crates and the galactic-tide force.
+//!
+//! Only starfield's offline machinery is used here: the frame matrices and
+//! typed coordinates are static data and require no network access.
+
+use std::sync::LazyLock;
+
+use nalgebra::{Matrix3, Vector3};
+use starfield::coordinates::cartesian::Cartesian3;
+use starfield::framelib::inertial::{Ecliptic, Equatorial, Galactic};
+use starfield::framelib::{Frame, ECLIPJ2000_MATRIX, ECLIPJ2000_MATRIX_INV, GALACTIC};
+use starfield::time::Timescale;
+
+use crate::constants::{J2000, RAD2DEG};
+
+/// Equatorial (ICRF/J2000) → galactic rotation, from starfield's SPICE
+/// `GALACTIC` frame (static; the epoch argument is ignored by the frame).
+static EQ_TO_GAL: LazyLock<Matrix3<f64>> =
+    LazyLock::new(|| GALACTIC.rotation_at(&Timescale::default().tt_jd(J2000, None)));
+
+/// Ecliptic J2000 → galactic rotation.
+static ECL_TO_GAL: LazyLock<Matrix3<f64>> = LazyLock::new(|| *EQ_TO_GAL * *ECLIPJ2000_MATRIX_INV);
+
+/// Rotation matrix: equatorial J2000 → ecliptic J2000.
+pub fn equatorial_to_ecliptic_matrix() -> Matrix3<f64> {
+    *ECLIPJ2000_MATRIX
+}
+
+/// Rotation matrix: ecliptic J2000 → equatorial J2000.
+pub fn ecliptic_to_equatorial_matrix() -> Matrix3<f64> {
+    *ECLIPJ2000_MATRIX_INV
+}
+
+/// Rotation matrix: equatorial J2000 → galactic.
+pub fn equatorial_to_galactic_matrix() -> Matrix3<f64> {
+    *EQ_TO_GAL
+}
+
+/// Rotation matrix: ecliptic J2000 → galactic.
+pub fn ecliptic_to_galactic_matrix() -> Matrix3<f64> {
+    *ECL_TO_GAL
+}
+
+/// Rotation matrix: galactic → ecliptic J2000.
+pub fn galactic_to_ecliptic_matrix() -> Matrix3<f64> {
+    ECL_TO_GAL.transpose()
+}
+
+/// Unit vector toward the north galactic pole in ecliptic J2000 coordinates
+/// (the galactic z-axis row of the ecliptic→galactic rotation).
+///
+/// λ ≈ 180.023°, β ≈ +29.812°; the complement of β gives the ≈60.19°
+/// ecliptic–galactic obliquity.
+pub fn galactic_pole_ecliptic() -> Vector3<f64> {
+    ECL_TO_GAL.row(2).transpose()
+}
+
+/// Equatorial (RA, dec) in radians from ecliptic (λ, β) in radians.
+pub fn ecliptic_to_equatorial(lon: f64, lat: f64) -> (f64, f64) {
+    let eq: Equatorial = Ecliptic { lon, lat }.into();
+    (eq.ra, eq.dec)
+}
+
+/// Equatorial (RA, dec) in degrees from ecliptic (λ, β) in degrees.
+/// RA is normalized to [0, 360).
+pub fn ecliptic_to_equatorial_deg(lon_deg: f64, lat_deg: f64) -> (f64, f64) {
+    let (ra, dec) = ecliptic_to_equatorial(lon_deg.to_radians(), lat_deg.to_radians());
+    (ra * RAD2DEG, dec * RAD2DEG)
+}
+
+/// Ecliptic (λ, β) in radians from equatorial (RA, dec) in radians.
+pub fn equatorial_to_ecliptic(ra: f64, dec: f64) -> (f64, f64) {
+    let ecl: Ecliptic = Equatorial::new(ra, dec).into();
+    (ecl.lon, ecl.lat)
+}
+
+/// Ecliptic (λ, β) in degrees from equatorial (RA, dec) in degrees.
+/// λ is normalized to [0, 360).
+pub fn equatorial_to_ecliptic_deg(ra_deg: f64, dec_deg: f64) -> (f64, f64) {
+    let (lon, lat) = equatorial_to_ecliptic(ra_deg.to_radians(), dec_deg.to_radians());
+    (
+        lon.rem_euclid(std::f64::consts::TAU) * RAD2DEG,
+        lat * RAD2DEG,
+    )
+}
+
+/// Galactic (l, b) in radians from equatorial (RA, dec) in radians.
+pub fn equatorial_to_galactic(ra: f64, dec: f64) -> (f64, f64) {
+    let gal: Galactic = Equatorial::new(ra, dec).into();
+    (gal.lon, gal.lat)
+}
+
+/// Equatorial (RA, dec) in degrees of a Cartesian vector in heliocentric
+/// (or geocentric) ecliptic-J2000 coordinates. RA is normalized to [0, 360).
+pub fn ecliptic_vec_to_equatorial_deg(v: &Vector3<f64>) -> (f64, f64) {
+    let eq = *ECLIPJ2000_MATRIX_INV * v;
+    let (ra, dec, _) = Cartesian3::from_vector3(eq).to_spherical();
+    (ra * RAD2DEG, dec * RAD2DEG)
+}
+
+/// Equatorial declination (radians) of a Cartesian vector in ecliptic-J2000
+/// coordinates.
+pub fn ecliptic_vec_declination(v: &Vector3<f64>) -> f64 {
+    let eq = *ECLIPJ2000_MATRIX_INV * v;
+    (eq.z / eq.norm()).asin()
+}
+
+/// True spherical angular distance (radians) between two direction vectors
+/// (any common frame), via starfield's `Cartesian3::angular_distance`.
+pub fn angular_distance(a: &Vector3<f64>, b: &Vector3<f64>) -> f64 {
+    Cartesian3::from_vector3(*a).angular_distance(&Cartesian3::from_vector3(*b))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::constants::DEG2RAD;
+    use approx::assert_relative_eq;
+
+    /// Mean obliquity of the ecliptic at J2000 implied by starfield's
+    /// ECLIPJ2000 matrix (≈ 23.4392911°).
+    fn obliquity_deg() -> f64 {
+        equatorial_to_ecliptic_matrix()[(1, 1)].acos() * RAD2DEG
+    }
+
+    #[test]
+    fn test_matrices_are_rotations_and_mutually_inverse() {
+        for m in [
+            equatorial_to_ecliptic_matrix(),
+            equatorial_to_galactic_matrix(),
+            ecliptic_to_galactic_matrix(),
+        ] {
+            assert_relative_eq!(m.determinant(), 1.0, epsilon = 1e-12);
+            assert_relative_eq!(
+                (m * m.transpose() - Matrix3::identity()).norm(),
+                0.0,
+                epsilon = 1e-12
+            );
+        }
+        assert_relative_eq!(
+            (equatorial_to_ecliptic_matrix() * ecliptic_to_equatorial_matrix()
+                - Matrix3::identity())
+            .norm(),
+            0.0,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            (ecliptic_to_galactic_matrix() * galactic_to_ecliptic_matrix() - Matrix3::identity())
+                .norm(),
+            0.0,
+            epsilon = 1e-12
+        );
+    }
+
+    #[test]
+    fn test_equinox_direction_shared_by_ecliptic_and_equatorial() {
+        let (ra, dec) = ecliptic_to_equatorial_deg(0.0, 0.0);
+        assert!(ra.abs() < 1e-9 || (ra - 360.0).abs() < 1e-9);
+        assert!(dec.abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_north_ecliptic_pole_declination() {
+        // The north ecliptic pole sits at dec = 90° − ε, RA = 270°.
+        let (ra, dec) = ecliptic_vec_to_equatorial_deg(&Vector3::new(0.0, 0.0, 1.0));
+        assert_relative_eq!(dec, 90.0 - obliquity_deg(), epsilon = 1e-9);
+        assert_relative_eq!(ra, 270.0, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn test_ecliptic_equatorial_round_trip_quadrants() {
+        for &lon in &[10.0, 100.0, 190.0, 280.0, 359.0] {
+            for &lat in &[-80.0, -30.0, 0.0, 45.0, 85.0] {
+                let (ra, dec) = ecliptic_to_equatorial_deg(lon, lat);
+                let (lon2, lat2) = equatorial_to_ecliptic_deg(ra, dec);
+                assert_relative_eq!(lon2, lon, epsilon = 1e-9);
+                assert_relative_eq!(lat2, lat, epsilon = 1e-9);
+            }
+        }
+    }
+
+    #[test]
+    fn test_galactic_round_trip_through_typed_coordinates() {
+        for &(ra_deg, dec_deg) in &[(0.0, 0.0), (192.86, 27.13), (266.4, -28.9), (45.0, -60.0)] {
+            let (l, b) = equatorial_to_galactic(ra_deg * DEG2RAD, dec_deg * DEG2RAD);
+            let eq: Equatorial = Galactic { lon: l, lat: b }.into();
+            // Compare as directions (RA wraps 360 → 0 at the equinox).
+            let sep = angular_distance(
+                &Cartesian3::from_spherical(eq.ra, eq.dec, 1.0).to_vector3(),
+                &Cartesian3::from_spherical(ra_deg * DEG2RAD, dec_deg * DEG2RAD, 1.0).to_vector3(),
+            );
+            assert!(
+                sep < 1e-9 * DEG2RAD,
+                "sep = {sep} rad at ({ra_deg}, {dec_deg})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_north_galactic_pole_equatorial() {
+        // IAU NGP: RA 192.85948°, dec +27.12825° (J2000).
+        let ngp = equatorial_to_galactic_matrix().row(2).transpose();
+        let (ra, dec, _) = Cartesian3::from_vector3(ngp).to_spherical();
+        assert_relative_eq!(ra * RAD2DEG, 192.85948, epsilon = 2e-4);
+        assert_relative_eq!(dec * RAD2DEG, 27.12825, epsilon = 2e-4);
+    }
+
+    #[test]
+    fn test_galactic_pole_ecliptic_orientation() {
+        // λ ≈ 180.02°, β ≈ +29.81°; ecliptic-galactic obliquity ≈ 60.19°.
+        let n = galactic_pole_ecliptic();
+        assert_relative_eq!(n.norm(), 1.0, epsilon = 1e-12);
+        let (lon, lat, _) = Cartesian3::from_vector3(n).to_spherical();
+        assert_relative_eq!(lon * RAD2DEG, 180.02, epsilon = 0.01);
+        assert_relative_eq!(lat * RAD2DEG, 29.81, epsilon = 0.01);
+        assert_relative_eq!(n.z.acos() * RAD2DEG, 60.19, epsilon = 0.01);
+    }
+
+    #[test]
+    fn test_galactic_center_near_galactic_origin() {
+        // Sgr A* (RA 266.41683°, dec −29.00781°) lies within ~0.1° of l = b = 0.
+        let (l, b) = equatorial_to_galactic(266.41683 * DEG2RAD, -29.00781 * DEG2RAD);
+        let sep = angular_distance(
+            &Vector3::new(l.cos() * b.cos(), l.sin() * b.cos(), b.sin()),
+            &Vector3::new(1.0, 0.0, 0.0),
+        );
+        assert!(sep * RAD2DEG < 0.1, "sep = {} deg", sep * RAD2DEG);
+    }
+
+    #[test]
+    fn test_declination_helper_matches_full_conversion() {
+        let v = Vector3::new(0.3, -1.2, 0.7);
+        let (_, dec_deg) = ecliptic_vec_to_equatorial_deg(&v);
+        assert_relative_eq!(
+            ecliptic_vec_declination(&v) * RAD2DEG,
+            dec_deg,
+            epsilon = 1e-12
+        );
+    }
+
+    #[test]
+    fn test_angular_distance_orthogonal_and_parallel() {
+        let x = Vector3::new(2.0, 0.0, 0.0);
+        let z = Vector3::new(0.0, 0.0, 0.5);
+        assert_relative_eq!(
+            angular_distance(&x, &z),
+            std::f64::consts::FRAC_PI_2,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(angular_distance(&x, &x), 0.0, epsilon = 1e-15);
+    }
+}

--- a/crates/p9-core/src/forces/galactic_tide.rs
+++ b/crates/p9-core/src/forces/galactic_tide.rs
@@ -7,7 +7,11 @@
 //!
 //! The galactic plane is inclined ~60.2° to the ecliptic, so the tide must be
 //! evaluated in the galactic frame and rotated back; applying it along
-//! ecliptic z misdirects the torque by the full obliquity.
+//! ecliptic z misdirects the torque by the full obliquity. The galactic
+//! orientation comes from starfield's SPICE `GALACTIC` frame via
+//! `coords::sky` (previously a hand-rolled λ=180.02°, β=29.81° pole; the
+//! starfield-derived pole is λ=180.0232°, β=29.8114°, an ~11 arcsec shift,
+//! well inside all test tolerances).
 //!
 //! The radial tide terms (Heisler & Tremaine's G1, G2, from the galactic
 //! rotation curve) are ~10x weaker than the disk term at the Sun's location
@@ -21,36 +25,26 @@
 use nalgebra::Vector3;
 
 use crate::constants::*;
+use crate::coords::sky;
 
-/// North galactic pole in ecliptic J2000 coordinates.
-/// Converted from the IAU NGP (RA 192.85948°, Dec +27.12825°, J2000) with
-/// obliquity 23.4393°: λ ≈ 180.02°, β ≈ +29.81°. The complement of β gives
-/// the ~60.19° ecliptic-galactic obliquity.
-const NGP_ECLIPTIC_LON_DEG: f64 = 180.02;
-const NGP_ECLIPTIC_LAT_DEG: f64 = 29.81;
-
-/// Unit vector toward the north galactic pole, ecliptic J2000 frame.
-pub fn galactic_pole_ecliptic() -> Vector3<f64> {
-    let lon = NGP_ECLIPTIC_LON_DEG * DEG2RAD;
-    let lat = NGP_ECLIPTIC_LAT_DEG * DEG2RAD;
-    Vector3::new(lat.cos() * lon.cos(), lat.cos() * lon.sin(), lat.sin())
-}
+pub use crate::coords::sky::galactic_pole_ecliptic;
 
 /// Galactic tidal acceleration on a particle at position `pos`
 /// (AU, heliocentric ecliptic J2000).
 ///
-/// The vertical disk tide -4πGρ z̃ acts along the galactic pole n̂ with
-/// z̃ = r·n̂, so the rotation in and out of the galactic frame collapses to
-///   a = -4π G ρ (r·n̂) n̂.
+/// The position is rotated into the galactic frame, the vertical disk tide
+/// (0, 0, -4πGρ z̃) is applied along galactic z, and the result is rotated
+/// back to the ecliptic frame.
 pub fn galactic_tide_acceleration(pos: &Vector3<f64>) -> Vector3<f64> {
     // 4*pi*G*rho in day^-2:
     // G = GM_SUN / M_sun (AU^3/(M_sun*day^2)), rho in M_sun/AU^3.
     let four_pi_g_rho = 4.0 * std::f64::consts::PI * GM_SUN * RHO_MW_MSUN_AU3;
 
-    let n_hat = galactic_pole_ecliptic();
-    let z_gal = pos.dot(&n_hat);
+    let ecl_to_gal = sky::ecliptic_to_galactic_matrix();
+    let pos_gal = ecl_to_gal * pos;
+    let acc_gal = Vector3::new(0.0, 0.0, -four_pi_g_rho * pos_gal.z);
 
-    -four_pi_g_rho * z_gal * n_hat
+    ecl_to_gal.transpose() * acc_gal
 }
 
 #[cfg(test)]
@@ -85,5 +79,17 @@ mod tests {
         let in_plane = n.cross(&Vector3::new(0.0, 0.0, 1.0)).normalize() * 10_000.0;
         let a = galactic_tide_acceleration(&in_plane);
         assert!(a.norm() < 1e-25);
+    }
+
+    #[test]
+    fn test_tide_matches_pole_projection_form() {
+        // The rotate-apply-rotate-back implementation must equal the
+        // algebraically collapsed form a = -4πGρ (r·n̂) n̂.
+        let four_pi_g_rho = 4.0 * std::f64::consts::PI * GM_SUN * RHO_MW_MSUN_AU3;
+        let n = galactic_pole_ecliptic();
+        let pos = Vector3::new(3_000.0, -7_000.0, 5_000.0);
+        let expected = -four_pi_g_rho * pos.dot(&n) * n;
+        let a = galactic_tide_acceleration(&pos);
+        assert_relative_eq!((a - expected).norm(), 0.0, epsilon = 1e-30);
     }
 }


### PR DESCRIPTION
Closes #36. Adds starfield 0.13 as a p9-core dependency; replaces the four hand-rolled ecliptic/equatorial/galactic conversions with starfield's SPICE-derived frame matrices via a new p9_core::coords::sky module; unifies overlapping constants (found starfield's GM_SUN is pre-DE440, 5.4e-12 relative — documented). Galactic pole shifted ~11.3 arcsec vs the old literals; all existing test tolerances absorbed it. Includes STARFIELD_INTEGRATION.md (the cross-map driving issues #30-#41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)