### PR TITLE
Add IAU H-G phase law and Neptune photometry cross-validation

### DIFF
--- a/crates/p9-2022-des/src/sky.rs
+++ b/crates/p9-2022-des/src/sky.rs
@@ -100,6 +100,22 @@ pub fn apparent_position_with_earth_deg(
     (ra, dec, r_helio)
 }
 
+/// Sun–object–Earth phase angle (radians) of an orbit `t_days` after its
+/// stored epoch, observed from the given Earth state (instantaneous
+/// geometry — the few-day light-time displacement changes α by far less
+/// than the H-G law resolves at these distances). Bounded by
+/// asin(1 AU / r): below 0.35° everywhere in the BB21 reference
+/// population (minimum r ≈ 176 AU), ~0.11° at the fiducial 500 AU.
+pub fn phase_angle_with_earth(
+    elem: &OrbitalElements,
+    earth_state: &EarthState,
+    t_days: f64,
+) -> f64 {
+    let helio = heliocentric_position(elem, t_days);
+    let delta = (helio - earth_state.0).norm();
+    p9_core::analysis::photometry::phase_angle(helio.norm(), delta, earth_state.0.norm())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -178,6 +194,80 @@ mod tests {
                 "ephemeris vs analytic apparent position differs by {sep:.4} deg at t = {t_days}"
             );
         }
+    }
+
+    /// Issue #41: measure the phase-induced Δmag over the reference
+    /// population at the real DES observing geometry. The phase angle is
+    /// bounded by asin(1 AU/r), tiny at P9 distances, but the H-G law's
+    /// opposition surge (dΔm/dα → ∞ at α = 0) makes the darkening tens of
+    /// mmag, not the <1 mmag a linear phase law would give: measured over
+    /// 500 BB21-posterior orbits × the 40-night DES grid (DE421 Earth
+    /// states), max Δm = 0.0763 mag at max α = 0.329° (the population's
+    /// minimum heliocentric distance is 176 AU; at the fiducial 500 AU the
+    /// surge is 0.039 mag). The survey-recovery pins absorb this: a
+    /// ≤0.08 mag dimming on the ephemeris path leaves the computed DES
+    /// recovery and the combined exclusion fractions inside their existing
+    /// regression tolerances (verified — no pins re-pinned). Kernel-gated.
+    #[test]
+    fn phase_induced_dmag_small_over_reference_population() {
+        use p9_2021_orbit::reference_population::generate_reference_population;
+        use p9_core::analysis::photometry::{hg_phase_factor, DEFAULT_SLOPE_G};
+        use p9_core::coords::observer::EphemerisEarth;
+        use rand::SeedableRng;
+
+        let mut earth = match EphemerisEarth::try_new() {
+            Ok(e) => e,
+            Err(_) => {
+                eprintln!("skipping: no ephemeris kernel in starfield cache");
+                return;
+            }
+        };
+        let nights =
+            crate::survey_model::DesSurvey::default().observing_epochs_with_earth(&mut earth);
+        let mut rng = rand::rngs::StdRng::seed_from_u64(41);
+        let population = generate_reference_population(500, &mut rng);
+
+        let mut max_dm = 0.0_f64;
+        let mut max_alpha = 0.0_f64;
+        let mut min_r = f64::INFINITY;
+        for obj in &population {
+            let elem = OrbitalElements {
+                a: obj.a,
+                e: obj.e,
+                i: obj.i,
+                omega: obj.omega,
+                omega_big: obj.omega_big,
+                mean_anomaly: obj.mean_anomaly,
+            };
+            for (_, t_days, state) in &nights {
+                let alpha = phase_angle_with_earth(&elem, state, *t_days);
+                let dm = -2.5 * hg_phase_factor(DEFAULT_SLOPE_G, alpha).log10();
+                max_alpha = max_alpha.max(alpha);
+                max_dm = max_dm.max(dm);
+                min_r = min_r.min(heliocentric_position(&elem, *t_days).norm());
+            }
+        }
+        eprintln!(
+            "max Δm = {max_dm:.4} mag, max α = {:.4}°, min r = {min_r:.1} AU",
+            max_alpha.to_degrees()
+        );
+
+        // Geometry: phase angle bounded by the annual maximum
+        // asin(1 AU / min r) = asin(1/176) = 0.326° (plus Earth's
+        // eccentricity); measured 0.329°.
+        assert!(
+            max_alpha.to_degrees() < 0.35,
+            "max phase angle = {:.4}°",
+            max_alpha.to_degrees()
+        );
+        assert!(min_r > 150.0, "min r = {min_r:.1} AU");
+        // Photometry: the opposition surge contributes a few tens of mmag
+        // (measured 0.0763 mag); it must never grow to a level that would
+        // move survey completeness materially (>0.1 mag).
+        assert!(
+            (0.03..0.10).contains(&max_dm),
+            "max phase-induced Δm = {max_dm:.4} mag"
+        );
     }
 
     #[test]

