### PR TITLE
Implement 2021-orbit inference: sim grid, KDE, GP emulator, MCMC

### DIFF
--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -89,6 +89,43 @@ from 1/12 to 1/9.5. If those literals trace to a published table, the source sho
 - See: `crates/p9-2025-perturbation/src/hansen.rs` (cross-validation tests against
   `p9_core::analysis::hansen::hansen_coefficient`).
 
+### 9. p9-2021-orbit — full inference pipeline: Reduced scale validates machinery, not the posterior
+
+The paper's models 1–4 are now implemented from scratch (issue #12): N-body simulation grid
+over (m₉, a₉, e₉, i₉) (`sim_grid.rs`), conditional KDE likelihood of the 10 vetted ETNOs with
+the paper's 5%→30% bandwidth law (`kde.rs`), Matérn-3/2 GP emulator with grid-searched
+hyperparameters and closed-form LOO cross-validation (`gp.rs`), and a Goodman–Weare
+affine-invariant ensemble sampler with R̂/ESS diagnostics (`mcmc.rs`), wired in `pipeline.rs`.
+
+**What the Reduced scale achieves** (12-point grid × 200 particles × 10 Myr; seeds 2021/777;
+measured 2026-06-12, release build, 64 cores, ~68 s wall / 12.9 CPU-min):
+
+- Pipeline health: MCMC acceptance 0.369, R̂ = [1.033, 1.038, 1.041, 1.053],
+  ESS = [688, 647, 680, 594] (32 walkers × 2000 steps), all posterior mass inside the
+  uniform prior box.
+- GP LOO relative error 0.239 (pinned < 0.35 in the `#[ignore]`d end-to-end test). The
+  paper's < 5% applies to its 121-point grid; 12 points in a 4-D box cannot reach that.
+- The grid-point log-likelihoods span only ~3.7 nats (−30.5 to −26.7): after 10 Myr the
+  secular anti-aligned clustering the inference keys on is only partially developed, so the
+  posterior is close to the prior. The published medians (6.2 M⊕, 380 AU, e = 0.21, 16°)
+  lie inside the Reduced posterior's 95% intervals — asserted as a *loose containment
+  sanity check*, explicitly not a reproduction (the intervals are nearly as wide as the
+  prior box).
+- The posterior medians consumed downstream remain the published ones via the `posterior`
+  summary module (re-documented as the published-posterior representation).
+
+**What Paper scale needs** (`PipelineConfig::paper()`, `#[ignore]`d): the 121-point grid
+surrogate (the paper's manual grid is unpublished; we use a regular grid over the same
+extent, 8 masses × 15 (a₉, e₉, i₉) combos + 1 central point) × 16,800 particles × 4 Gyr,
+plus the paper's MCMC settings (100 walkers, 20,890 steps, burn 260, thin 42 → ≈49,100
+samples). At the measured throughput (~265 ns per particle-step) that is ≈3,000 CPU-days
+(~1.5 months wall on a 64-core machine, less as removal thins the disk) — not run here.
+Documented physics reductions even at Paper scale: J+S+U as the orbit-averaged J2 field
+with Neptune+P9 direct (dt = 3000 d) instead of all four giants direct at dt = 300 d, and
+the P9 orientation angles (ϖ₉, Ω₉) profiled out of the KDE likelihood over a 15° scan
+rather than sampled as MCMC dimensions. The cluster-scattering Fréchet prior is not
+implemented (uniform prior only; needs the Batygin & Brown 2021b scattering suite).
+
 ---
 
 ## Agreements within tolerance (for completeness)

--- a/crates/p9-2021-orbit/Cargo.toml
+++ b/crates/p9-2021-orbit/Cargo.toml
@@ -10,3 +10,5 @@ rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 approx = { workspace = true }
+rayon = { workspace = true }
+nalgebra = { workspace = true }

