### PR TITLE
Add Clement & Sheppard precession and Neptune resonance crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,6 +1308,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "p9-2020-clement-precession"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "nalgebra",
+ "p9-core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "p9-2021-oort-cloud"
 version = "0.1.0"
 dependencies = [
@@ -1325,9 +1336,11 @@ name = "p9-2021-orbit"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "nalgebra",
  "p9-core",
  "rand 0.8.5",
  "rand_distr",
+ "rayon",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/p9-2018-resonance",
     "crates/p9-2019-clustering",
     "crates/p9-2019-review",
+    "crates/p9-2020-clement-precession",
     "crates/p9-2021-oort-cloud",
     "crates/p9-2021-orbit",
     "crates/p9-2021-stability",

--- a/crates/p9-2020-clement-precession/Cargo.toml
+++ b/crates/p9-2020-clement-precession/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "p9-2020-clement-precession"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+p9-core = { path = "../p9-core" }
+nalgebra = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/p9-2020-clement-precession/src/lib.rs
+++ b/crates/p9-2020-clement-precession/src/lib.rs
@@ -1,0 +1,81 @@
+//! Reproduction of Clement & Sheppard (2020), "Orbital Precession in the
+//! Distant Solar System" (arXiv:2005.05326), and the companion 2021 study of
+//! Neptune's distant mean-motion resonances under a Planet Nine
+//! (arXiv:2105.01065).
+//!
+//! Two headline results are reproduced from real computations (no hard-coded
+//! answers), reusing `p9-core`'s secular, resonance, constants, and ETNO data:
+//!
+//! 1. [`precession`] — the orbit-averaged quadrupole apsidal precession rate
+//!    dϖ/dt imposed on a distant ETNO by the known giant planets, the extra
+//!    rate from a nominal Planet Nine, and the combined rate. The
+//!    giant-planet-only precession period is of order ~1 Gyr for the clustered
+//!    ETNOs (slow, coherent circulation); an exterior P9 adds a prograde term
+//!    that shortens it. The leading-order analytic rates are validated against
+//!    a finite difference of `p9_core`'s exact Gauss-ring secular Hamiltonian.
+//!
+//! 2. [`resonance`] — the semi-major-axis locations of Neptune's distant
+//!    exterior n:1 (n = 2..12) and n:2 resonances, computed from the shared
+//!    `resonance_semi_major_axis` (a = a_N (n/m)^{2/3}), and the nearest
+//!    distant resonance for each clustered ETNO in `p9_core::data::etno`.
+
+pub mod precession;
+pub mod resonance;
+
+/// Convenience summary of the two headline results for a test ETNO and a
+/// nominal Planet Nine. Returned as plain numbers so callers (and the binary
+/// report below) can serialize or print them.
+#[derive(Debug, Clone)]
+pub struct Summary {
+    /// Test ETNO semi-major axis (AU).
+    pub a_au: f64,
+    /// Test ETNO eccentricity.
+    pub e: f64,
+    /// Giant-planet-induced precession rate (rad/day).
+    pub giant_rate: f64,
+    /// Giant-planet precession period (Gyr).
+    pub giant_period_gyr: f64,
+    /// Combined giant-planet + P9 precession rate (rad/day).
+    pub combined_rate: f64,
+    /// Combined precession period (Gyr).
+    pub combined_period_gyr: f64,
+    /// Nearest-resonance matches for the clustered sample.
+    pub matches: Vec<resonance::EtnoResonance>,
+}
+
+/// Build the [`Summary`] for an ETNO at (a, e) and a Planet Nine.
+pub fn summarize(a_au: f64, e: f64, p9: &p9_core::types::P9Params) -> Summary {
+    let giant_rate = precession::giant_planet_precession_rate(a_au, e);
+    let combined_rate = precession::combined_precession_rate(a_au, e, p9);
+    Summary {
+        a_au,
+        e,
+        giant_rate,
+        giant_period_gyr: precession::precession_period_gyr(giant_rate),
+        combined_rate,
+        combined_period_gyr: precession::precession_period_gyr(combined_rate),
+        matches: resonance::match_sample_to_resonances(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p9_core::types::P9Params;
+
+    #[test]
+    fn test_summary_is_self_consistent() {
+        // a = 250 AU, q = 40 AU ⇒ e = 0.84.
+        let a = 250.0;
+        let e = 1.0 - 40.0 / a;
+        let s = summarize(a, e, &P9Params::nominal_2016());
+
+        assert!(s.giant_rate > 0.0);
+        assert!(s.combined_rate > s.giant_rate);
+        assert!(s.combined_period_gyr < s.giant_period_gyr);
+        assert_eq!(
+            s.matches.len(),
+            p9_core::data::etno::BROWN_2017_SAMPLE.len()
+        );
+    }
+}

--- a/crates/p9-2020-clement-precession/src/precession.rs
+++ b/crates/p9-2020-clement-precession/src/precession.rs
@@ -1,0 +1,299 @@
+//! Secular apsidal precession of a distant ETNO.
+//!
+//! For a test particle *exterior* to a set of interior perturbing rings (the
+//! known giant planets), the orbit-averaged quadrupole secular theory gives a
+//! steady prograde precession of the longitude of perihelion ϖ. To leading
+//! order in α_p = a_p / a ≪ 1 (the relevant limit for a ≳ 200 AU ETNO and
+//! a_p ≤ 30 AU planets), the Laplace–Lagrange free-precession rate reduces to
+//!
+//!   dϖ/dt = (3/4) · n · Σ_p (m_p / M_⊙) · (a_p / a)² · 1 / (1 − e²)²
+//!
+//! where n = √(GM_⊙ / a³) is the particle's mean motion and the sum runs over
+//! the interior perturbers (Murray & Dermott 1999, eq. 7.16, exterior-particle
+//! limit b_{3/2}^{(1)}(α) → 3α; the (1 − e²)^{-2} factor is the standard
+//! finite-eccentricity correction). The total precession is slow and prograde,
+//! with a period of order >~ 1 Gyr for the clustered ETNOs — the regime in
+//! which the apsidal lines can stay coherently confined (Clement & Sheppard
+//! 2020, arXiv:2005.05326).
+//!
+//! A Planet Nine is *exterior* to the ETNO and adds an opposite-sign secular
+//! term. For an exterior perturber the leading quadrupole free-precession rate
+//! is
+//!
+//!   dϖ_9/dt = (3/4) · n · (m_9 / M_⊙) · (a / a_9_eff)³ · 1 / √(1 − e²)
+//!
+//! with a_9_eff = a_9 (1 − e_9²)^{1/2} the perturber's averaged ring scale
+//! (Murray & Dermott eq. 7.16, interior-particle limit b_{3/2}^{(1)}(α) → 3α
+//! with α = a / a_9). The two contributions add; the constraint of the paper
+//! is that P9 sits in a mass–semimajor-axis band where this extra rate keeps
+//! the combined precession slow and coherent rather than disrupting the
+//! cluster.
+//!
+//! These analytic rates are independently cross-checked in the tests against a
+//! finite-difference of `p9_core::analysis::secular::numerical_secular_hamiltonian`
+//! (the exact Gauss-ring average), which captures the same dϖ/dt = +∂H/∂(action)
+//! structure without any α expansion.
+
+use p9_core::analysis::secular::numerical_secular_hamiltonian;
+use p9_core::constants::{
+    GM_SUN, GYR_DAYS, MASS_JUPITER_SOLAR, MASS_NEPTUNE_SOLAR, MASS_SATURN_SOLAR, MASS_URANUS_SOLAR,
+    YEAR_DAYS,
+};
+use p9_core::types::P9Params;
+
+/// An interior perturbing ring: semi-major axis (AU) and mass (solar masses).
+#[derive(Debug, Clone, Copy)]
+pub struct Perturber {
+    pub a_au: f64,
+    pub mass_solar: f64,
+}
+
+/// The four known giant planets as interior secular perturbers.
+///
+/// Semi-major axes are the standard mean values (Jupiter 5.20, Saturn 9.58,
+/// Uranus 19.20 AU) with Neptune anchored to `p9_core`'s `A_NEPTUNE_AU`, and
+/// masses from `p9_core`'s mass constants.
+pub fn giant_planets() -> [Perturber; 4] {
+    [
+        Perturber {
+            a_au: 5.2026,
+            mass_solar: MASS_JUPITER_SOLAR,
+        },
+        Perturber {
+            a_au: 9.5549,
+            mass_solar: MASS_SATURN_SOLAR,
+        },
+        Perturber {
+            a_au: 19.2184,
+            mass_solar: MASS_URANUS_SOLAR,
+        },
+        Perturber {
+            a_au: p9_core::constants::A_NEPTUNE_AU,
+            mass_solar: MASS_NEPTUNE_SOLAR,
+        },
+    ]
+}
+
+/// Mean motion n = √(GM_⊙ / a³) in rad/day for a heliocentric orbit.
+pub fn mean_motion(a_au: f64) -> f64 {
+    (GM_SUN / a_au.powi(3)).sqrt()
+}
+
+/// Leading-order quadrupole apsidal precession rate dϖ/dt (rad/day) imposed on
+/// an exterior test particle (a, e) by a single interior perturbing ring.
+///
+///   dϖ/dt = (3/4) n (m_p/M_⊙) (a_p/a)² (1 − e²)^{-2}
+pub fn precession_rate_interior(a_au: f64, e: f64, p: Perturber) -> f64 {
+    let n = mean_motion(a_au);
+    let alpha = p.a_au / a_au;
+    0.75 * n * p.mass_solar * alpha * alpha / (1.0 - e * e).powi(2)
+}
+
+/// Total giant-planet-induced apsidal precession rate dϖ/dt (rad/day) for an
+/// exterior ETNO at (a, e): the sum of the four interior-planet contributions.
+pub fn giant_planet_precession_rate(a_au: f64, e: f64) -> f64 {
+    giant_planets()
+        .iter()
+        .map(|&p| precession_rate_interior(a_au, e, p))
+        .sum()
+}
+
+/// Leading-order quadrupole apsidal precession rate dϖ/dt (rad/day) imposed on
+/// an *interior* test particle (the ETNO) by an exterior perturber (Planet
+/// Nine). Using the averaged ring scale a_9_eff = a_9 √(1 − e_9²):
+///
+///   dϖ_9/dt = (3/4) n (m_9/M_⊙) (a/a_9_eff)³ (1 − e²)^{-1/2}
+pub fn p9_precession_rate(a_au: f64, e: f64, p9: &P9Params) -> f64 {
+    let n = mean_motion(a_au);
+    let a9_eff = p9.a * (1.0 - p9.e * p9.e).sqrt();
+    let alpha = a_au / a9_eff;
+    0.75 * n * p9.mass_solar() * alpha.powi(3) / (1.0 - e * e).sqrt()
+}
+
+/// Combined giant-planet + Planet Nine apsidal precession rate (rad/day).
+pub fn combined_precession_rate(a_au: f64, e: f64, p9: &P9Params) -> f64 {
+    giant_planet_precession_rate(a_au, e) + p9_precession_rate(a_au, e, p9)
+}
+
+/// Convert a precession rate (rad/day) to the precession period (years), i.e.
+/// the time for ϖ to circulate once. Returns `f64::INFINITY` at zero rate.
+pub fn precession_period_years(rate_rad_per_day: f64) -> f64 {
+    if rate_rad_per_day == 0.0 {
+        return f64::INFINITY;
+    }
+    let period_days = std::f64::consts::TAU / rate_rad_per_day.abs();
+    period_days / YEAR_DAYS
+}
+
+/// Precession period in Gyr.
+pub fn precession_period_gyr(rate_rad_per_day: f64) -> f64 {
+    if rate_rad_per_day == 0.0 {
+        return f64::INFINITY;
+    }
+    (std::f64::consts::TAU / rate_rad_per_day.abs()) / GYR_DAYS
+}
+
+/// Cross-check estimate of dϖ/dt (rad/day) from a finite difference of the
+/// exact Gauss-ring secular Hamiltonian of a single perturber.
+///
+/// In the coplanar secular problem the apsidal angle is canonically conjugate
+/// to the Delaunay action G = L√(1 − e²) with L = √(GM_⊙ a), so
+///
+///   dϖ/dt = ∂H/∂G = (∂H/∂e) · (∂e/∂G),   ∂e/∂G = −√(1 − e²)/(L e).
+///
+/// `numerical_secular_hamiltonian` returns −gm_p⟨⟨1/Δ⟩⟩ in the perturber frame
+/// (Δϖ = omega); we difference it in e at fixed a to obtain ∂H/∂e. This makes
+/// no α expansion and is used purely to validate the analytic rates above.
+pub fn precession_rate_numerical_interior(a_au: f64, e: f64, p: Perturber) -> f64 {
+    let gm_p = p.mass_solar * GM_SUN;
+    let a_p = p.a_au;
+    // Circular perturber: axisymmetric ring, the correct comparison for the
+    // analytic interior formula (which assumes e_p = 0).
+    let e_p = 0.0;
+    let n_quad = 256;
+    let h = 1.0e-4;
+
+    let ham = |ecc: f64| {
+        numerical_secular_hamiltonian(a_au, ecc, 0.0, 0.0, 0.0, a_p, e_p, gm_p, n_quad, 0.0)
+    };
+    let dh_de = (ham(e + h) - ham(e - h)) / (2.0 * h);
+
+    let big_l = (GM_SUN * a_au).sqrt();
+    let de_dg = -(1.0 - e * e).sqrt() / (big_l * e);
+    dh_de * de_dg
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    // ---- Published / documented reference values (labelled constants) ----
+
+    /// Test ETNO used throughout: a = 250 AU, q = 40 AU ⇒ e = 1 − q/a = 0.84.
+    const A_TEST: f64 = 250.0;
+    const Q_TEST: f64 = 40.0;
+
+    fn e_test() -> f64 {
+        1.0 - Q_TEST / A_TEST
+    }
+
+    #[test]
+    fn test_giant_planet_precession_period_is_documented_order() {
+        // Clement & Sheppard 2020: the giant planets drive a slow prograde
+        // apsidal precession of the distant ETNOs, with a period of order
+        // ~1 Gyr (>~ a Gyr for a ≳ 250 AU). The rate must be positive
+        // (prograde) and the period in the 10^8–10^10 yr band.
+        let rate = giant_planet_precession_rate(A_TEST, e_test());
+        assert!(rate > 0.0, "precession should be prograde: {rate:e}");
+
+        let period_gyr = precession_period_gyr(rate);
+        assert!(
+            (0.05..20.0).contains(&period_gyr),
+            "giant-planet precession period {period_gyr:.3} Gyr out of documented order"
+        );
+        // Cross-check the year/Gyr converters agree.
+        let period_yr = precession_period_years(rate);
+        assert_relative_eq!(period_yr / 1.0e9, period_gyr, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn test_analytic_matches_numerical_gauss_ring() {
+        // The leading-order analytic interior rate (which truncates the
+        // eccentricity dependence at (1 − e²)^{-2}) is validated against the
+        // exact Gauss-ring secular derivative for the dominant perturber
+        // (Neptune) at a moderate eccentricity where the truncation is small.
+        // Here α = a_N/a ≈ 0.12 is small, so the residual is the leading
+        // O(e^4) eccentricity term, a few percent at e = 0.3.
+        let gp = giant_planets();
+        let neptune = gp[3];
+        let e = 0.3;
+        let analytic = precession_rate_interior(A_TEST, e, neptune);
+        let numerical = precession_rate_numerical_interior(A_TEST, e, neptune);
+        assert!(analytic > 0.0 && numerical > 0.0);
+        let rel = ((analytic - numerical) / numerical).abs();
+        assert!(
+            rel < 0.05,
+            "analytic vs Gauss-ring rate mismatch: {rel:.3e}"
+        );
+    }
+
+    #[test]
+    fn test_eccentricity_correction_underestimates_at_high_e() {
+        // At the q = 40 AU test ETNO (e = 0.84) the (1 − e²)^{-2} leading-order
+        // factor underestimates the full ring precession: the exact Gauss-ring
+        // derivative is ~2x the analytic rate. Both stay prograde and the
+        // analytic value is the conservative (lower) bound. Documented residual
+        // — the slow-precession conclusion is unchanged, both give Gyr periods.
+        let gp = giant_planets();
+        let neptune = gp[3];
+        let e = e_test();
+        let analytic = precession_rate_interior(A_TEST, e, neptune);
+        let numerical = precession_rate_numerical_interior(A_TEST, e, neptune);
+        assert!(analytic > 0.0 && numerical > analytic);
+        let ratio = numerical / analytic;
+        assert!(
+            (1.5..2.5).contains(&ratio),
+            "high-e Gauss-ring/analytic ratio = {ratio:.3}"
+        );
+    }
+
+    #[test]
+    fn test_p9_changes_rate_in_expected_direction() {
+        // Adding an exterior Planet Nine adds a strictly positive (prograde)
+        // secular term, so the combined rate exceeds the giant-planet-only
+        // rate, and the combined precession period shortens.
+        let e = e_test();
+        let p9 = P9Params::nominal_2016();
+        let gp_rate = giant_planet_precession_rate(A_TEST, e);
+        let p9_rate = p9_precession_rate(A_TEST, e, &p9);
+        let combined = combined_precession_rate(A_TEST, e, &p9);
+
+        assert!(p9_rate > 0.0, "P9 secular term should be prograde");
+        assert_relative_eq!(combined, gp_rate + p9_rate, epsilon = 1e-18);
+        assert!(combined > gp_rate, "P9 must increase the precession rate");
+        assert!(
+            precession_period_gyr(combined) < precession_period_gyr(gp_rate),
+            "P9 must shorten the precession period"
+        );
+    }
+
+    #[test]
+    fn test_p9_contribution_grows_with_mass_and_shrinks_with_distance() {
+        let e = e_test();
+        let light = P9Params {
+            mass_earth: 5.0,
+            ..P9Params::nominal_2016()
+        };
+        let heavy = P9Params {
+            mass_earth: 10.0,
+            ..P9Params::nominal_2016()
+        };
+        assert!(
+            p9_precession_rate(A_TEST, e, &heavy) > p9_precession_rate(A_TEST, e, &light),
+            "heavier P9 must precess the ETNO faster"
+        );
+
+        let near = P9Params {
+            a: 400.0,
+            ..P9Params::nominal_2016()
+        };
+        let far = P9Params {
+            a: 800.0,
+            ..P9Params::nominal_2016()
+        };
+        assert!(
+            p9_precession_rate(A_TEST, e, &near) > p9_precession_rate(A_TEST, e, &far),
+            "a more distant P9 must precess the ETNO more slowly"
+        );
+    }
+
+    #[test]
+    fn test_precession_period_inversely_tracks_rate() {
+        // Sanity: doubling the rate halves the period.
+        let p = precession_period_years(2.0e-12);
+        let p2 = precession_period_years(4.0e-12);
+        assert_relative_eq!(p / p2, 2.0, epsilon = 1e-12);
+        assert!(precession_period_years(0.0).is_infinite());
+    }
+}

--- a/crates/p9-2020-clement-precession/src/resonance.rs
+++ b/crates/p9-2020-clement-precession/src/resonance.rs
@@ -1,0 +1,201 @@
+//! Locations of Neptune's distant exterior mean-motion resonances and the
+//! clustered ETNOs that sit near them.
+//!
+//! The companion 2021 work (arXiv:2105.01065) maps Neptune's distant n:1 and
+//! n:2 exterior resonances across the ~100–800 AU range and asks which
+//! clustered ETNOs lie near them. An exterior n:m resonance with Neptune (the
+//! particle completes m orbits per n Neptune orbits, n > m) sits at
+//!
+//!   a_res = a_N (n/m)^{2/3}
+//!
+//! which is exactly `p9_core::analysis::resonance::resonance_semi_major_axis`.
+//! This module only catalogs the relevant (n, m) and finds the nearest
+//! resonance for each object — it adds no new resonance physics.
+
+use p9_core::analysis::resonance::resonance_semi_major_axis;
+use p9_core::constants::A_NEPTUNE_AU;
+use p9_core::data::etno::{Etno, BROWN_2017_SAMPLE};
+
+/// A located Neptune exterior resonance.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Resonance {
+    /// Period ratio numerator (Neptune orbits).
+    pub n: u32,
+    /// Period ratio denominator (particle orbits).
+    pub m: u32,
+    /// Semi-major axis of the resonance (AU).
+    pub a_au: f64,
+}
+
+impl Resonance {
+    fn new(n: u32, m: u32) -> Self {
+        Self {
+            n,
+            m,
+            a_au: resonance_semi_major_axis(n, m, A_NEPTUNE_AU),
+        }
+    }
+
+    /// "n:m" label, e.g. "5:1".
+    pub fn label(&self) -> String {
+        format!("{}:{}", self.n, self.m)
+    }
+}
+
+/// Neptune's exterior n:1 resonances for n = 2..=12 — the headline chain
+/// (a ≈ 48–158 AU) anchoring the lower half of the distant range.
+pub fn neptune_n1_resonances() -> Vec<Resonance> {
+    (2..=12).map(|n| Resonance::new(n, 1)).collect()
+}
+
+/// A selection of Neptune's exterior n:2 resonances (odd n so the ratio is in
+/// lowest terms) spanning the distant range.
+pub fn neptune_n2_resonances() -> Vec<Resonance> {
+    [5u32, 7, 9, 11, 13, 15, 17, 19, 21, 23]
+        .iter()
+        .map(|&n| Resonance::new(n, 2))
+        .collect()
+}
+
+/// Neptune's exterior n:1 resonances out to a_au ≈ 800 AU. The n:1 chain runs
+/// to n ≈ 130 at 800 AU and the spacing shrinks to a few AU past ~400 AU, so
+/// every clustered ETNO (a ≈ 228–506 AU) sits within a few AU of one.
+pub fn distant_n1_resonances() -> Vec<Resonance> {
+    (2u32..=130)
+        .map(|n| Resonance::new(n, 1))
+        .take_while(|r| r.a_au <= 800.0)
+        .collect()
+}
+
+/// All cataloged distant resonances (n:1 to ~800 AU plus the n:2 selection)
+/// sorted by semi-major axis. Used for nearest-resonance matching.
+pub fn distant_resonances() -> Vec<Resonance> {
+    let mut all = distant_n1_resonances();
+    all.extend(neptune_n2_resonances());
+    all.sort_by(|x, y| x.a_au.partial_cmp(&y.a_au).unwrap());
+    all
+}
+
+/// The resonance from `catalog` whose semi-major axis is closest to `a_au`,
+/// with the absolute offset in AU.
+pub fn nearest_resonance(a_au: f64, catalog: &[Resonance]) -> (Resonance, f64) {
+    catalog
+        .iter()
+        .map(|&r| (r, (r.a_au - a_au).abs()))
+        .min_by(|x, y| x.1.partial_cmp(&y.1).unwrap())
+        .expect("non-empty catalog")
+}
+
+/// An ETNO paired with its nearest distant Neptune resonance.
+#[derive(Debug, Clone)]
+pub struct EtnoResonance {
+    pub name: &'static str,
+    pub a_au: f64,
+    pub resonance: Resonance,
+    /// Signed offset a_etno − a_res (AU); negative means interior to the
+    /// resonance.
+    pub offset_au: f64,
+}
+
+/// Match every member of the Brown (2017) clustered sample to its nearest
+/// distant Neptune resonance (n:1 ∪ n:2).
+pub fn match_sample_to_resonances() -> Vec<EtnoResonance> {
+    let catalog = distant_resonances();
+    BROWN_2017_SAMPLE
+        .iter()
+        .map(|etno: &Etno| {
+            let (res, _) = nearest_resonance(etno.a, &catalog);
+            EtnoResonance {
+                name: etno.name,
+                a_au: etno.a,
+                resonance: res,
+                offset_au: etno.a - res.a_au,
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn test_n1_resonances_match_kepler_relation() {
+        // The headline pin: each n:1 a-value matches the analytic Kepler
+        // relation a = a_N · n^(2/3) to within 1e-6 AU, cross-checking the
+        // shared `resonance_semi_major_axis`.
+        for r in neptune_n1_resonances() {
+            assert_eq!(r.m, 1);
+            let kepler = A_NEPTUNE_AU * (r.n as f64).powf(2.0 / 3.0);
+            assert_relative_eq!(r.a_au, kepler, epsilon = 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_n2_resonances_match_kepler_relation() {
+        for r in neptune_n2_resonances() {
+            assert_eq!(r.m, 2);
+            let kepler = A_NEPTUNE_AU * (r.n as f64 / 2.0).powf(2.0 / 3.0);
+            assert_relative_eq!(r.a_au, kepler, epsilon = 1e-6);
+        }
+    }
+
+    #[test]
+    fn test_n1_range_spans_distant_region() {
+        let res = neptune_n1_resonances();
+        // 2:1 just beyond Neptune, 12:1 out near ~480 AU — the n=2..12 chain
+        // covers the lower half of the 100–800 AU band.
+        let a2 = res.first().unwrap().a_au;
+        let a12 = res.last().unwrap().a_au;
+        assert!((a2 - 47.8).abs() < 0.5, "2:1 at {a2:.1} AU");
+        assert!(a12 > 150.0 && a12 < 200.0, "12:1 at {a12:.1} AU");
+    }
+
+    #[test]
+    fn test_resonances_sorted_and_nonempty() {
+        let all = distant_resonances();
+        assert!(!all.is_empty());
+        for w in all.windows(2) {
+            assert!(w[0].a_au <= w[1].a_au, "catalog must be a-sorted");
+        }
+    }
+
+    #[test]
+    fn test_nearest_resonance_picks_closest() {
+        let catalog = distant_resonances();
+        // Build a point exactly on the 9:1 resonance; nearest must be it.
+        let nine = Resonance::new(9, 1);
+        let (got, off) = nearest_resonance(nine.a_au, &catalog);
+        assert_eq!(got, nine);
+        assert!(off < 1e-9, "offset {off}");
+    }
+
+    #[test]
+    fn test_sample_matches_have_modest_offsets() {
+        // Every clustered ETNO should land within a fraction of the local
+        // resonance spacing of *some* distant resonance — the offsets are
+        // tens of AU, not hundreds, across the 228–506 AU sample.
+        let matches = match_sample_to_resonances();
+        assert_eq!(matches.len(), BROWN_2017_SAMPLE.len());
+        for m in &matches {
+            assert!(
+                m.offset_au.abs() < 60.0,
+                "{} (a={:.0}) nearest {} at offset {:.1} AU",
+                m.name,
+                m.a_au,
+                m.resonance.label(),
+                m.offset_au
+            );
+        }
+        // Sedna (a = 506 AU) is the most distant; its nearest distant
+        // resonance must itself be far out (a_res > 300 AU).
+        let sedna = matches.iter().find(|m| m.name == "Sedna").unwrap();
+        assert!(
+            sedna.resonance.a_au > 300.0,
+            "Sedna nearest resonance {} at {:.0} AU",
+            sedna.resonance.label(),
+            sedna.resonance.a_au
+        );
+    }
+}


### PR DESCRIPTION
Reproduces Clement & Sheppard 2020 (arXiv:2005.05326, orbital precession in
the distant solar system) and the companion 2021 Neptune distant-MMR study
(arXiv:2105.01065). New crate `p9-2020-clement-precession`, reusing
`p9-core`'s secular, resonance, constants, and ETNO data.

## Computed + pinned

**Apsidal precession (`precession`)** — for the test ETNO a = 250 AU,
q = 40 AU (e = 0.84):
- Giant-planet quadrupole rate dϖ/dt = 6.91e-11 rad/day → period ≈ 0.25 Gyr
  (slow, prograde, coherent), from the Laplace–Lagrange leading-order rate
  summed over Jupiter–Neptune.
- Adding a nominal P9 (10 M⊕, 700 AU, e = 0.6) contributes +1.61e-11 rad/day
  (prograde), raising the combined rate to 8.52e-11 rad/day (period ≈ 0.20 Gyr).
- The leading-order analytic rate is cross-checked against a finite difference
  of `p9_core`'s exact Gauss-ring `numerical_secular_hamiltonian` (∂H/∂G): they
  agree to <5% at moderate e, and the documented high-e residual (~2x, the
  (1−e²)^-2 truncation underestimating the full ring) is itself pinned.

**Neptune distant resonances (`resonance`)** — n:1 for n = 2..12 and a set of
n:2, from the shared `resonance_semi_major_axis` (a = a_N (n/m)^{2/3}):
- Each n:1 / n:2 a-value matches the analytic Kepler relation a = a_N·(n/m)^(2/3)
  within 1e-6.
- Nearest-resonance match for the clustered Brown (2017) sample — every object
  sits within ~3 AU of a Neptune n:1 resonance (e.g. Sedna 506 AU near 69:1,
  2007 TG422 501 AU near 68:1, 2000 CR105 228 AU near 21:1).

## Tests pinned
- Neptune n:1 / n:2 a-values vs Kepler relation within 1e-6.
- Giant-planet precession period positive and of documented order (0.05–20 Gyr).
- Adding P9 increases the rate / shortens the period; scales up with P9 mass,
  down with P9 distance.
- Analytic vs Gauss-ring agreement at moderate e; high-e residual documented.

All 13 tests pass; `cargo fmt --check` clean.

Closes #51