--- a/crates/p9-2022-des/src/survey_model.rs
+++ b/crates/p9-2022-des/src/survey_model.rs
@@ -289,7 +289,10 @@ impl DesSurvey {
 
     /// Ephemeris-path counterpart of `night_probabilities`: per-night
     /// apparent positions from real Earth states (parallax from the true
-    /// orbit, light-time, aberration). `nights` comes from
+    /// orbit, light-time, aberration), and per-night IAU H-G phase
+    /// darkening (G = 0.15) relative to the zero-phase `mags` — the H-G
+    /// opposition surge contributes up to ~0.05 mag at P9 distances
+    /// (α ≤ asin(1 AU/r)). `nights` comes from
     /// `observing_epochs_with_earth`.
     pub fn night_probabilities_with_earth(
         &self,
@@ -297,12 +300,15 @@ impl DesSurvey {
         mags: &BandMagnitudes,
         nights: &[(DesBand, f64, EarthState)],
     ) -> Vec<f64> {
+        use p9_core::analysis::photometry::{hg_phase_factor, DEFAULT_SLOPE_G};
         nights
             .iter()
             .map(|(band, t_days, state)| {
                 let (ra, dec, _) = apparent_position_with_earth_deg(elem, state, *t_days);
                 if self.is_in_footprint(ra, dec) {
-                    self.night_detection_probability(mags.magnitude(*band), *band)
+                    let alpha = crate::sky::phase_angle_with_earth(elem, state, *t_days);
+                    let dm = -2.5 * hg_phase_factor(DEFAULT_SLOPE_G, alpha).log10();
+                    self.night_detection_probability(mags.magnitude(*band) + dm, *band)
                 } else {
                     0.0
                 }

--- a/crates/p9-2024-panstarrs/src/detection_pipeline.rs
+++ b/crates/p9-2024-panstarrs/src/detection_pipeline.rs
@@ -84,15 +84,22 @@ pub fn equatorial_position_with_earth_deg(
     (ra, dec)
 }
 
-/// Ephemeris-path counterpart of `detection_probability_for_orbit`.
+/// Ephemeris-path counterpart of `detection_probability_for_orbit`, with
+/// IAU H-G phase darkening (G = 0.15) applied to the zero-phase
+/// `v_magnitude`: the real Earth state yields the Sun–object–Earth phase
+/// angle, whose H-G opposition surge dims the object by up to ~0.05 mag at
+/// P9 distances.
 pub fn detection_probability_for_orbit_with_earth(
     survey: &Ps1Survey,
     elements: &OrbitalElements,
     v_magnitude: f64,
     earth_state: &EarthState,
 ) -> f64 {
+    use p9_core::analysis::photometry::{hg_phase_factor, DEFAULT_SLOPE_G};
     let (_, dec) = equatorial_position_with_earth_deg(elements, earth_state);
-    survey.detection_probability(v_magnitude, dec)
+    let alpha = p9_2022_des::sky::phase_angle_with_earth(elements, earth_state, 0.0);
+    let dm = -2.5 * hg_phase_factor(DEFAULT_SLOPE_G, alpha).log10();
+    survey.detection_probability(v_magnitude + dm, dec)
 }
 
 /// Deterministic expected number of detections for a synthetic population

--- a/crates/p9-core/src/analysis/photometry.rs
+++ b/crates/p9-core/src/analysis/photometry.rs
@@ -1,5 +1,6 @@
 //! Photometry of distant solar-system bodies: mass-radius relation, absolute
-//! magnitude, and the reflected-sunlight apparent-magnitude law.
+//! magnitude, the reflected-sunlight apparent-magnitude law, and the IAU
+//! H-G phase function.
 //!
 //! Single source for the workspace (p9-2016-constraints, p9-2019-review,
 //! p9-2021-orbit, p9-2022-des and p9-2024-panstarrs previously carried
@@ -8,9 +9,20 @@
 //! Reflected sunlight falls off as 1/(r²Δ²) — once for the Sun→body leg, once
 //! for the body→Earth leg — so
 //!
-//!   m = H + 5 log10(r·Δ) + phase terms (≈ 0 near opposition at large r),
+//!   m = H + 5 log10(r·Δ) − 2.5 log10 Φ(α),
 //!
-//! never the stellar 5 log10(d/10 pc).
+//! never the stellar 5 log10(d/10 pc). The phase function Φ(α) is the
+//! two-term IAU H-G law of Bowell et al. (1989, in *Asteroids II*, 524),
+//! implemented locally ([`hg_phase_factor`]) with the same coefficients as
+//! starfield-mpc's `hg_apparent_magnitude` (unpublished crate; issue #33
+//! tracks contributing this generic-body photometry upstream, so the APIs
+//! are kept convergent).
+//!
+//! Note the H-G law's opposition surge: dΦ/dα → −∞ as α → 0 (the tan^0.63
+//! term), so even the tiny phase angles reachable at Planet Nine distances
+//! (α ≤ asin(1 AU/r) ≈ 0.1–0.2°) darken the body by a few hundredths of a
+//! magnitude relative to the exact-opposition limit — not the µmag a linear
+//! phase law would suggest.
 
 /// Neptune's volumetric mean radius in Earth radii (24 622 km / 6 371 km).
 pub const NEPTUNE_RADIUS_EARTH: f64 = 3.865;
@@ -44,14 +56,74 @@ pub fn absolute_magnitude(radius_km: f64, albedo: f64) -> f64 {
     5.0 * (1329.0 / (albedo.sqrt() * 2.0 * radius_km)).log10()
 }
 
-/// Apparent magnitude of reflected sunlight:
+/// Apparent magnitude of reflected sunlight in the exact-opposition
+/// (zero-phase) limit:
 ///
 ///   m = H + 5 log10(r·Δ)
 ///
-/// with `r_au` the heliocentric and `delta_au` the geocentric distance
-/// (phase function ≈ 1 near opposition for distant bodies).
+/// with `r_au` the heliocentric and `delta_au` the geocentric distance.
+/// This is [`apparent_magnitude_with_phase`] at α = 0 (Φ(0) = 1); use the
+/// phase-aware form whenever the observer geometry yields a phase angle.
 pub fn apparent_magnitude(h: f64, r_au: f64, delta_au: f64) -> f64 {
     h + 5.0 * (r_au * delta_au).log10()
+}
+
+/// Default IAU H-G slope parameter G = 0.15, the standard assumption for
+/// bodies with unmeasured phase behavior (Bowell et al. 1989; the MPC uses
+/// the same default for asteroids without fitted G).
+pub const DEFAULT_SLOPE_G: f64 = 0.15;
+
+/// IAU H-G phase function Φ(α) (Bowell et al. 1989):
+///
+///   Φ(α) = (1 − G) Φ₁(α) + G Φ₂(α),
+///   Φᵢ(α) = exp(−Aᵢ tan^{Bᵢ}(α/2)),
+///   A₁ = 3.332, B₁ = 0.631, A₂ = 1.862, B₂ = 1.218,
+///
+/// with `phase_rad` the Sun–body–observer angle in radians (valid for
+/// 0 ≤ α ≲ 120°). Φ(0) = 1 by construction; Φ decreases monotonically
+/// with α. Coefficients match starfield-mpc's `hg_apparent_magnitude`.
+pub fn hg_phase_factor(g: f64, phase_rad: f64) -> f64 {
+    let tan_half = (phase_rad / 2.0).tan();
+    let phi1 = (-3.332 * tan_half.powf(0.631)).exp();
+    let phi2 = (-1.862 * tan_half.powf(1.218)).exp();
+    (1.0 - g) * phi1 + g * phi2
+}
+
+/// Phase integral of the H-G system, q(G) = 0.290 + 0.684 G (Bowell et al.
+/// 1989), relating Bond albedo to geometric albedo: A_B = q · p.
+pub fn phase_integral(g: f64) -> f64 {
+    0.290 + 0.684 * g
+}
+
+/// Apparent magnitude of reflected sunlight with the IAU H-G phase term:
+///
+///   m = H + 5 log10(r·Δ) − 2.5 log10 Φ(α; G)
+///
+/// `phase_rad` is the Sun–body–observer phase angle (see [`phase_angle`]);
+/// `g` is the H-G slope parameter ([`DEFAULT_SLOPE_G`] = 0.15 when
+/// unmeasured). Reduces to [`apparent_magnitude`] at α = 0.
+pub fn apparent_magnitude_with_phase(
+    h: f64,
+    r_au: f64,
+    delta_au: f64,
+    phase_rad: f64,
+    g: f64,
+) -> f64 {
+    h + 5.0 * (r_au * delta_au).log10() - 2.5 * hg_phase_factor(g, phase_rad).log10()
+}
+
+/// Phase angle α (Sun–body–observer, radians) from the triangle of
+/// heliocentric distance `r_helio`, body–observer distance `delta`, and
+/// Sun–observer distance `r_earth_sun` (law of cosines):
+///
+///   cos α = (r² + Δ² − R²) / (2 r Δ)
+///
+/// All three sides in the same units (AU). At Planet Nine distances the
+/// phase angle is bounded by asin(R/r) ≈ 0.1–0.2°.
+pub fn phase_angle(r_helio: f64, delta: f64, r_earth_sun: f64) -> f64 {
+    let cos_alpha =
+        (r_helio * r_helio + delta * delta - r_earth_sun * r_earth_sun) / (2.0 * r_helio * delta);
+    cos_alpha.clamp(-1.0, 1.0).acos()
 }
 
 /// Geocentric distance at opposition: Δ = r − 1 AU.
@@ -95,6 +167,94 @@ mod tests {
         assert!(r10 > 3.0 && r10 < 3.6, "R(10 M⊕) = {r10:.2} R⊕");
         // Smaller than Neptune below Neptune's mass
         assert!(r10 < NEPTUNE_RADIUS_EARTH);
+    }
+
+    #[test]
+    fn test_hg_phase_factor_is_one_at_opposition() {
+        // Φ(0) = 1 exactly: tan(0)^B = 0, exp(0) = 1, for any G.
+        for &g in &[0.0, 0.15, 0.25, 1.0] {
+            assert_eq!(hg_phase_factor(g, 0.0), 1.0, "G = {g}");
+        }
+        // ... so the phase-aware law reduces to the opposition form.
+        let (h, r, d) = (-6.87, 30.1, 29.1);
+        assert_eq!(
+            apparent_magnitude_with_phase(h, r, d, 0.0, DEFAULT_SLOPE_G),
+            apparent_magnitude(h, r, d)
+        );
+    }
+
+    #[test]
+    fn test_hg_phase_factor_monotone_decreasing() {
+        for &g in &[0.0, 0.15, 0.4] {
+            let mut prev = 1.0;
+            for k in 1..=120 {
+                let alpha = (k as f64).to_radians();
+                let f = hg_phase_factor(g, alpha);
+                assert!(f < prev, "Φ not decreasing at α = {k}° (G = {g})");
+                assert!(f > 0.0);
+                prev = f;
+            }
+        }
+    }
+
+    #[test]
+    fn test_hg_phase_factor_pinned_values() {
+        // Direct evaluation of the Bowell et al. (1989) two-term law with
+        // G = 0.15 (independent reference computation, matching
+        // starfield-mpc's coefficients):
+        //   α = 10°: Φ = 0.55159, Δm = 0.6460 mag
+        //   α = 30°: Φ = 0.30225, Δm = 1.2991 mag
+        let f10 = hg_phase_factor(0.15, 10.0_f64.to_radians());
+        assert!((f10 - 0.551585).abs() < 1e-5, "Φ(10°) = {f10:.6}");
+        let f30 = hg_phase_factor(0.15, 30.0_f64.to_radians());
+        assert!((f30 - 0.302247).abs() < 1e-5, "Φ(30°) = {f30:.6}");
+
+        // Ceres-like opposition case from starfield-mpc's test suite:
+        // H = 3.35, G = 0.15, r = 2.77, Δ = 1.77, α = 0 → V = 6.802.
+        let v = apparent_magnitude_with_phase(3.35, 2.77, 1.77, 0.0, 0.15);
+        assert!((v - 6.802).abs() < 0.001, "V_ceres = {v:.3}");
+    }
+
+    #[test]
+    fn test_phase_integral_standard_values() {
+        // q(G) = 0.290 + 0.684 G: q(0.15) = 0.3926.
+        assert!((phase_integral(0.15) - 0.3926).abs() < 1e-12);
+        assert!((phase_integral(0.0) - 0.290).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_phase_angle_geometry() {
+        // Opposition (Sun–Earth–body collinear): Δ = r − R → α = 0.
+        assert!(phase_angle(500.0, 499.0, 1.0) < 1e-7);
+        // Conjunction (body behind the Sun): Δ = r + R → α = 0 too.
+        assert!(phase_angle(500.0, 501.0, 1.0) < 1e-7);
+        // Quadrature right triangle at the *body*: r² + Δ² = R² is
+        // impossible for r > R; instead check the right angle at the Sun:
+        // Δ² = r² + R² → cos α = r/Δ.
+        let r = 400.0;
+        let delta = (r * r + 1.0_f64).sqrt();
+        let alpha = phase_angle(r, delta, 1.0);
+        assert!((alpha.cos() - r / delta).abs() < 1e-12);
+        // The phase angle is bounded by the annual maximum asin(R/r).
+        let alpha_max = (1.0_f64 / r).asin();
+        assert!(alpha <= alpha_max + 1e-12, "α = {alpha} > {alpha_max}");
+    }
+
+    #[test]
+    fn test_phase_darkening_small_at_p9_distances() {
+        // At r = 300–700 AU the phase angle never exceeds asin(1/r)
+        // (0.08–0.19°), but the H-G opposition surge still produces a few
+        // hundredths of a magnitude: Δm(α_max) = 0.054 mag at 300 AU,
+        // 0.039 mag at 500 AU. (A linear 0.04 mag/deg law would give
+        // ~5 mmag — the surge dominates at these tiny angles.)
+        for &(r, dm_expect) in &[(300.0, 0.0542), (500.0, 0.0393), (700.0, 0.0318)] {
+            let alpha_max = (1.0_f64 / r).asin();
+            let dm = -2.5 * hg_phase_factor(DEFAULT_SLOPE_G, alpha_max).log10();
+            assert!(
+                (dm - dm_expect).abs() < 5e-3,
+                "Δm(α_max) at {r} AU = {dm:.4}, expected ~{dm_expect}"
+            );
+        }
     }
 
     #[test]

--- a/crates/p9-core/tests/magnitude_oracle.rs
+++ b/crates/p9-core/tests/magnitude_oracle.rs
@@ -1,0 +1,121 @@
+//! Cross-validation of p9-core's generic-body photometry against
+//! starfield's Mallama & Hilton (2018) planetary magnitude model, using
+//! Neptune — the closest physical analog to Planet Nine and the anchor of
+//! the mass-radius relation — as the common target.
+//!
+//! The two paths share no constants:
+//! - starfield `magnitudelib::planetary_magnitude`: empirical Neptune
+//!   model (year-dependent baseline from secular brightening, fitted phase
+//!   polynomial above 1.9°), real DE-kernel observer geometry.
+//! - p9-core `analysis::photometry`: H from radius + geometric albedo via
+//!   the 1329 km diameter relation, the reflected-light 5 log10(rΔ)
+//!   distance law, and the IAU H-G phase function (G = 0.15) — evaluated
+//!   at the *same* r, Δ, α taken from the observed kernel geometry.
+//!
+//! Kernel-gated: skips when the starfield cache holds neither de421.bsp
+//! nor de440.bsp (never downloads).
+
+use starfield::jplephem::SpiceKernel;
+use starfield::jplephem_ext::SpiceKernelExt;
+use starfield::magnitudelib::planetary_magnitude;
+use starfield::time::Timescale;
+
+use p9_core::analysis::photometry::{
+    absolute_magnitude, apparent_magnitude_with_phase, mass_radius_neptunian, phase_angle,
+    ALBEDO_NEPTUNE, DEFAULT_SLOPE_G, NEPTUNE_MASS_EARTH,
+};
+use p9_core::constants::EARTH_RADIUS_KM;
+
+/// Open a JPL ephemeris from the starfield cache (de421 preferred, de440
+/// accepted), or `None` when absent so callers can skip hermetically.
+fn cached_kernel() -> Option<SpiceKernel> {
+    let cache = starfield::data::get_cache_dir();
+    for name in ["de421.bsp", "de440.bsp"] {
+        let path = cache.join(name);
+        let populated = std::fs::metadata(&path)
+            .map(|m| m.len() > 0)
+            .unwrap_or(false);
+        if populated {
+            return SpiceKernel::open(&path).ok();
+        }
+    }
+    None
+}
+
+/// Neptune's V magnitude computed (a) by starfield's Mallama-Hilton model
+/// on real ephemeris geometry and (b) by p9-core's generic photometry
+/// (Neptune mass through the mass-radius relation, p_V = 0.41, H-G phase
+/// term) at the same r, Δ, α — pinning the two implementations against
+/// each other independently of shared constants.
+///
+/// Agreement is not expected to be tight: Mallama-Hilton carries Neptune's
+/// secular brightening (V(0) clamped at −7.00 after ~2000 vs the static
+/// H ≈ −6.88 from R = 24 622 km, p_V = 0.41) and no phase term below
+/// α = 1.9°, while the H-G law's opposition surge adds ~0.02 mag at
+/// Neptune's near-opposition α. Measured at the 2020-09-11 opposition
+/// epoch (r = 29.92 AU, Δ = 28.92 AU, α = 0.042°): V_MH = 7.686,
+/// V_p9 = 7.828, Δ = +0.142 mag (0.124 from the V(0) baselines, 0.021
+/// from the H-G surge) — the documented band below allows ±0.35 mag.
+#[test]
+fn neptune_v_magnitude_cross_validation() {
+    let mut kernel = match cached_kernel() {
+        Some(k) => k,
+        None => {
+            eprintln!("skipping: no de421/de440 kernel in starfield cache");
+            return;
+        }
+    };
+    let ts = Timescale::default();
+    // Neptune opposition (2020-09-11): minimal phase angle, so the
+    // Mallama-Hilton model's missing sub-1.9° phase term contributes the
+    // least confound. Inside both DE421 and DE440 coverage.
+    let t = ts.utc((2020, 9, 11));
+
+    // (a) Mallama & Hilton 2018 via starfield, real observe() geometry.
+    let earth = kernel.at("earth", &t).expect("earth in kernel");
+    let neptune = earth
+        .observe("neptune barycenter", &mut kernel, &t)
+        .expect("neptune in kernel");
+    let v_mh = planetary_magnitude(&neptune, &t).expect("Neptune is supported");
+    assert!(v_mh.is_finite());
+
+    // The same geometry the magnitude model used: observer->target vector
+    // plus the observer's barycentric position (Sun ~ SSB, as in
+    // magnitudelib).
+    let obs_bary = neptune
+        .observer_barycentric
+        .as_ref()
+        .expect("observe() sets observer_barycentric");
+    let sun_to_observer = obs_bary.position;
+    let sun_to_neptune = sun_to_observer + neptune.position;
+    let r = sun_to_neptune.norm();
+    let delta = neptune.position.norm();
+    let alpha = phase_angle(r, delta, sun_to_observer.norm());
+
+    // Sanity: opposition geometry (Δ ≈ r − 1, α well below 1.9° so the
+    // M-H Neptune model applies no phase correction at all).
+    assert!((29.0..31.0).contains(&r), "r = {r:.2} AU");
+    assert!((delta - (r - 1.0)).abs() < 0.05, "Δ = {delta:.2} AU");
+    assert!(alpha.to_degrees() < 1.9, "α = {:.3}°", alpha.to_degrees());
+
+    // (b) p9-core generic photometry at the same r, Δ, α: Neptune's mass
+    // through the (Neptune-anchored) mass-radius relation, V-band
+    // geometric albedo 0.41, IAU H-G phase term with the default G.
+    let radius_km = mass_radius_neptunian(NEPTUNE_MASS_EARTH) * EARTH_RADIUS_KM;
+    let h = absolute_magnitude(radius_km, ALBEDO_NEPTUNE);
+    let v_p9 = apparent_magnitude_with_phase(h, r, delta, alpha, DEFAULT_SLOPE_G);
+
+    // Both must land at Neptune's familiar V ≈ 7.7-7.8 near opposition.
+    assert!((7.5..8.2).contains(&v_mh), "V_MH = {v_mh:.3}");
+    assert!((7.5..8.2).contains(&v_p9), "V_p9 = {v_p9:.3}");
+
+    // Cross-validation band (see doc comment): measured Δ = +0.142 mag at
+    // this epoch, dominated by the secular-brightening baseline (−7.00 vs
+    // −6.88, 0.124 mag) plus the H-G opposition surge (0.021 mag at this
+    // α) that Mallama-Hilton omits below 1.9°.
+    let dv = v_p9 - v_mh;
+    assert!(
+        dv.abs() < 0.35,
+        "p9-core vs Mallama-Hilton Neptune V: {v_p9:.3} vs {v_mh:.3} (Δ = {dv:+.3})"
+    );
+}


### PR DESCRIPTION
Closes #41. Implements the two-term IAU H-G phase function locally (Bowell et al. 1989; starfield-mpc is not on crates.io, coefficients kept identical for API convergence with #33), with phase_angle geometry and apparent_magnitude_with_phase (G=0.15 documented default). Threaded through the DES/PS1 ephemeris paths; measured max phase darkening over the reference population is 0.076 mag at alpha=0.33 deg (H-G opposition surge — the issue's <1 mmag guess was wrong; documented), with zero movement in the 87%/0.171/0.050 pins. Kernel-gated Neptune oracle: Mallama-Hilton V=7.686 vs p9-core mass/albedo chain V=7.828 (delta +0.142 mag, decomposed and pinned at +/-0.35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)