--- a/crates/p9-2021-orbit/src/gp.rs
+++ b/crates/p9-2021-orbit/src/gp.rs
@@ -1,0 +1,320 @@
+//! Model 3 of Brown & Batygin (2021), Section 4: Gaussian-process emulation
+//! of the simulation-grid likelihood.
+//!
+//! The paper interpolates the per-grid-point likelihood over continuous
+//! (m9, a9, e9, i9) with a GP using a Matern nu = 3/2 kernel, so the MCMC
+//! (Model 4) can evaluate the likelihood off-grid. The grid is small
+//! (<= 121 points), so exact GP regression via Cholesky factorization
+//! (nalgebra) is used — no sparse/inducing-point machinery.
+//!
+//! Hyperparameters (shared length scale over the normalized inputs, noise
+//! variance) are fit by grid-search maximization of the log marginal
+//! likelihood — documented choice: with <= 121 training points and a
+//! 2-parameter search space, an optimizer buys nothing over an exhaustive
+//! scan. Targets are standardized internally (zero mean, unit variance), so
+//! the signal variance is fixed at 1.
+//!
+//! Leave-one-out cross-validation uses the closed-form identities
+//! mu_i = y_i - [K^-1 y]_i / [K^-1]_ii (Rasmussen & Williams 2006, eq. 5.12).
+
+use nalgebra::{Cholesky, DMatrix, DVector, Dyn};
+use serde::{Deserialize, Serialize};
+
+/// Matern nu = 3/2 correlation as a function of the scaled distance r:
+/// k(r) = (1 + sqrt(3) r) exp(-sqrt(3) r).
+pub fn matern32(r: f64) -> f64 {
+    let s = 3.0_f64.sqrt() * r;
+    (1.0 + s) * (-s).exp()
+}
+
+/// Hyperparameter search grids (normalized-input units / standardized-target
+/// units). Length scales span "wiggly within the box" to "nearly linear";
+/// noise spans interpolation to heavy regularization.
+const LENGTH_SCALE_GRID: [f64; 10] = [0.1, 0.15, 0.25, 0.4, 0.6, 0.9, 1.3, 2.0, 3.0, 5.0];
+const NOISE_VAR_GRID: [f64; 6] = [1e-6, 1e-4, 1e-3, 1e-2, 1e-1, 0.5];
+
+/// Exact GP regressor with a Matern 3/2 kernel over normalized inputs.
+#[derive(Debug, Clone)]
+pub struct Matern32Gp {
+    x: Vec<[f64; 4]>,
+    /// Standardized targets
+    y: DVector<f64>,
+    y_mean: f64,
+    y_std: f64,
+    /// Fitted hyperparameters
+    pub length_scale: f64,
+    pub noise_var: f64,
+    /// Log marginal likelihood at the fitted hyperparameters
+    pub log_marginal: f64,
+    chol: Cholesky<f64, Dyn>,
+    alpha: DVector<f64>,
+}
+
+/// Summary of the fitted GP, serializable for output records.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GpFitSummary {
+    pub n_points: usize,
+    pub length_scale: f64,
+    pub noise_var: f64,
+    pub log_marginal: f64,
+    pub loo_relative_error: f64,
+}
+
+fn kernel_matrix(x: &[[f64; 4]], length_scale: f64, noise_var: f64) -> DMatrix<f64> {
+    let n = x.len();
+    DMatrix::from_fn(n, n, |i, j| {
+        let r = scaled_distance(&x[i], &x[j], length_scale);
+        matern32(r) + if i == j { noise_var } else { 0.0 }
+    })
+}
+
+fn scaled_distance(a: &[f64; 4], b: &[f64; 4], length_scale: f64) -> f64 {
+    let mut s = 0.0;
+    for d in 0..4 {
+        let dx = (a[d] - b[d]) / length_scale;
+        s += dx * dx;
+    }
+    s.sqrt()
+}
+
+impl Matern32Gp {
+    /// Fit the GP to (normalized input, target) pairs, grid-searching the
+    /// length scale and noise variance by maximum log marginal likelihood.
+    ///
+    /// Panics if fewer than 3 points are supplied or the targets are
+    /// degenerate (zero variance).
+    pub fn fit(inputs: &[[f64; 4]], targets: &[f64]) -> Self {
+        assert!(inputs.len() == targets.len());
+        assert!(inputs.len() >= 3, "GP needs at least 3 training points");
+        let n = inputs.len();
+
+        let y_mean = targets.iter().sum::<f64>() / n as f64;
+        let var = targets.iter().map(|y| (y - y_mean).powi(2)).sum::<f64>() / n as f64;
+        assert!(var > 0.0, "degenerate (constant) GP targets");
+        let y_std = var.sqrt();
+        let y = DVector::from_iterator(n, targets.iter().map(|t| (t - y_mean) / y_std));
+
+        struct Candidate {
+            lml: f64,
+            ell: f64,
+            noise: f64,
+            chol: Cholesky<f64, Dyn>,
+            alpha: DVector<f64>,
+        }
+        let mut best: Option<Candidate> = None;
+        for &ell in LENGTH_SCALE_GRID.iter() {
+            for &noise in NOISE_VAR_GRID.iter() {
+                let k = kernel_matrix(inputs, ell, noise);
+                let Some(chol) = Cholesky::new(k) else {
+                    continue; // numerically non-PD; skip this combination
+                };
+                let alpha = chol.solve(&y);
+                let log_det: f64 = chol.l().diagonal().iter().map(|d| 2.0 * d.ln()).sum();
+                let lml = -0.5 * y.dot(&alpha)
+                    - 0.5 * log_det
+                    - 0.5 * n as f64 * (2.0 * std::f64::consts::PI).ln();
+                if best.as_ref().is_none_or(|b| lml > b.lml) {
+                    best = Some(Candidate {
+                        lml,
+                        ell,
+                        noise,
+                        chol,
+                        alpha,
+                    });
+                }
+            }
+        }
+        let best = best.expect("no positive-definite kernel matrix in the search grid");
+
+        Self {
+            x: inputs.to_vec(),
+            y,
+            y_mean,
+            y_std,
+            length_scale: best.ell,
+            noise_var: best.noise,
+            log_marginal: best.lml,
+            chol: best.chol,
+            alpha: best.alpha,
+        }
+    }
+
+    /// Predictive mean and variance at a normalized input point
+    /// (de-standardized to target units).
+    pub fn predict(&self, x: &[f64; 4]) -> (f64, f64) {
+        let n = self.x.len();
+        let k_star = DVector::from_iterator(
+            n,
+            self.x
+                .iter()
+                .map(|xi| matern32(scaled_distance(xi, x, self.length_scale))),
+        );
+        let mean_std = k_star.dot(&self.alpha);
+        let v = self.chol.solve(&k_star);
+        let var_std = (1.0 + self.noise_var - k_star.dot(&v)).max(0.0);
+        (
+            self.y_mean + self.y_std * mean_std,
+            self.y_std * self.y_std * var_std,
+        )
+    }
+
+    /// Leave-one-out residuals (target units), via the closed-form
+    /// K^-1 identities — no n refits.
+    pub fn loo_residuals(&self) -> Vec<f64> {
+        let n = self.x.len();
+        let k_inv = self.chol.inverse();
+        let k_inv_y = &k_inv * &self.y;
+        (0..n)
+            .map(|i| self.y_std * k_inv_y[i] / k_inv[(i, i)])
+            .collect()
+    }
+
+    /// LOO relative error: mean |residual| divided by the target range.
+    ///
+    /// Normalizing by the range (not |y_i|) keeps the metric meaningful for
+    /// log-likelihood targets, whose absolute values are offset-arbitrary.
+    pub fn loo_relative_error(&self) -> f64 {
+        let res = self.loo_residuals();
+        let n = res.len() as f64;
+        let mean_abs = res.iter().map(|r| r.abs()).sum::<f64>() / n;
+        let y_min = self.y.iter().cloned().fold(f64::INFINITY, f64::min);
+        let y_max = self.y.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        let range = (y_max - y_min) * self.y_std;
+        mean_abs / range
+    }
+
+    pub fn summary(&self) -> GpFitSummary {
+        GpFitSummary {
+            n_points: self.x.len(),
+            length_scale: self.length_scale,
+            noise_var: self.noise_var,
+            log_marginal: self.log_marginal,
+            loo_relative_error: self.loo_relative_error(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    /// Smooth test surface over the unit box.
+    fn smooth_fn(x: &[f64; 4]) -> f64 {
+        3.0 * x[0] - 2.0 * (x[1] * std::f64::consts::PI).sin() + x[2] * x[3] - 0.5 * x[2]
+    }
+
+    /// Deterministic low-discrepancy-ish points in the unit box.
+    fn test_inputs(n: usize) -> Vec<[f64; 4]> {
+        (0..n)
+            .map(|k| {
+                let t = k as f64;
+                [
+                    (t * 0.618_033_988_75).fract(),
+                    (t * 0.414_213_562_37).fract(),
+                    (t * 0.732_050_807_57).fract(),
+                    (t * 0.236_067_977_50).fract(),
+                ]
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_matern32_limits() {
+        assert_relative_eq!(matern32(0.0), 1.0);
+        assert!(matern32(0.5) > matern32(1.0));
+        assert!(matern32(10.0) < 1e-6);
+    }
+
+    #[test]
+    fn test_gp_interpolates_training_points() {
+        let x = test_inputs(40);
+        let y: Vec<f64> = x.iter().map(smooth_fn).collect();
+        let gp = Matern32Gp::fit(&x, &y);
+        for (xi, yi) in x.iter().zip(&y) {
+            let (mean, _) = gp.predict(xi);
+            assert!(
+                (mean - yi).abs() < 0.15,
+                "training point miss: {mean} vs {yi}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_gp_predicts_held_out_points() {
+        let x = test_inputs(60);
+        let y: Vec<f64> = x.iter().map(smooth_fn).collect();
+        let gp = Matern32Gp::fit(&x, &y);
+        let y_range = 6.0; // approximate range of smooth_fn on the box
+        for probe in test_inputs(97).iter().skip(60) {
+            let (mean, var) = gp.predict(probe);
+            let truth = smooth_fn(probe);
+            assert!(
+                (mean - truth).abs() < 0.2 * y_range,
+                "off-grid miss: {mean} vs {truth}"
+            );
+            assert!(var >= 0.0);
+        }
+    }
+
+    #[test]
+    fn test_loo_residuals_match_explicit_refits() {
+        // The closed-form LOO must agree with literally refitting without
+        // each point (same fixed hyperparameters).
+        let x = test_inputs(20);
+        let y: Vec<f64> = x.iter().map(smooth_fn).collect();
+        let gp = Matern32Gp::fit(&x, &y);
+        let res = gp.loo_residuals();
+
+        for hold in [0usize, 7, 19] {
+            let xs: Vec<[f64; 4]> = x
+                .iter()
+                .enumerate()
+                .filter(|(k, _)| *k != hold)
+                .map(|(_, v)| *v)
+                .collect();
+            // Standardize with the *full* stats and reuse the fitted
+            // hyperparameters, mirroring the closed-form identity.
+            let y_mean = y.iter().sum::<f64>() / y.len() as f64;
+            let y_std =
+                (y.iter().map(|v| (v - y_mean).powi(2)).sum::<f64>() / y.len() as f64).sqrt();
+            let ys = DVector::from_iterator(
+                xs.len(),
+                y.iter()
+                    .enumerate()
+                    .filter(|(k, _)| *k != hold)
+                    .map(|(_, v)| (v - y_mean) / y_std),
+            );
+            let k = kernel_matrix(&xs, gp.length_scale, gp.noise_var);
+            let chol = Cholesky::new(k).unwrap();
+            let alpha = chol.solve(&ys);
+            let k_star = DVector::from_iterator(
+                xs.len(),
+                xs.iter()
+                    .map(|xi| matern32(scaled_distance(xi, &x[hold], gp.length_scale))),
+            );
+            let mu = y_mean + y_std * k_star.dot(&alpha);
+            assert_relative_eq!(y[hold] - mu, res[hold], epsilon = 1e-8);
+        }
+    }
+
+    #[test]
+    fn test_loo_relative_error_small_on_smooth_function() {
+        // 12 points (the Reduced grid size) on the smooth surface: measured
+        // LOO relative error 0.203 — 12 points in a 4-D box is genuinely
+        // sparse. (The paper quotes < 5% for its 121-point grid; see
+        // REPRODUCTION_NOTES.md for the scale difference.)
+        let x = test_inputs(12);
+        let y: Vec<f64> = x.iter().map(smooth_fn).collect();
+        let gp = Matern32Gp::fit(&x, &y);
+        let err = gp.loo_relative_error();
+        assert!(err < 0.25, "12-point LOO relative error = {err:.4}");
+
+        // At 60 points the same surface must emulate below the paper's 5%.
+        let x = test_inputs(60);
+        let y: Vec<f64> = x.iter().map(smooth_fn).collect();
+        let gp = Matern32Gp::fit(&x, &y);
+        let err = gp.loo_relative_error();
+        assert!(err < 0.05, "60-point LOO relative error = {err:.4}");
+    }
+}

--- a/crates/p9-2021-orbit/src/kde.rs
+++ b/crates/p9-2021-orbit/src/kde.rs
@@ -1,0 +1,434 @@
+//! Model 2 of Brown & Batygin (2021), Section 3: kernel density estimation
+//! of the conditional distributions P_{j,k}[(i, delta_varpi, delta_Omega) |
+//! (a, e) bin].
+//!
+//! For each simulation grid point j the pooled post-burn particle samples
+//! (Model 1) are binned by (a, e); within the bin matching an observed
+//! ETNO's (a, e), a 3-D kernel density estimate over (i, delta_varpi,
+//! delta_Omega) gives the likelihood of that object's observed angles.
+//!
+//! Bandwidth law (Brown & Batygin 2021, Section 3): the distributions are
+//! smoothed with a fractional bandwidth of 5% below a = 230 AU, rising
+//! linearly to 30% at a = 730 AU. The paper does not spell out how the
+//! fraction maps onto each coordinate; here it multiplies the natural domain
+//! width of each dimension (documented interpretation):
+//!
+//! - delta_varpi, delta_Omega: von Mises kernels with sigma = f(a) * 2 pi,
+//!   concentration kappa = 1/sigma^2 (the small-angle Gaussian limit);
+//! - inclination: Gaussian kernel with sigma = f(a) * pi/2, reflected at
+//!   i = 0 so density does not leak to negative inclinations.
+//!
+//! Empty/sparse bins fall back to the full sample set, and a log-density
+//! floor keeps the likelihood finite (both documented below) — at reduced
+//! simulation scale sparse bins are common.
+
+use std::f64::consts::PI;
+
+use serde::{Deserialize, Serialize};
+
+use p9_core::constants::{DEG2RAD, TWO_PI};
+use p9_core::data::etno::Etno;
+
+use crate::sim_grid::ElementSample;
+
+/// Below this semi-major axis the fractional bandwidth is 5%
+/// (Brown & Batygin 2021, Section 3).
+pub const BANDWIDTH_A_LOW: f64 = 230.0;
+/// At this semi-major axis the fractional bandwidth has risen to 30%.
+pub const BANDWIDTH_A_HIGH: f64 = 730.0;
+/// Fractional bandwidth below `BANDWIDTH_A_LOW`.
+pub const BANDWIDTH_FRAC_LOW: f64 = 0.05;
+/// Fractional bandwidth at and above `BANDWIDTH_A_HIGH`.
+pub const BANDWIDTH_FRAC_HIGH: f64 = 0.30;
+
+/// Floor on the per-object log-density. Keeps the total log-likelihood
+/// finite when an observation falls in a region with no simulation support
+/// (exp(-30) ~ 1e-13, far below any resolved density).
+pub const LOG_DENSITY_FLOOR: f64 = -30.0;
+
+/// Fewer samples than this in the matched (a, e) bin triggers the
+/// full-sample fallback (documented reduced-scale necessity).
+pub const MIN_BIN_SAMPLES: usize = 10;
+
+/// The paper's bandwidth law: 5% fractional bandwidth for a < 230 AU,
+/// linear in a up to 30% at a = 730 AU, constant beyond.
+pub fn fractional_bandwidth(a: f64) -> f64 {
+    let t = ((a - BANDWIDTH_A_LOW) / (BANDWIDTH_A_HIGH - BANDWIDTH_A_LOW)).clamp(0.0, 1.0);
+    BANDWIDTH_FRAC_LOW + t * (BANDWIDTH_FRAC_HIGH - BANDWIDTH_FRAC_LOW)
+}
+
+/// (a, e) bin edges for the conditional distributions.
+///
+/// The defaults bracket both the initial disk (a in 150-500 AU, e in
+/// ~0.67-0.94) and the observed ETNO sample (a in 228-506 AU, e in
+/// 0.69-0.93). Out-of-range values are clamped into the nearest bin
+/// (documented: at reduced scale discarding diffused particles starves the
+/// estimate).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BinSpec {
+    pub a_edges: Vec<f64>,
+    pub e_edges: Vec<f64>,
+}
+
+impl Default for BinSpec {
+    fn default() -> Self {
+        Self {
+            a_edges: vec![150.0, 250.0, 350.0, 450.0, 600.0],
+            e_edges: vec![0.5, 0.7, 0.8, 0.9, 1.0],
+        }
+    }
+}
+
+impl BinSpec {
+    /// Bin index for (a, e), clamping out-of-range values into the nearest
+    /// edge bin.
+    pub fn bin_index(&self, a: f64, e: f64) -> (usize, usize) {
+        (clamped_bin(&self.a_edges, a), clamped_bin(&self.e_edges, e))
+    }
+
+    fn n_bins(&self) -> (usize, usize) {
+        (self.a_edges.len() - 1, self.e_edges.len() - 1)
+    }
+}
+
+fn clamped_bin(edges: &[f64], x: f64) -> usize {
+    let n = edges.len() - 1;
+    if x < edges[0] {
+        return 0;
+    }
+    for k in 0..n {
+        if x < edges[k + 1] {
+            return k;
+        }
+    }
+    n - 1
+}
+
+/// Modified Bessel function I0 (Abramowitz & Stegun 9.8.1/9.8.2 polynomial
+/// approximations, |error| < 2e-7). Needed for the von Mises normalization.
+fn bessel_i0(x: f64) -> f64 {
+    let ax = x.abs();
+    if ax < 3.75 {
+        let t = (ax / 3.75).powi(2);
+        1.0 + t
+            * (3.5156229
+                + t * (3.0899424
+                    + t * (1.2067492 + t * (0.2659732 + t * (0.0360768 + t * 0.0045813)))))
+    } else {
+        let t = 3.75 / ax;
+        (ax.exp() / ax.sqrt())
+            * (0.39894228
+                + t * (0.01328592
+                    + t * (0.00225319
+                        + t * (-0.00157565
+                            + t * (0.00916281
+                                + t * (-0.02057706
+                                    + t * (0.02635537 + t * (-0.01647633 + t * 0.00392377))))))))
+    }
+}
+
+/// Von Mises density on [0, 2 pi).
+fn von_mises_pdf(theta: f64, mu: f64, kappa: f64) -> f64 {
+    (kappa * (theta - mu).cos()).exp() / (TWO_PI * bessel_i0(kappa))
+}
+
+/// Gaussian density reflected at i = 0 (inclination support is i >= 0).
+fn reflected_gaussian_pdf(x: f64, mu: f64, sigma: f64) -> f64 {
+    let norm = 1.0 / (sigma * (TWO_PI).sqrt());
+    let g = |m: f64| norm * (-0.5 * ((x - m) / sigma).powi(2)).exp();
+    g(mu) + g(-mu)
+}
+
+/// 3-D conditional KDE over (i, delta_varpi, delta_Omega) for one (a, e)
+/// bin, with kernel widths set by the paper's bandwidth law evaluated at
+/// the *observed* object's semi-major axis.
+#[derive(Debug, Clone)]
+pub struct ConditionalKde {
+    samples: Vec<(f64, f64, f64)>,
+    /// Gaussian sigma for inclination (radians)
+    sigma_i: f64,
+    /// Von Mises concentration for the two angle dimensions
+    kappa_angle: f64,
+}
+
+impl ConditionalKde {
+    /// Build a KDE from bin samples, with bandwidths from
+    /// `fractional_bandwidth(a_obs)`. Returns None for an empty sample set.
+    pub fn new(samples: Vec<(f64, f64, f64)>, a_obs: f64) -> Option<Self> {
+        if samples.is_empty() {
+            return None;
+        }
+        let f = fractional_bandwidth(a_obs);
+        let sigma_angle = f * TWO_PI;
+        let sigma_i = f * (PI / 2.0);
+        Some(Self {
+            samples,
+            sigma_i,
+            kappa_angle: 1.0 / (sigma_angle * sigma_angle),
+        })
+    }
+
+    /// Density at (i, delta_varpi, delta_Omega), angles in radians.
+    pub fn density(&self, i: f64, delta_varpi: f64, delta_omega_big: f64) -> f64 {
+        let mut total = 0.0;
+        for &(si, svarpi, somega) in &self.samples {
+            total += reflected_gaussian_pdf(i, si, self.sigma_i)
+                * von_mises_pdf(delta_varpi, svarpi, self.kappa_angle)
+                * von_mises_pdf(delta_omega_big, somega, self.kappa_angle);
+        }
+        total / self.samples.len() as f64
+    }
+}
+
+/// All conditional KDE inputs for one simulation grid point: samples binned
+/// by (a, e), with the documented sparse-bin fallback.
+#[derive(Debug, Clone)]
+pub struct GridPointKde {
+    spec: BinSpec,
+    /// bins\[ia\]\[ie\] -> (i, delta_varpi, delta_Omega) tuples
+    bins: Vec<Vec<Vec<(f64, f64, f64)>>>,
+    all: Vec<(f64, f64, f64)>,
+}
+
+impl GridPointKde {
+    pub fn from_samples(samples: &[ElementSample], spec: BinSpec) -> Self {
+        let (na, ne) = spec.n_bins();
+        let mut bins = vec![vec![Vec::new(); ne]; na];
+        let mut all = Vec::with_capacity(samples.len());
+        for s in samples {
+            let tuple = (s.i, s.delta_varpi, s.delta_omega_big);
+            let (ia, ie) = spec.bin_index(s.a, s.e);
+            bins[ia][ie].push(tuple);
+            all.push(tuple);
+        }
+        Self { spec, bins, all }
+    }
+
+    /// Number of samples in the bin matched by (a, e).
+    pub fn bin_count(&self, a: f64, e: f64) -> usize {
+        let (ia, ie) = self.spec.bin_index(a, e);
+        self.bins[ia][ie].len()
+    }
+
+    /// Log-density of observed (i, delta_varpi, delta_Omega) given the
+    /// observation's (a, e) bin. Falls back to the full sample set when the
+    /// bin holds fewer than `MIN_BIN_SAMPLES` samples; floored at
+    /// `LOG_DENSITY_FLOOR`.
+    pub fn log_density(
+        &self,
+        a_obs: f64,
+        e_obs: f64,
+        i: f64,
+        delta_varpi: f64,
+        delta_omega_big: f64,
+    ) -> f64 {
+        let (ia, ie) = self.spec.bin_index(a_obs, e_obs);
+        let bin = &self.bins[ia][ie];
+        let samples = if bin.len() >= MIN_BIN_SAMPLES {
+            bin
+        } else {
+            &self.all
+        };
+        match ConditionalKde::new(samples.clone(), a_obs) {
+            Some(kde) => kde
+                .density(i, delta_varpi, delta_omega_big)
+                .ln()
+                .max(LOG_DENSITY_FLOOR),
+            None => LOG_DENSITY_FLOOR,
+        }
+    }
+}
+
+/// Total log-likelihood of the observed ETNO sample given this grid point's
+/// conditional distributions and a hypothesized Planet Nine orientation
+/// (varpi9, Omega9) (radians).
+///
+/// The simulations record particle angles *relative* to Planet Nine, so the
+/// observed relative angles are delta_varpi = varpi_etno - varpi9 and
+/// delta_Omega = Omega_etno - Omega9.
+pub fn etno_log_likelihood(
+    kde: &GridPointKde,
+    etnos: &[Etno],
+    varpi9: f64,
+    omega_big9: f64,
+) -> f64 {
+    etnos
+        .iter()
+        .map(|etno| {
+            let delta_varpi = (etno.longitude_of_perihelion() - varpi9).rem_euclid(TWO_PI);
+            let delta_omega_big = (etno.omega_big_deg * DEG2RAD - omega_big9).rem_euclid(TWO_PI);
+            kde.log_density(
+                etno.a,
+                etno.e,
+                etno.i_deg * DEG2RAD,
+                delta_varpi,
+                delta_omega_big,
+            )
+        })
+        .sum()
+}
+
+/// Profile the ETNO log-likelihood over the Planet Nine orientation angles.
+///
+/// The paper's MCMC includes (varpi9, Omega9) as free parameters; the
+/// reduced 4-parameter pipeline here (m9, a9, e9, i9) instead *profiles*
+/// them out: a coarse `n_scan` x `n_scan` scan over [0, 2 pi)^2 keeps the
+/// maximizing orientation (documented reduction; 24 x 24 = 15 deg
+/// resolution is finer than any kernel bandwidth in use).
+///
+/// Returns (max log-likelihood, best varpi9, best Omega9).
+pub fn profiled_log_likelihood(
+    kde: &GridPointKde,
+    etnos: &[Etno],
+    n_scan: usize,
+) -> (f64, f64, f64) {
+    let mut best = (f64::NEG_INFINITY, 0.0, 0.0);
+    for jv in 0..n_scan {
+        let varpi9 = TWO_PI * jv as f64 / n_scan as f64;
+        for jo in 0..n_scan {
+            let omega_big9 = TWO_PI * jo as f64 / n_scan as f64;
+            let ll = etno_log_likelihood(kde, etnos, varpi9, omega_big9);
+            if ll > best.0 {
+                best = (ll, varpi9, omega_big9);
+            }
+        }
+    }
+    best
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use p9_core::data::etno::BROWN_2017_SAMPLE;
+
+    #[test]
+    fn test_bandwidth_law() {
+        // Paper values: 5% below 230 AU, 30% at 730 AU, linear between.
+        assert_relative_eq!(fractional_bandwidth(150.0), 0.05);
+        assert_relative_eq!(fractional_bandwidth(230.0), 0.05);
+        assert_relative_eq!(fractional_bandwidth(480.0), 0.175); // midpoint
+        assert_relative_eq!(fractional_bandwidth(730.0), 0.30);
+        assert_relative_eq!(fractional_bandwidth(1000.0), 0.30);
+    }
+
+    #[test]
+    fn test_bessel_i0_reference_values() {
+        // Abramowitz & Stegun Table 9.8: I0(0)=1, I0(1)=1.2660658,
+        // I0(2)=2.2795853, I0(5)=27.239872.
+        assert_relative_eq!(bessel_i0(0.0), 1.0, epsilon = 1e-6);
+        assert_relative_eq!(bessel_i0(1.0), 1.2660658, epsilon = 1e-5);
+        assert_relative_eq!(bessel_i0(2.0), 2.2795853, epsilon = 1e-5);
+        assert_relative_eq!(bessel_i0(5.0), 27.239872, max_relative = 1e-5);
+    }
+
+    #[test]
+    fn test_von_mises_normalization() {
+        // Numerically integrate the von Mises pdf over the circle.
+        for &kappa in &[0.3, 2.0, 10.0] {
+            let n = 5000;
+            let sum: f64 = (0..n)
+                .map(|k| von_mises_pdf(TWO_PI * k as f64 / n as f64, 1.0, kappa))
+                .sum::<f64>()
+                * TWO_PI
+                / n as f64;
+            assert_relative_eq!(sum, 1.0, epsilon = 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_reflected_gaussian_integrates_to_one_on_half_line() {
+        let (mu, sigma) = (0.05, 0.1);
+        let n = 20000;
+        let dx = 2.0 / n as f64;
+        let sum: f64 = (0..n)
+            .map(|k| reflected_gaussian_pdf((k as f64 + 0.5) * dx, mu, sigma))
+            .sum::<f64>()
+            * dx;
+        assert_relative_eq!(sum, 1.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_bin_clamping() {
+        let spec = BinSpec::default();
+        // In-range values land in the right bins.
+        assert_eq!(spec.bin_index(160.0, 0.55), (0, 0));
+        assert_eq!(spec.bin_index(500.0, 0.95), (3, 3));
+        // Out-of-range values clamp to the nearest edge bin.
+        assert_eq!(spec.bin_index(100.0, 0.2), (0, 0));
+        assert_eq!(spec.bin_index(2000.0, 0.999), (3, 3));
+    }
+
+    #[test]
+    fn test_kde_peaks_near_samples() {
+        // Tight cluster of samples at i=0.3, dvarpi=pi, dOmega=0.
+        let samples: Vec<(f64, f64, f64)> = (0..50)
+            .map(|k| {
+                let eps = 0.01 * (k as f64 - 25.0) / 25.0;
+                (0.3 + eps, PI + eps, eps.rem_euclid(TWO_PI))
+            })
+            .collect();
+        let kde = ConditionalKde::new(samples, 300.0).unwrap();
+        let at_cluster = kde.density(0.3, PI, 0.0);
+        let far_away = kde.density(1.2, 0.0, PI);
+        assert!(
+            at_cluster > far_away,
+            "KDE not peaked at samples: {at_cluster} <= {far_away}"
+        );
+    }
+
+    #[test]
+    fn test_grid_point_kde_fallback_and_floor() {
+        use crate::sim_grid::ElementSample;
+        // 5 samples in one bin: below MIN_BIN_SAMPLES, so every lookup uses
+        // the full-set fallback and still returns a finite value.
+        let samples: Vec<ElementSample> = (0..5)
+            .map(|k| ElementSample {
+                a: 300.0,
+                e: 0.85,
+                i: 0.3,
+                delta_varpi: PI + 0.01 * k as f64,
+                delta_omega_big: 0.1,
+            })
+            .collect();
+        let kde = GridPointKde::from_samples(&samples, BinSpec::default());
+        assert_eq!(kde.bin_count(300.0, 0.85), 5);
+        let ll = kde.log_density(450.0, 0.75, 0.3, PI, 0.1);
+        assert!(ll.is_finite() && ll > LOG_DENSITY_FLOOR);
+
+        // Empty sample set -> floor.
+        let empty = GridPointKde::from_samples(&[], BinSpec::default());
+        assert_eq!(
+            empty.log_density(300.0, 0.85, 0.3, PI, 0.1),
+            LOG_DENSITY_FLOOR
+        );
+    }
+
+    #[test]
+    fn test_profiled_likelihood_finds_clustered_orientation() {
+        use crate::sim_grid::ElementSample;
+        // Synthetic anti-aligned population: delta_varpi concentrated at pi,
+        // delta_Omega at 0, inclinations near the ETNO range.
+        let mut samples = Vec::new();
+        for k in 0..400 {
+            let jitter = 0.25 * ((k * 37 % 100) as f64 / 100.0 - 0.5);
+            samples.push(ElementSample {
+                a: 250.0 + (k % 30) as f64 * 8.0,
+                e: 0.7 + (k % 25) as f64 * 0.01,
+                i: (15.0 + 10.0 * ((k * 13 % 50) as f64 / 50.0 - 0.5)) * DEG2RAD,
+                delta_varpi: (PI + jitter).rem_euclid(TWO_PI),
+                delta_omega_big: jitter.rem_euclid(TWO_PI),
+            });
+        }
+        let kde = GridPointKde::from_samples(&samples, BinSpec::default());
+        let (ll_best, varpi9, _) = profiled_log_likelihood(&kde, &BROWN_2017_SAMPLE, 24);
+        assert!(ll_best.is_finite());
+
+        // The clustered ETNO varpi values sit near ~50 deg (circular mean of
+        // the 8-object cluster); anti-alignment puts the preferred varpi9
+        // roughly opposite. The profile maximum must beat a deliberately
+        // orthogonal orientation.
+        let ll_off = etno_log_likelihood(&kde, &BROWN_2017_SAMPLE, varpi9 + PI / 2.0, 0.0);
+        assert!(ll_best >= ll_off);
+    }
+}

--- a/crates/p9-2021-orbit/src/lib.rs
+++ b/crates/p9-2021-orbit/src/lib.rs
@@ -1,17 +1,40 @@
 //! Reproduction of Brown & Batygin (2021)
 //! "The Orbit of Planet Nine"
 //!
-//! The paper uses an MCMC analysis of 11 distant KBOs (a > 250 AU) to derive
-//! posterior distributions for Planet Nine's orbital parameters.
-//! Key results: m = 6.2 (+2.2/-1.3) Earth masses, a = 380 (+140/-80) AU,
-//! i = 16 +/- 5 degrees, q = 300 (+85/-60) AU.
+//! The paper derives the Planet Nine posterior by MCMC over a likelihood
+//! built from N-body simulations: key results m = 6.2 (+2.2/-1.3) Earth
+//! masses, a = 380 (+140/-80) AU, i = 16 +/- 5 degrees, q = 300 (+85/-60)
+//! AU, clustering significant at 99.6%.
 //!
-//! This crate is a *posterior-summary emulator*: it does not re-run the
-//! likelihood/MCMC, it resamples the published summaries (with a documented
-//! a-q correlation assumption) and recomputes the clustering statistics from
-//! the vetted ETNO table.
+//! Two paths through this crate:
+//!
+//! 1. **From-scratch inference pipeline** (the paper's models 1-4):
+//!    [`sim_grid`] integrates scattered-disk particles over a grid of
+//!    (m9, a9, e9, i9) points, [`kde`] turns the surviving-particle
+//!    distributions into conditional likelihoods of the observed ETNOs,
+//!    [`gp`] emulates the likelihood surface with a Matern 3/2 Gaussian
+//!    process, and [`mcmc`] (affine-invariant ensemble sampler) draws the
+//!    posterior; [`pipeline`] wires them end to end. Default tests run the
+//!    machinery at reduced scale; the published posterior itself is only
+//!    reachable at the `#[ignore]`d paper scale (121 points x 16,800
+//!    particles x 4 Gyr — estimated CPU-days, see REPRODUCTION_NOTES.md).
+//!
+//! 2. **Published-posterior summary** ([`posterior`]): split-normal
+//!    resampling of the published medians/intervals (with a documented a-q
+//!    correlation assumption). This is what the downstream survey crates
+//!    (p9-2021-ztf, p9-2022-des, p9-2024-panstarrs) consume via
+//!    [`reference_population`]; it represents the *published* posterior,
+//!    not the reduced-scale pipeline output.
+//!
+//! [`statistical_measures`] recomputes the clustering significance from the
+//! vetted ETNO table (0.989 computed vs 0.996 published, documented).
 
+pub mod gp;
+pub mod kde;
+pub mod mcmc;
+pub mod pipeline;
 pub mod plots;
 pub mod posterior;
 pub mod reference_population;
+pub mod sim_grid;
 pub mod statistical_measures;

--- a/crates/p9-2021-orbit/src/mcmc.rs
+++ b/crates/p9-2021-orbit/src/mcmc.rs
@@ -1,0 +1,428 @@
+//! Model 4 of Brown & Batygin (2021), Section 5: affine-invariant ensemble
+//! MCMC (Goodman & Weare 2010; the emcee "stretch move" with the red-black
+//! parallel update of Foreman-Mackey et al. 2013).
+//!
+//! The sampler is generic over a log-posterior closure. The paper ran 100
+//! chains of 20,890 samples, burn-in 260, thinning 42, yielding 49,100
+//! uncorrelated posterior samples; those numbers are pinned in
+//! [`PaperMcmcSettings`] for the `#[ignore]`d paper-scale entry point, while
+//! reduced runs use shorter chains (documented at the call sites).
+//!
+//! Convergence diagnostics:
+//! - Gelman-Rubin R-hat treating each walker's post-burn chain as a chain.
+//!   Walkers in an ensemble are not independent chains, so this is a health
+//!   metric (R-hat near 1 is necessary, not sufficient) — documented caveat.
+//! - Effective sample size from the integrated autocorrelation time
+//!   (Sokal windowing, c = 5, autocorrelations averaged across walkers).
+
+use rand::{Rng, SeedableRng};
+use serde::{Deserialize, Serialize};
+
+/// The paper's MCMC run settings (Brown & Batygin 2021, Section 5).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct PaperMcmcSettings {
+    pub n_walkers: usize,
+    pub n_steps: usize,
+    pub burn_in: usize,
+    pub thin: usize,
+}
+
+impl PaperMcmcSettings {
+    pub fn paper() -> Self {
+        Self {
+            n_walkers: 100,
+            n_steps: 20_890,
+            burn_in: 260,
+            thin: 42,
+        }
+    }
+}
+
+/// Ensemble chain: `samples[step][walker]` is a parameter vector.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnsembleChain {
+    pub samples: Vec<Vec<Vec<f64>>>,
+    pub log_probs: Vec<Vec<f64>>,
+    pub acceptance_rate: f64,
+    pub seed: u64,
+}
+
+impl EnsembleChain {
+    pub fn n_steps(&self) -> usize {
+        self.samples.len()
+    }
+
+    pub fn n_walkers(&self) -> usize {
+        self.samples.first().map_or(0, |s| s.len())
+    }
+
+    pub fn dim(&self) -> usize {
+        self.samples
+            .first()
+            .and_then(|s| s.first())
+            .map_or(0, |w| w.len())
+    }
+
+    /// Flattened post-burn, thinned samples (all walkers interleaved).
+    pub fn flat_samples(&self, burn_in: usize, thin: usize) -> Vec<Vec<f64>> {
+        let mut out = Vec::new();
+        for step in (burn_in..self.n_steps()).step_by(thin.max(1)) {
+            for walker in &self.samples[step] {
+                out.push(walker.clone());
+            }
+        }
+        out
+    }
+
+    /// Gelman-Rubin R-hat per dimension over the post-burn chain, treating
+    /// each walker as a chain (health metric; see module docs for the
+    /// ensemble caveat).
+    pub fn gelman_rubin(&self, burn_in: usize) -> Vec<f64> {
+        let m = self.n_walkers();
+        let n = self.n_steps().saturating_sub(burn_in);
+        let d = self.dim();
+        assert!(
+            m >= 2 && n >= 4,
+            "need >= 2 walkers and >= 4 post-burn steps"
+        );
+
+        (0..d)
+            .map(|dim| {
+                // Per-walker means and variances.
+                let mut means = vec![0.0; m];
+                for step in burn_in..self.n_steps() {
+                    for (w, mean) in means.iter_mut().enumerate() {
+                        *mean += self.samples[step][w][dim];
+                    }
+                }
+                for mean in means.iter_mut() {
+                    *mean /= n as f64;
+                }
+                let grand = means.iter().sum::<f64>() / m as f64;
+
+                let mut within = 0.0;
+                for (w, &mean) in means.iter().enumerate() {
+                    let mut s2 = 0.0;
+                    for step in burn_in..self.n_steps() {
+                        s2 += (self.samples[step][w][dim] - mean).powi(2);
+                    }
+                    within += s2 / (n - 1) as f64;
+                }
+                within /= m as f64;
+
+                let between = n as f64 / (m - 1) as f64
+                    * means.iter().map(|&mu| (mu - grand).powi(2)).sum::<f64>();
+
+                if within <= 0.0 {
+                    return 1.0; // all walkers frozen at the same value
+                }
+                let var_plus = (n - 1) as f64 / n as f64 * within + between / n as f64;
+                (var_plus / within).sqrt()
+            })
+            .collect()
+    }
+
+    /// Effective sample size per dimension: ESS = (m * n) / tau, with the
+    /// integrated autocorrelation time tau estimated per walker, averaged
+    /// across walkers, using Sokal's adaptive window (c = 5).
+    pub fn effective_sample_size(&self, burn_in: usize) -> Vec<f64> {
+        let m = self.n_walkers();
+        let n = self.n_steps().saturating_sub(burn_in);
+        let d = self.dim();
+        assert!(n >= 8, "need >= 8 post-burn steps for an ESS estimate");
+
+        (0..d)
+            .map(|dim| {
+                // Mean autocorrelation function across walkers.
+                let max_lag = n / 2;
+                let mut acf_sum = vec![0.0; max_lag];
+                for w in 0..m {
+                    let series: Vec<f64> = (burn_in..self.n_steps())
+                        .map(|s| self.samples[s][w][dim])
+                        .collect();
+                    let mean = series.iter().sum::<f64>() / n as f64;
+                    let var = series.iter().map(|x| (x - mean).powi(2)).sum::<f64>() / n as f64;
+                    if var <= 0.0 {
+                        continue;
+                    }
+                    for (lag, acf) in acf_sum.iter_mut().enumerate() {
+                        let mut c = 0.0;
+                        for t in 0..(n - lag) {
+                            c += (series[t] - mean) * (series[t + lag] - mean);
+                        }
+                        *acf += c / (n as f64 * var);
+                    }
+                }
+                for acf in acf_sum.iter_mut() {
+                    *acf /= m as f64;
+                }
+
+                // Sokal window: smallest W with W >= c * tau(W), c = 5.
+                let mut tau = 1.0;
+                for window in 1..max_lag {
+                    tau = 1.0 + 2.0 * acf_sum[1..=window].iter().sum::<f64>();
+                    if (window as f64) >= 5.0 * tau {
+                        break;
+                    }
+                }
+                let tau = tau.max(1.0);
+                (m * n) as f64 / tau
+            })
+            .collect()
+    }
+}
+
+/// Affine-invariant ensemble sampler (Goodman & Weare 2010 stretch move).
+#[derive(Debug, Clone)]
+pub struct EnsembleSampler {
+    pub n_walkers: usize,
+    /// Stretch parameter a (paper and emcee default: 2).
+    pub stretch_a: f64,
+}
+
+impl EnsembleSampler {
+    pub fn new(n_walkers: usize) -> Self {
+        assert!(
+            n_walkers >= 4 && n_walkers.is_multiple_of(2),
+            "need an even number of walkers >= 4"
+        );
+        Self {
+            n_walkers,
+            stretch_a: 2.0,
+        }
+    }
+
+    /// Run the sampler for `n_steps` ensemble updates from the given initial
+    /// walker positions. `log_prob` may return -inf (rejected region).
+    ///
+    /// Red-black update: each half of the ensemble is moved using partners
+    /// drawn only from the other half (Foreman-Mackey et al. 2013), which
+    /// preserves detailed balance for the whole ensemble update.
+    pub fn run<F: Fn(&[f64]) -> f64>(
+        &self,
+        log_prob: F,
+        initial: &[Vec<f64>],
+        n_steps: usize,
+        seed: u64,
+    ) -> EnsembleChain {
+        assert_eq!(initial.len(), self.n_walkers);
+        let dim = initial[0].len();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+        let mut positions: Vec<Vec<f64>> = initial.to_vec();
+        let mut log_probs: Vec<f64> = positions.iter().map(|p| log_prob(p)).collect();
+        assert!(
+            log_probs.iter().any(|lp| lp.is_finite()),
+            "no walker starts at finite log-probability"
+        );
+
+        let half = self.n_walkers / 2;
+        let mut samples = Vec::with_capacity(n_steps);
+        let mut chain_log_probs = Vec::with_capacity(n_steps);
+        let mut n_accept = 0usize;
+        let mut n_propose = 0usize;
+
+        for _ in 0..n_steps {
+            for side in 0..2 {
+                let (lo, hi) = if side == 0 {
+                    (0, half)
+                } else {
+                    (half, self.n_walkers)
+                };
+                let (other_lo, other_len) = if side == 0 {
+                    (half, self.n_walkers - half)
+                } else {
+                    (0, half)
+                };
+                for k in lo..hi {
+                    let partner = other_lo + rng.gen_range(0..other_len);
+                    // z ~ g(z) prop. 1/sqrt(z) on [1/a, a]:
+                    // z = ((a-1) u + 1)^2 / a.
+                    let u: f64 = rng.gen();
+                    let z = ((self.stretch_a - 1.0) * u + 1.0).powi(2) / self.stretch_a;
+                    let proposal: Vec<f64> = (0..dim)
+                        .map(|d| {
+                            positions[partner][d] + z * (positions[k][d] - positions[partner][d])
+                        })
+                        .collect();
+                    let lp_new = log_prob(&proposal);
+                    let ln_accept = (dim as f64 - 1.0) * z.ln() + lp_new - log_probs[k];
+                    n_propose += 1;
+                    if ln_accept >= 0.0 || rng.gen::<f64>().ln() < ln_accept {
+                        positions[k] = proposal;
+                        log_probs[k] = lp_new;
+                        n_accept += 1;
+                    }
+                }
+            }
+            samples.push(positions.clone());
+            chain_log_probs.push(log_probs.clone());
+        }
+
+        EnsembleChain {
+            samples,
+            log_probs: chain_log_probs,
+            acceptance_rate: n_accept as f64 / n_propose as f64,
+            seed,
+        }
+    }
+}
+
+/// Initialize walkers uniformly inside a box (seeded).
+pub fn init_walkers_in_box(n_walkers: usize, bounds: &[(f64, f64)], seed: u64) -> Vec<Vec<f64>> {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    (0..n_walkers)
+        .map(|_| {
+            bounds
+                .iter()
+                .map(|&(lo, hi)| rng.gen_range(lo..hi))
+                .collect()
+        })
+        .collect()
+}
+
+/// Quantile of a (will be sorted) sample vector, linear interpolation.
+pub fn quantile(values: &mut [f64], q: f64) -> f64 {
+    assert!(!values.is_empty());
+    values.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let pos = q.clamp(0.0, 1.0) * (values.len() - 1) as f64;
+    let lo = pos.floor() as usize;
+    let hi = pos.ceil() as usize;
+    let frac = pos - lo as f64;
+    values[lo] * (1.0 - frac) + values[hi] * frac
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 2D correlated Gaussian: mean (1, -2), var (2, 0.5), corr 0.6.
+    fn gaussian_2d_logp(x: &[f64]) -> f64 {
+        let (mx, my) = (1.0, -2.0);
+        let (sx2, sy2, rho): (f64, f64, f64) = (2.0, 0.5, 0.6);
+        let (sx, sy) = (sx2.sqrt(), sy2.sqrt());
+        let dx = (x[0] - mx) / sx;
+        let dy = (x[1] - my) / sy;
+        -0.5 * (dx * dx - 2.0 * rho * dx * dy + dy * dy) / (1.0 - rho * rho)
+    }
+
+    #[test]
+    fn test_recovers_gaussian_mean_and_covariance() {
+        let sampler = EnsembleSampler::new(32);
+        let init = init_walkers_in_box(32, &[(0.0, 2.0), (-3.0, -1.0)], 7);
+        let chain = sampler.run(gaussian_2d_logp, &init, 3000, 11);
+
+        let flat = chain.flat_samples(500, 1);
+        let n = flat.len() as f64;
+        let mean_x = flat.iter().map(|s| s[0]).sum::<f64>() / n;
+        let mean_y = flat.iter().map(|s| s[1]).sum::<f64>() / n;
+        assert!((mean_x - 1.0).abs() < 0.1, "mean x = {mean_x}");
+        assert!((mean_y + 2.0).abs() < 0.05, "mean y = {mean_y}");
+
+        let var_x = flat.iter().map(|s| (s[0] - mean_x).powi(2)).sum::<f64>() / n;
+        let var_y = flat.iter().map(|s| (s[1] - mean_y).powi(2)).sum::<f64>() / n;
+        let cov_xy = flat
+            .iter()
+            .map(|s| (s[0] - mean_x) * (s[1] - mean_y))
+            .sum::<f64>()
+            / n;
+        assert!((var_x - 2.0).abs() < 0.25, "var x = {var_x}");
+        assert!((var_y - 0.5).abs() < 0.07, "var y = {var_y}");
+        let corr = cov_xy / (var_x * var_y).sqrt();
+        assert!((corr - 0.6).abs() < 0.08, "corr = {corr}");
+
+        // Healthy diagnostics on a well-sampled unimodal target.
+        let r_hat = chain.gelman_rubin(500);
+        assert!(r_hat.iter().all(|&r| r < 1.05), "R-hat = {r_hat:?}");
+        let ess = chain.effective_sample_size(500);
+        assert!(ess.iter().all(|&e| e > 500.0), "ESS = {ess:?}");
+        assert!(chain.acceptance_rate > 0.1 && chain.acceptance_rate < 0.9);
+    }
+
+    #[test]
+    fn test_rosenbrock_smoke() {
+        // Rosenbrock density (log pi = -(100 (y - x^2)^2 + (1 - x)^2) / 20):
+        // banana-shaped, the standard hard smoke target.
+        let logp =
+            |x: &[f64]| -(100.0 * (x[1] - x[0] * x[0]).powi(2) + (1.0 - x[0]).powi(2)) / 20.0;
+        let sampler = EnsembleSampler::new(32);
+        let init = init_walkers_in_box(32, &[(-2.0, 2.0), (-1.0, 3.0)], 3);
+        let chain = sampler.run(logp, &init, 6000, 5);
+
+        let flat = chain.flat_samples(2000, 5);
+        assert!(!flat.is_empty());
+        // The mode is at (1, 1); the sampler must populate its vicinity.
+        let near_mode = flat
+            .iter()
+            .filter(|s| (s[0] - 1.0).abs() < 1.0 && (s[1] - 1.0).abs() < 2.0)
+            .count();
+        assert!(
+            near_mode as f64 > 0.2 * flat.len() as f64,
+            "only {near_mode}/{} samples near the Rosenbrock mode",
+            flat.len()
+        );
+        // Loose smoke bound: the banana's long tails give the stretch move
+        // a large autocorrelation time (measured R-hat = [1.37, 1.29] at
+        // 6000 steps / burn 2000, seed 5; 1.59 at 2000 steps — this is a
+        // machinery check, not a convergence claim).
+        let r_hat = chain.gelman_rubin(2000);
+        assert!(
+            r_hat.iter().all(|&r| r.is_finite() && r < 1.5),
+            "R-hat = {r_hat:?}"
+        );
+    }
+
+    #[test]
+    fn test_sampler_is_deterministic_for_fixed_seed() {
+        let sampler = EnsembleSampler::new(8);
+        let init = init_walkers_in_box(8, &[(0.0, 1.0), (0.0, 1.0)], 1);
+        let c1 = sampler.run(gaussian_2d_logp, &init, 50, 2);
+        let c2 = sampler.run(gaussian_2d_logp, &init, 50, 2);
+        assert_eq!(c1.samples, c2.samples);
+        let c3 = sampler.run(gaussian_2d_logp, &init, 50, 3);
+        assert_ne!(c1.samples, c3.samples);
+    }
+
+    #[test]
+    fn test_walkers_never_enter_forbidden_region() {
+        // Uniform box prior: -inf outside. No accepted sample may be outside.
+        let logp = |x: &[f64]| {
+            if x.iter().all(|&v| (0.0..1.0).contains(&v)) {
+                0.0
+            } else {
+                f64::NEG_INFINITY
+            }
+        };
+        let sampler = EnsembleSampler::new(16);
+        let init = init_walkers_in_box(16, &[(0.2, 0.8), (0.2, 0.8)], 9);
+        let chain = sampler.run(logp, &init, 500, 13);
+        for step in &chain.samples {
+            for walker in step {
+                assert!(walker.iter().all(|&v| (0.0..1.0).contains(&v)));
+            }
+        }
+    }
+
+    #[test]
+    fn test_quantile() {
+        let mut v: Vec<f64> = (0..101).map(|k| k as f64).collect();
+        assert_eq!(quantile(&mut v, 0.5), 50.0);
+        assert_eq!(quantile(&mut v, 0.0), 0.0);
+        assert_eq!(quantile(&mut v, 1.0), 100.0);
+        assert!((quantile(&mut v, 0.975) - 97.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_paper_settings_pinned() {
+        // Brown & Batygin (2021) Section 5: 100 chains, 20,890 samples,
+        // burn-in 260, thin 42 -> 49,100 uncorrelated samples.
+        let s = PaperMcmcSettings::paper();
+        assert_eq!(s.n_walkers, 100);
+        let kept_per_walker = (s.n_steps - s.burn_in) / s.thin;
+        let total = kept_per_walker * s.n_walkers;
+        assert!(
+            (total as i64 - 49_100).abs() < 100,
+            "paper sample count: {total}"
+        );
+    }
+}

--- a/crates/p9-2021-orbit/src/pipeline.rs
+++ b/crates/p9-2021-orbit/src/pipeline.rs
@@ -1,0 +1,332 @@
+//! End-to-end inference pipeline: simulation grid (Model 1) -> conditional
+//! KDE likelihood (Model 2) -> GP emulator (Model 3) -> ensemble MCMC
+//! (Model 4), wired as in Brown & Batygin (2021).
+//!
+//! Prior: uniform over the grid extent (m9, a9, e9, i9) — the paper's
+//! primary prior. The paper's alternative *cluster-scattering* prior (a
+//! Frechet distribution over m9/a9 from a planet-scattering population
+//! synthesis, their Section 5) is **not implemented**: it requires the
+//! scattering-simulation suite of Batygin & Brown (2021b), which is out of
+//! scope here.
+//!
+//! Fidelity: at `GridScale::Smoke`/`Reduced` the pipeline validates the
+//! *machinery* (deterministic grid -> finite likelihood surface -> healthy
+//! GP cross-validation -> converged MCMC). It does NOT reproduce the
+//! published posterior (m9 = 6.2, a9 = 380 AU, ...): that requires the
+//! `Paper`-scale grid (121 points x 16,800 particles x 4 Gyr, estimated
+//! ~3,000 CPU-days — see REPRODUCTION_NOTES.md). The `#[ignore]`d
+//! paper-scale entry point is `run_pipeline(PipelineConfig::paper())`.
+
+use serde::{Deserialize, Serialize};
+
+use p9_core::data::etno::BROWN_2017_SAMPLE;
+
+use crate::gp::{GpFitSummary, Matern32Gp};
+use crate::kde::{profiled_log_likelihood, BinSpec, GridPointKde};
+use crate::mcmc::{init_walkers_in_box, quantile, EnsembleSampler, PaperMcmcSettings};
+use crate::sim_grid::{
+    run_grid, GridPoint, GridScale, SimGridConfig, A9_RANGE, E9_RANGE, I9_RANGE_DEG, M9_RANGE,
+};
+
+/// Pipeline configuration. The grid scale drives the MCMC budget.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineConfig {
+    pub grid: SimGridConfig,
+    /// Orientation-profiling scan resolution (Model 2; n x n over
+    /// (varpi9, Omega9)).
+    pub kde_scan: usize,
+    pub n_walkers: usize,
+    pub n_steps: usize,
+    pub burn_in: usize,
+    pub thin: usize,
+    /// Base seed for the MCMC stage (grid seeding lives in `grid.seed`).
+    pub mcmc_seed: u64,
+}
+
+impl PipelineConfig {
+    /// Default-test budget: 4-point grid, 12 x 12 orientation scan,
+    /// 16 walkers x 400 steps.
+    pub fn smoke() -> Self {
+        Self {
+            grid: SimGridConfig::smoke(),
+            kde_scan: 12,
+            n_walkers: 16,
+            n_steps: 400,
+            burn_in: 100,
+            thin: 5,
+            mcmc_seed: 777,
+        }
+    }
+
+    /// Reduced scale (release mode, behind `#[ignore]`): 12-point grid,
+    /// 24 x 24 scan, 32 walkers x 2000 steps.
+    pub fn reduced() -> Self {
+        Self {
+            grid: SimGridConfig::reduced(),
+            kde_scan: 24,
+            n_walkers: 32,
+            n_steps: 2000,
+            burn_in: 500,
+            thin: 10,
+            mcmc_seed: 777,
+        }
+    }
+
+    /// Paper-scale entry point (121-point surrogate grid, 4 Gyr, the
+    /// paper's MCMC settings). Estimated CPU-days; `#[ignore]`d only.
+    pub fn paper() -> Self {
+        let mcmc = PaperMcmcSettings::paper();
+        Self {
+            grid: SimGridConfig::paper(),
+            kde_scan: 24,
+            n_walkers: mcmc.n_walkers,
+            n_steps: mcmc.n_steps,
+            burn_in: mcmc.burn_in,
+            thin: mcmc.thin,
+            mcmc_seed: 777,
+        }
+    }
+
+    /// The uniform-prior box over (m9, a9 [AU], e9, i9 [deg]): the grid
+    /// extent, matching the paper's uniform prior over its grid.
+    pub fn prior_bounds() -> [(f64, f64); 4] {
+        [M9_RANGE, A9_RANGE, E9_RANGE, I9_RANGE_DEG]
+    }
+}
+
+/// Posterior quantiles for one parameter.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ParamQuantiles {
+    pub q025: f64,
+    pub median: f64,
+    pub q975: f64,
+}
+
+/// Full pipeline output.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PipelineResult {
+    pub scale: GridScale,
+    pub grid_seed: u64,
+    pub mcmc_seed: u64,
+    pub grid_points: Vec<GridPoint>,
+    /// Profiled ETNO log-likelihood per grid point (the GP targets).
+    pub log_likelihoods: Vec<f64>,
+    pub gp: GpFitSummary,
+    /// Flattened post-burn, thinned posterior samples of
+    /// (m9, a9 [AU], e9, i9 [deg]).
+    pub samples: Vec<Vec<f64>>,
+    pub acceptance_rate: f64,
+    pub r_hat: Vec<f64>,
+    pub ess: Vec<f64>,
+    /// Quantiles for (m9, a9, e9, i9).
+    pub quantiles: [ParamQuantiles; 4],
+}
+
+impl PipelineResult {
+    /// Fraction of posterior samples inside the prior box (must be 1.0 for
+    /// a healthy run: the prior is -inf outside).
+    pub fn fraction_in_prior(&self) -> f64 {
+        let bounds = PipelineConfig::prior_bounds();
+        let inside = self
+            .samples
+            .iter()
+            .filter(|s| {
+                s.iter()
+                    .zip(bounds.iter())
+                    .all(|(&v, &(lo, hi))| v >= lo && v <= hi)
+            })
+            .count();
+        inside as f64 / self.samples.len().max(1) as f64
+    }
+}
+
+/// Run the full grid -> KDE -> GP -> MCMC pipeline.
+pub fn run_pipeline(config: &PipelineConfig) -> PipelineResult {
+    // Model 1: the simulation grid.
+    let grid_results = run_grid(&config.grid);
+    let grid_points: Vec<GridPoint> = grid_results.iter().map(|r| r.point).collect();
+
+    // Model 2: profiled ETNO log-likelihood per grid point.
+    let log_likelihoods: Vec<f64> = grid_results
+        .iter()
+        .map(|r| {
+            let kde = GridPointKde::from_samples(&r.samples, BinSpec::default());
+            let (ll, _, _) = profiled_log_likelihood(&kde, &BROWN_2017_SAMPLE, config.kde_scan);
+            ll
+        })
+        .collect();
+
+    // Model 3: GP emulator over normalized grid coordinates.
+    let inputs: Vec<[f64; 4]> = grid_points.iter().map(|p| p.normalized()).collect();
+    let gp = Matern32Gp::fit(&inputs, &log_likelihoods);
+    let gp_summary = gp.summary();
+
+    // Model 4: ensemble MCMC over the uniform prior box x GP likelihood.
+    let bounds = PipelineConfig::prior_bounds();
+    let log_post = |theta: &[f64]| -> f64 {
+        let inside = theta
+            .iter()
+            .zip(bounds.iter())
+            .all(|(&v, &(lo, hi))| v >= lo && v <= hi);
+        if !inside {
+            return f64::NEG_INFINITY;
+        }
+        let x = [
+            (theta[0] - M9_RANGE.0) / (M9_RANGE.1 - M9_RANGE.0),
+            (theta[1] - A9_RANGE.0) / (A9_RANGE.1 - A9_RANGE.0),
+            (theta[2] - E9_RANGE.0) / (E9_RANGE.1 - E9_RANGE.0),
+            (theta[3] - I9_RANGE_DEG.0) / (I9_RANGE_DEG.1 - I9_RANGE_DEG.0),
+        ];
+        gp.predict(&x).0
+    };
+
+    let sampler = EnsembleSampler::new(config.n_walkers);
+    let init = init_walkers_in_box(config.n_walkers, &bounds, config.mcmc_seed);
+    let chain = sampler.run(log_post, &init, config.n_steps, config.mcmc_seed + 1);
+
+    let r_hat = chain.gelman_rubin(config.burn_in);
+    let ess = chain.effective_sample_size(config.burn_in);
+    let samples = chain.flat_samples(config.burn_in, config.thin);
+
+    let quantiles = std::array::from_fn(|dim| {
+        let mut values: Vec<f64> = samples.iter().map(|s| s[dim]).collect();
+        ParamQuantiles {
+            q025: quantile(&mut values, 0.025),
+            median: quantile(&mut values, 0.5),
+            q975: quantile(&mut values, 0.975),
+        }
+    });
+
+    PipelineResult {
+        scale: config.grid.scale,
+        grid_seed: config.grid.seed,
+        mcmc_seed: config.mcmc_seed,
+        grid_points,
+        log_likelihoods,
+        gp: gp_summary,
+        samples,
+        acceptance_rate: chain.acceptance_rate,
+        r_hat,
+        ess,
+        quantiles,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_machinery_health(result: &PipelineResult, r_hat_max: f64, ess_min: f64) {
+        assert!(result.log_likelihoods.iter().all(|ll| ll.is_finite()));
+        assert!(result.gp.loo_relative_error.is_finite());
+        assert!(!result.samples.is_empty());
+        assert!(
+            (result.fraction_in_prior() - 1.0).abs() < 1e-12,
+            "posterior mass escaped the prior box"
+        );
+        assert!(
+            result.acceptance_rate > 0.05 && result.acceptance_rate < 0.95,
+            "acceptance = {}",
+            result.acceptance_rate
+        );
+        for (dim, &r) in result.r_hat.iter().enumerate() {
+            assert!(r < r_hat_max, "R-hat[{dim}] = {r}");
+        }
+        for (dim, &e) in result.ess.iter().enumerate() {
+            assert!(e > ess_min, "ESS[{dim}] = {e}");
+        }
+        for q in &result.quantiles {
+            assert!(q.q025 <= q.median && q.median <= q.q975);
+        }
+    }
+
+    /// Default-test smoke run of the full pipeline. Validates machinery
+    /// only — at this scale the likelihood surface is noise (see module
+    /// docs); no posterior values are asserted.
+    #[test]
+    fn test_pipeline_smoke() {
+        let result = run_pipeline(&PipelineConfig::smoke());
+        assert_eq!(result.grid_points.len(), 4);
+        assert_eq!(result.log_likelihoods.len(), 4);
+        // Short chains on a flat-ish surface: loose health bounds.
+        assert_machinery_health(&result, 1.5, 50.0);
+    }
+
+    #[test]
+    fn test_pipeline_smoke_is_deterministic() {
+        let r1 = run_pipeline(&PipelineConfig::smoke());
+        let r2 = run_pipeline(&PipelineConfig::smoke());
+        assert_eq!(r1.log_likelihoods, r2.log_likelihoods);
+        assert_eq!(r1.samples, r2.samples);
+    }
+
+    /// Reduced-scale end-to-end run (release mode):
+    /// `cargo test --release -p p9-2021-orbit -- --ignored`.
+    ///
+    /// Asserts machinery health (R-hat < 1.2, ESS, posterior in prior, GP
+    /// LOO sane) and the loose sanity check that the published medians lie
+    /// inside the Reduced posterior's 95% box. It does NOT assert the
+    /// published medians as point estimates — full-fidelity reproduction
+    /// requires the Paper-scale grid (see REPRODUCTION_NOTES.md).
+    #[test]
+    #[ignore]
+    fn test_pipeline_reduced_end_to_end() {
+        let result = run_pipeline(&PipelineConfig::reduced());
+
+        // Run record (REPRODUCTION_NOTES.md documents the measured values):
+        eprintln!(
+            "reduced pipeline: grid_seed={} mcmc_seed={} acceptance={:.3}",
+            result.grid_seed, result.mcmc_seed, result.acceptance_rate
+        );
+        eprintln!(
+            "  log-likelihoods = {:?}\n  GP: ell={} noise={} LOO_rel={:.4}\n  R-hat={:?}\n  ESS={:?}\n  quantiles={:?}",
+            result.log_likelihoods,
+            result.gp.length_scale,
+            result.gp.noise_var,
+            result.gp.loo_relative_error,
+            result.r_hat,
+            result.ess,
+            result.quantiles
+        );
+
+        assert_eq!(result.grid_points.len(), 12);
+        assert_machinery_health(&result, 1.2, 200.0);
+        // Reduced 12-point grid: measured GP LOO relative error 0.239
+        // (seeds 2021/777, run 2026-06-12; ~68 s wall / 12.9 CPU-min on 64
+        // cores). The paper's < 5% applies to its 121-point grid — see
+        // REPRODUCTION_NOTES.md. Pinned with headroom for cross-platform
+        // FP jitter.
+        assert!(
+            result.gp.loo_relative_error < 0.35,
+            "GP LOO relative error = {}",
+            result.gp.loo_relative_error
+        );
+
+        // Loose sanity: published medians (Brown & Batygin 2021) inside the
+        // Reduced posterior's 95% intervals. At reduced scale the posterior
+        // is broad, so this is a weak containment check, not a reproduction.
+        let published = [6.2, 380.0, 0.21, 16.0]; // m9, a9, e9 (1 - 300/380), i9
+        for (dim, (&pub_val, q)) in published.iter().zip(result.quantiles.iter()).enumerate() {
+            assert!(
+                pub_val >= q.q025 && pub_val <= q.q975,
+                "published value {pub_val} outside 95% interval [{}, {}] for dim {dim}",
+                q.q025,
+                q.q975
+            );
+        }
+    }
+
+    /// Paper-scale entry point: 121-point grid x 16,800 particles x 4 Gyr
+    /// with the paper's MCMC settings. Estimated CPU-days — see
+    /// REPRODUCTION_NOTES.md. Expected (not yet verified here): posterior
+    /// medians within the published m9 = 6.2 (+2.2/-1.3), a9 = 380
+    /// (+140/-80) AU, e9 = 0.3 (+0.1/-0.1), i9 = 16 +/- 5 deg intervals.
+    #[test]
+    #[ignore]
+    fn test_pipeline_paper_scale() {
+        let result = run_pipeline(&PipelineConfig::paper());
+        assert_eq!(result.grid_points.len(), 121);
+        assert_machinery_health(&result, 1.1, 1000.0);
+        assert!(result.gp.loo_relative_error < 0.05);
+    }
+}

--- a/crates/p9-2021-orbit/src/posterior.rs
+++ b/crates/p9-2021-orbit/src/posterior.rs
@@ -1,12 +1,21 @@
-//! Posterior-summary *emulator* for Brown & Batygin (2021).
+//! Summary of the *published* posterior of Brown & Batygin (2021).
 //!
-//! This module is not an MCMC reproduction: the paper's likelihood (11 ETNO
-//! orbits against N-body reference populations) is not re-evaluated here.
-//! Instead the published posterior *summaries* (median with asymmetric
-//! 1-sigma intervals) are emulated with two-piece (split-normal)
-//! distributions, plus a documented correlation assumption linking a and q
-//! (and hence e) — the published corner plot shows a strong positive a–q
-//! degeneracy which independent marginal sampling would erase.
+//! This module does not re-run the inference: the published posterior
+//! summaries (median with asymmetric 1-sigma intervals) are emulated with
+//! two-piece (split-normal) distributions, plus a documented correlation
+//! assumption linking a and q (and hence e) — the published corner plot
+//! shows a strong positive a–q degeneracy which independent marginal
+//! sampling would erase. It is the stable representation of the paper's
+//! *result*, consumed by the downstream survey crates via
+//! `reference_population`.
+//!
+//! The from-scratch path (the paper's models 1-4: simulation grid -> KDE
+//! likelihood -> GP emulator -> ensemble MCMC) lives in `sim_grid`/`kde`/
+//! `gp`/`mcmc`, wired in `pipeline`. At the default reduced scale that
+//! pipeline validates machinery, not the published numbers (the
+//! `#[ignore]`d reduced end-to-end test checks the published medians fall
+//! inside its loose 95% region; full fidelity needs the paper-scale grid —
+//! see REPRODUCTION_NOTES.md).
 
 use rand::Rng;
 use rand_distr::{Distribution, Normal};

--- a/crates/p9-2021-orbit/src/sim_grid.rs
+++ b/crates/p9-2021-orbit/src/sim_grid.rs
@@ -1,0 +1,511 @@
+//! Model 1 of Brown & Batygin (2021), Section 2: the N-body simulation grid.
+//!
+//! The paper integrates scattered-disk test particles (a in 150-500 AU,
+//! q in 30-50 AU, i in 0-25 deg) for 4 Gyr under the four giant planets plus
+//! a Planet Nine drawn from a manually-constructed 121-point grid over
+//! (m9, a9, e9, i9), with m9 in {3, 4, 5, 6, 7, 10, 12, 20} Earth masses.
+//! Particles are removed at r < 4.5 AU or r > 10,000 AU; element snapshots
+//! after the first Gyr are pooled as samples of the quasi-steady-state
+//! distribution.
+//!
+//! Documented deviations from the paper (scale reductions, repo convention):
+//!
+//! - **Grid geometry.** The paper's exact 121-point manual grid is not
+//!   published. We use a *regular* grid spanning the same extent
+//!   (a9 in 300-800 AU, e9 in 0.1-0.5, i9 in 5-25 deg, the paper's 8 masses),
+//!   sized by the [`GridScale`] knob: `Paper` builds a 121-point surrogate
+//!   (8 masses x 15 (a9, e9, i9) combinations + 1 central point), `Reduced`
+//!   and `Smoke` are coarse sub-grids that run in test time.
+//! - **Perturber treatment.** The paper integrates all four giant planets
+//!   directly with a 300 d timestep. We use the workspace-standard reduced
+//!   configuration: Jupiter+Saturn+Uranus absorbed into the orbit-averaged
+//!   J2 field with monopole boost (`ExtraForce::J2Jsu`), Neptune and Planet
+//!   Nine direct, dt = 3000 d (P_Neptune/20, the WHM resolution criterion
+//!   for the innermost direct body). This is valid for q >= 30 AU, which the
+//!   initial conditions guarantee.
+//! - **Inner removal boundary.** The paper removes particles at r < 4.5 AU
+//!   after close encounters with the directly-integrated gas giants. With
+//!   JSU absorbed into the averaged J2 field there are no close encounters
+//!   to scatter particles that deep; the r < 4.5 AU boundary is kept (it is
+//!   the configured `removal_inner_au`) but in practice particles leave
+//!   through perihelion detachment or the r > 10,000 AU boundary. Particles
+//!   that random-walk inside q ~ 30 AU are outside the J2 field's validity
+//!   for a few orbits before removal — a documented cost of the averaged
+//!   treatment.
+//! - **Duration / population.** `Reduced` integrates 12 grid points x 200
+//!   particles x 10 Myr (machinery validation; the secular clustering that
+//!   the inference keys on is only partially developed). `Paper` is the
+//!   121 x 16,800 x 4 Gyr configuration, run only behind `#[ignore]`
+//!   (estimated ~3,000 CPU-days, see REPRODUCTION_NOTES.md).
+
+use rand::{Rng, SeedableRng};
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use p9_core::constants::{DEG2RAD, GM_SUN, GYR_DAYS, TWO_PI, YEAR_DAYS};
+use p9_core::forces::ExtraForce;
+use p9_core::initial_conditions::planets;
+use p9_core::integrator::whm::WhmIntegrator;
+use p9_core::types::{
+    cartesian_to_elements, OrbitalElements, P9Params, SimConfig as CoreSimConfig, StateVector,
+};
+
+/// The paper's Planet Nine mass grid (Earth masses), Brown & Batygin (2021)
+/// Section 2.
+pub const P9_MASSES_PAPER: [f64; 8] = [3.0, 4.0, 5.0, 6.0, 7.0, 10.0, 12.0, 20.0];
+
+/// Extent of the (m9, a9, e9, i9) grid. Also used as the uniform-prior box
+/// for the MCMC stage (Model 4).
+pub const M9_RANGE: (f64, f64) = (3.0, 20.0);
+/// Semi-major axis extent of the grid (AU).
+pub const A9_RANGE: (f64, f64) = (300.0, 800.0);
+/// Eccentricity extent of the grid.
+pub const E9_RANGE: (f64, f64) = (0.1, 0.5);
+/// Inclination extent of the grid (degrees).
+pub const I9_RANGE_DEG: (f64, f64) = (5.0, 25.0);
+
+/// Grid size / fidelity knob.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GridScale {
+    /// 4 points x 30 particles x 0.1 Myr — runs in default (debug) test time.
+    /// Exercises the full machinery; the dynamics has not had time to do
+    /// anything, so the resulting likelihood surface is noise.
+    Smoke,
+    /// 12 points x 200 particles x 10 Myr — measured ~67 s wall / 12.9
+    /// CPU-min (release, 64 cores), behind `#[ignore]`. Secular clustering
+    /// is only partially developed.
+    Reduced,
+    /// 121-point surrogate of the paper grid x 16,800 particles x 4 Gyr.
+    /// Estimated ~3,000 CPU-days at the measured reduced-scale throughput
+    /// (~265 ns per particle-step); `#[ignore]`d entry point only.
+    Paper,
+}
+
+/// One Planet Nine parameter point of the simulation grid.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct GridPoint {
+    /// Planet Nine mass (Earth masses)
+    pub m9: f64,
+    /// Planet Nine semi-major axis (AU)
+    pub a9: f64,
+    /// Planet Nine eccentricity
+    pub e9: f64,
+    /// Planet Nine inclination (degrees)
+    pub i9_deg: f64,
+}
+
+impl GridPoint {
+    /// Normalized coordinates in the grid box (each dimension mapped to
+    /// [0, 1] over the grid extent). This is the GP input space (Model 3).
+    pub fn normalized(&self) -> [f64; 4] {
+        [
+            (self.m9 - M9_RANGE.0) / (M9_RANGE.1 - M9_RANGE.0),
+            (self.a9 - A9_RANGE.0) / (A9_RANGE.1 - A9_RANGE.0),
+            (self.e9 - E9_RANGE.0) / (E9_RANGE.1 - E9_RANGE.0),
+            (self.i9_deg - I9_RANGE_DEG.0) / (I9_RANGE_DEG.1 - I9_RANGE_DEG.0),
+        ]
+    }
+
+    /// Planet Nine parameters with the orientation angles fixed at zero.
+    ///
+    /// The recorded particle angles are *relative* to Planet Nine
+    /// (delta_varpi, delta_Omega), and the initial disk is uniform in its
+    /// own angles, so the absolute orientation of Planet Nine is a gauge
+    /// choice; omega = Omega = M = 0 is used for every grid point.
+    pub fn p9_params(&self) -> P9Params {
+        P9Params {
+            mass_earth: self.m9,
+            a: self.a9,
+            e: self.e9,
+            i: self.i9_deg * DEG2RAD,
+            omega: 0.0,
+            omega_big: 0.0,
+            mean_anomaly: 0.0,
+        }
+    }
+}
+
+/// Configuration for the simulation grid (Model 1).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SimGridConfig {
+    pub scale: GridScale,
+    /// Base RNG seed; grid point k uses seed `seed + k`.
+    pub seed: u64,
+    /// Test particles per grid point.
+    pub n_particles: usize,
+    /// Integration time (Gyr). Paper: 4.0.
+    pub t_gyr: f64,
+    /// Timestep (days); 3000 d = P_Neptune/20 with Neptune innermost direct.
+    pub dt_days: f64,
+    /// Fraction of the run discarded before snapshots are pooled.
+    /// Paper: 1 Gyr of 4 Gyr = 0.25.
+    pub burn_fraction: f64,
+    /// Interval between pooled element snapshots (days).
+    pub snapshot_interval_days: f64,
+    /// Initial disk: semi-major axis range (AU). Paper: 150-500.
+    pub disk_a_range: (f64, f64),
+    /// Initial disk: perihelion range (AU). Paper: 30-50.
+    pub disk_q_range: (f64, f64),
+    /// Initial disk: inclination range (degrees), uniform. Paper: 0-25.
+    pub disk_i_max_deg: f64,
+    /// Removal boundaries (AU). Paper: 4.5 / 10,000.
+    pub r_remove_inner: f64,
+    pub r_remove_outer: f64,
+}
+
+impl SimGridConfig {
+    fn base(scale: GridScale, n_particles: usize, t_gyr: f64, snapshot_myr: f64) -> Self {
+        Self {
+            scale,
+            seed: 2021,
+            n_particles,
+            t_gyr,
+            dt_days: 3000.0,
+            burn_fraction: 0.25,
+            snapshot_interval_days: snapshot_myr * 1e6 * YEAR_DAYS,
+            disk_a_range: (150.0, 500.0),
+            disk_q_range: (30.0, 50.0),
+            disk_i_max_deg: 25.0,
+            r_remove_inner: 4.5,
+            r_remove_outer: 10_000.0,
+        }
+    }
+
+    /// Smoke scale: 4 points x 30 particles x 0.1 Myr. Default-test budget.
+    pub fn smoke() -> Self {
+        Self::base(GridScale::Smoke, 30, 1e-4, 0.02)
+    }
+
+    /// Reduced scale (default): 12 points x 200 particles x 10 Myr.
+    pub fn reduced() -> Self {
+        Self::base(GridScale::Reduced, 200, 0.01, 1.0)
+    }
+
+    /// Paper-scale surrogate: 121 points x 16,800 particles x 4 Gyr.
+    /// `#[ignore]`d entry point only — estimated CPU-days.
+    pub fn paper() -> Self {
+        Self::base(GridScale::Paper, 16_800, 4.0, 10.0)
+    }
+
+    /// The grid points for this scale (deterministic, no RNG involved).
+    ///
+    /// - `Smoke`: m9 {5, 10} x a9 {400, 700} at (e9, i9) = (0.3, 15).
+    /// - `Reduced`: m9 {5, 10} x a9 {350, 550, 750} x (e9, i9) in
+    ///   {(0.2, 10), (0.4, 20)} — e9 and i9 co-vary so all four GP input
+    ///   dimensions have spread at 12 points (documented confounding).
+    /// - `Paper`: the 8 paper masses x 15 (a9, e9, i9) combinations
+    ///   (a9 {300, 425, 550, 675, 800} x e9 {0.1, 0.3, 0.5}, i9 cycling
+    ///   {5, 15, 25} over combinations) + 1 central point
+    ///   (6 M_E, 550 AU, 0.3, 15 deg) = 121 points, matching the paper's
+    ///   count over the same extent. The paper's actual manual grid is not
+    ///   published.
+    pub fn grid_points(&self) -> Vec<GridPoint> {
+        match self.scale {
+            GridScale::Smoke => {
+                let mut pts = Vec::new();
+                for &m9 in &[5.0, 10.0] {
+                    for &a9 in &[400.0, 700.0] {
+                        pts.push(GridPoint {
+                            m9,
+                            a9,
+                            e9: 0.3,
+                            i9_deg: 15.0,
+                        });
+                    }
+                }
+                pts
+            }
+            GridScale::Reduced => {
+                let mut pts = Vec::new();
+                for &m9 in &[5.0, 10.0] {
+                    for &a9 in &[350.0, 550.0, 750.0] {
+                        for &(e9, i9_deg) in &[(0.2, 10.0), (0.4, 20.0)] {
+                            pts.push(GridPoint { m9, a9, e9, i9_deg });
+                        }
+                    }
+                }
+                pts
+            }
+            GridScale::Paper => {
+                let a9_values = [300.0, 425.0, 550.0, 675.0, 800.0];
+                let e9_values = [0.1, 0.3, 0.5];
+                let i9_values = [5.0, 15.0, 25.0];
+                let mut pts = Vec::new();
+                for &m9 in P9_MASSES_PAPER.iter() {
+                    let mut combo = 0usize;
+                    for &a9 in &a9_values {
+                        for &e9 in &e9_values {
+                            pts.push(GridPoint {
+                                m9,
+                                a9,
+                                e9,
+                                i9_deg: i9_values[combo % i9_values.len()],
+                            });
+                            combo += 1;
+                        }
+                    }
+                }
+                // Central point to reach the paper's 121-point count.
+                pts.push(GridPoint {
+                    m9: 6.0,
+                    a9: 550.0,
+                    e9: 0.3,
+                    i9_deg: 15.0,
+                });
+                pts
+            }
+        }
+    }
+}
+
+/// One pooled element sample of a surviving test particle, relative to
+/// Planet Nine. Angles in radians; `delta_varpi`/`delta_omega_big` wrapped
+/// to [0, 2 pi).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ElementSample {
+    pub a: f64,
+    pub e: f64,
+    pub i: f64,
+    /// varpi_particle - varpi_P9, wrapped to [0, 2 pi)
+    pub delta_varpi: f64,
+    /// Omega_particle - Omega_P9, wrapped to [0, 2 pi)
+    pub delta_omega_big: f64,
+}
+
+/// Result of integrating one grid point.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GridPointResult {
+    pub point: GridPoint,
+    /// RNG seed used for this point's initial conditions (recorded output).
+    pub seed: u64,
+    pub n_initial: usize,
+    /// Particles still active at the end of the run.
+    pub n_surviving: usize,
+    /// Pooled post-burn snapshot samples of surviving particles.
+    pub samples: Vec<ElementSample>,
+}
+
+/// Generate the paper's initial scattered disk: a ~ U(150, 500) AU,
+/// q ~ U(30, 50) AU (resampled when q > a, which cannot occur for these
+/// ranges), i ~ U(0, 25 deg), angles uniform.
+pub fn generate_disk<R: Rng>(config: &SimGridConfig, rng: &mut R) -> Vec<StateVector> {
+    let mut particles = Vec::with_capacity(config.n_particles);
+    while particles.len() < config.n_particles {
+        let a = rng.gen_range(config.disk_a_range.0..config.disk_a_range.1);
+        let q = rng.gen_range(config.disk_q_range.0..config.disk_q_range.1);
+        if q >= a {
+            continue;
+        }
+        let elements = OrbitalElements {
+            a,
+            e: 1.0 - q / a,
+            i: rng.gen_range(0.0..config.disk_i_max_deg) * DEG2RAD,
+            omega: rng.gen_range(0.0..TWO_PI),
+            omega_big: rng.gen_range(0.0..TWO_PI),
+            mean_anomaly: rng.gen_range(0.0..TWO_PI),
+        };
+        particles.push(elements.to_state_vector(GM_SUN));
+    }
+    particles
+}
+
+fn wrap_two_pi(angle: f64) -> f64 {
+    angle.rem_euclid(TWO_PI)
+}
+
+/// Integrate one grid point and pool post-burn element snapshots.
+///
+/// Physics: WHM (democratic heliocentric), Neptune + Planet Nine direct,
+/// Jupiter+Saturn+Uranus as the orbit-averaged J2 field (`ExtraForce::J2Jsu`),
+/// removal at the configured radii (see module docs for the deviations from
+/// the paper's all-four-direct treatment).
+pub fn run_grid_point(config: &SimGridConfig, point: &GridPoint, seed: u64) -> GridPointResult {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+
+    let mut particles = generate_disk(config, &mut rng);
+    let n = particles.len();
+    let mut active = vec![true; n];
+
+    let mut bodies = vec![planets::neptune_j2000(), point.p9_params().to_body()];
+
+    let core_config = CoreSimConfig {
+        dt: config.dt_days,
+        t_start: 0.0,
+        t_end: config.t_gyr * GYR_DAYS,
+        removal_inner_au: config.r_remove_inner,
+        removal_outer_au: config.r_remove_outer,
+        snapshot_interval_days: config.snapshot_interval_days,
+        hybrid_changeover_hill: 3.0,
+        bs_epsilon: 1e-11,
+    };
+
+    // Sequential per-step kicks: the grid is already parallel over points
+    // (`run_grid`), and at a few hundred particles per point the per-step
+    // rayon fan-out costs more than the kick itself.
+    let mut integrator = WhmIntegrator::with_extra_forces(vec![ExtraForce::J2Jsu]);
+    integrator.parallel = false;
+
+    let t_total = config.t_gyr * GYR_DAYS;
+    let n_steps = (t_total / config.dt_days).ceil() as usize;
+    let snap_every = (config.snapshot_interval_days / config.dt_days)
+        .ceil()
+        .max(1.0) as usize;
+    let burn_steps = (config.burn_fraction * n_steps as f64).floor() as usize;
+
+    let mut samples = Vec::new();
+
+    for step in 1..=n_steps {
+        integrator.step(
+            &mut bodies,
+            &mut particles,
+            &mut active,
+            config.dt_days,
+            &core_config,
+        );
+
+        if step > burn_steps && (step % snap_every == 0 || step == n_steps) {
+            // P9 elements at this snapshot (its varpi/Omega precess under
+            // the J2 field and Neptune).
+            let p9_elem = cartesian_to_elements(&bodies[1].state, GM_SUN);
+            let p9_varpi = wrap_two_pi(p9_elem.omega + p9_elem.omega_big);
+            for (idx, state) in particles.iter().enumerate() {
+                if !active[idx] {
+                    continue;
+                }
+                let elem = cartesian_to_elements(state, GM_SUN);
+                if elem.a <= 0.0 || elem.e >= 1.0 {
+                    continue; // unbound at this instant; not a disk sample
+                }
+                samples.push(ElementSample {
+                    a: elem.a,
+                    e: elem.e,
+                    i: elem.i,
+                    delta_varpi: wrap_two_pi(elem.omega + elem.omega_big - p9_varpi),
+                    delta_omega_big: wrap_two_pi(elem.omega_big - p9_elem.omega_big),
+                });
+            }
+        }
+    }
+
+    let n_surviving = active.iter().filter(|&&a| a).count();
+
+    GridPointResult {
+        point: *point,
+        seed,
+        n_initial: n,
+        n_surviving,
+        samples,
+    }
+}
+
+/// Run the whole grid (parallel over grid points; point k seeded with
+/// `config.seed + k`, so results are deterministic and independent of the
+/// scheduling order).
+pub fn run_grid(config: &SimGridConfig) -> Vec<GridPointResult> {
+    let points = config.grid_points();
+    points
+        .par_iter()
+        .enumerate()
+        .map(|(k, point)| run_grid_point(config, point, config.seed + k as u64))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_grid_point_counts() {
+        assert_eq!(SimGridConfig::smoke().grid_points().len(), 4);
+        assert_eq!(SimGridConfig::reduced().grid_points().len(), 12);
+        // The paper-scale surrogate matches the paper's 121-point count.
+        assert_eq!(SimGridConfig::paper().grid_points().len(), 121);
+    }
+
+    #[test]
+    fn test_paper_grid_covers_extent_and_masses() {
+        let pts = SimGridConfig::paper().grid_points();
+        for &m in P9_MASSES_PAPER.iter() {
+            assert!(pts.iter().any(|p| p.m9 == m), "mass {m} missing");
+        }
+        for p in &pts {
+            assert!(p.a9 >= A9_RANGE.0 && p.a9 <= A9_RANGE.1);
+            assert!(p.e9 >= E9_RANGE.0 && p.e9 <= E9_RANGE.1);
+            assert!(p.i9_deg >= I9_RANGE_DEG.0 && p.i9_deg <= I9_RANGE_DEG.1);
+            let n = p.normalized();
+            assert!(n.iter().all(|&x| (0.0..=1.0).contains(&x)));
+        }
+    }
+
+    #[test]
+    fn test_disk_generation_ranges() {
+        let config = SimGridConfig::smoke();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(7);
+        let disk = generate_disk(&config, &mut rng);
+        assert_eq!(disk.len(), config.n_particles);
+        for state in &disk {
+            let elem = cartesian_to_elements(state, GM_SUN);
+            assert!(elem.a > 149.0 && elem.a < 501.0, "a = {}", elem.a);
+            let q = elem.a * (1.0 - elem.e);
+            assert!(q > 29.0 && q < 51.0, "q = {q}");
+            assert!(elem.i >= 0.0 && elem.i <= 25.5 * DEG2RAD);
+        }
+    }
+
+    #[test]
+    fn test_grid_point_run_is_deterministic() {
+        let mut config = SimGridConfig::smoke();
+        config.n_particles = 10;
+        let point = config.grid_points()[0];
+        let r1 = run_grid_point(&config, &point, 99);
+        let r2 = run_grid_point(&config, &point, 99);
+        assert_eq!(r1.samples.len(), r2.samples.len());
+        for (s1, s2) in r1.samples.iter().zip(&r2.samples) {
+            assert_eq!(s1.a, s2.a);
+            assert_eq!(s1.delta_varpi, s2.delta_varpi);
+        }
+        // Different seed -> different initial conditions -> different samples.
+        let r3 = run_grid_point(&config, &point, 100);
+        assert!(r1
+            .samples
+            .iter()
+            .zip(&r3.samples)
+            .any(|(s1, s3)| s1.a != s3.a));
+    }
+
+    #[test]
+    fn test_smoke_grid_point_produces_samples() {
+        let config = SimGridConfig::smoke();
+        let point = config.grid_points()[0];
+        let result = run_grid_point(&config, &point, config.seed);
+        assert_eq!(result.n_initial, config.n_particles);
+        // 0.1 Myr cannot remove the whole disk.
+        assert!(result.n_surviving > 0);
+        assert!(!result.samples.is_empty());
+        for s in &result.samples {
+            assert!(s.a > 0.0 && s.e < 1.0);
+            assert!((0.0..TWO_PI).contains(&s.delta_varpi));
+            assert!((0.0..TWO_PI).contains(&s.delta_omega_big));
+        }
+    }
+
+    /// Reduced-scale grid: measured ~67 s wall / 12.9 CPU-min in release
+    /// mode on 64 cores.
+    /// Run with `cargo test --release -p p9-2021-orbit -- --ignored`.
+    #[test]
+    #[ignore]
+    fn test_reduced_grid_runs() {
+        let config = SimGridConfig::reduced();
+        let results = run_grid(&config);
+        assert_eq!(results.len(), 12);
+        for r in &results {
+            assert!(
+                r.n_surviving > 0,
+                "all particles lost at {:?} (seed {})",
+                r.point,
+                r.seed
+            );
+            assert!(!r.samples.is_empty());
+        }
+    }
+}


### PR DESCRIPTION
Closes #12. Implements Brown & Batygin (2021) models 1-4 in p9-2021-orbit:

- sim_grid: deterministic (m9,a9,e9,i9) grid over the paper's extent with GridScale Smoke/Reduced/Paper (the paper's manual 121-point grid is unpublished; Paper scale is a 121-point surrogate, #[ignore]d)
- kde: P[(i,dvarpi,dOmega)|(a,e) bin] with the paper's 5%->30% bandwidth law, von Mises angular kernels
- gp: exact Matern-3/2 GP (nalgebra Cholesky), grid-search hyperparameters, closed-form LOO (verified vs explicit refits to 1e-8); LOO 0.24 at 12 training points, <5% at 60 (issue target documented as paper-grid-sized)
- mcmc: Goodman-Weare ensemble sampler with Gelman-Rubin + Sokal ESS, validated on analytic targets; paper's 100/20,890/260/42 settings pinned

End-to-end Reduced run (12 pts x 200 particles x 10 Myr, 68 s): R-hat < 1.06, ESS > 590, published medians inside the 95% intervals (asserted as loose containment only — the 10 Myr likelihood surface spans ~3.7 nats, so the posterior is near-prior; stated plainly). Paper-scale cost measured at ~3,000 CPU-days and documented in REPRODUCTION_NOTES.md section 9 with the remaining reductions even at that scale. posterior.rs re-documented as the published-posterior summary that downstream crates consume.