### PR TITLE
Add 2025 new-discoveries crate stressing ETNO clustering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,9 +1325,11 @@ name = "p9-2021-orbit"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "nalgebra",
  "p9-core",
  "rand 0.8.5",
  "rand_distr",
+ "rayon",
  "serde",
  "serde_json",
 ]
@@ -1433,6 +1435,16 @@ dependencies = [
  "p9-core",
  "rand 0.8.5",
  "rand_distr",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "p9-2025-new-discoveries"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "p9-core",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/p9-2024-oort-selfgrav",
     "crates/p9-2024-panstarrs",
     "crates/p9-2025-clustering",
+    "crates/p9-2025-new-discoveries",
     "crates/p9-2025-iras-akari",
     "crates/p9-2025-perturbation",
     "crates/p9-review-article",

--- a/crates/p9-2025-new-discoveries/Cargo.toml
+++ b/crates/p9-2025-new-discoveries/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "p9-2025-new-discoveries"
+version = "0.1.0"
+edition = "2021"
+description = "Reproduction of two 2025 distant-TNO discoveries (Cheng et al. 2017 OF201; Chen et al. Ammonite / 2023 KQ14) that stress the Planet Nine clustering hypothesis"
+
+[dependencies]
+p9-core = { path = "../p9-core" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/p9-2025-new-discoveries/src/discoveries.rs
+++ b/crates/p9-2025-new-discoveries/src/discoveries.rs
@@ -1,0 +1,133 @@
+//! The two new 2025 objects encoded as documented `Etno`-style entries.
+//!
+//! Provenance of every element below: NASA/JPL Small-Body Database (SBDB)
+//! osculating solutions, fetched 2026-06-14, epoch JD 2461200.5 (TDB),
+//! frame ECLIPJ2000 (same heliocentric ecliptic frame as
+//! `p9_core::data::etno::BROWN_2017_SAMPLE`). The discovery-paper abstracts
+//! quote only rounded headline numbers (830 AU / 45 AU for 2017 OF201;
+//! 252 AU / 66 AU / 11° for Ammonite); the full angular elements ω and Ω —
+//! which the ϖ clustering analysis needs — come from the JPL fits, which are
+//! the same arc the papers report.
+
+use p9_core::data::etno::Etno;
+
+/// A new discovery with its discovery-paper headline reference numbers kept
+/// separately from the computed orbit.
+#[derive(Debug, Clone, Copy)]
+pub struct NewDiscovery {
+    /// Vetted orbital elements (reuses the workspace `Etno` type).
+    pub etno: Etno,
+    /// arXiv identifier of the discovery paper.
+    pub arxiv: &'static str,
+    /// Semi-major axis (AU) as quoted in the paper headline, kept as a
+    /// labelled reference value (the JPL osculating `a` differs slightly).
+    pub paper_a_au: f64,
+    /// Perihelion distance q (AU) as quoted in the paper headline.
+    pub paper_q_au: f64,
+    /// One-line note on why this object stresses the clustering hypothesis.
+    pub note: &'static str,
+}
+
+/// 2017 OF201 — Cheng, Yang, et al. 2025 (arXiv:2505.15806).
+///
+/// JPL SBDB solution 2 (soln 2025-07-03, 25 obs, arc 2004–2018):
+/// a = 823.64 AU, e = 0.94519, i = 16.221°, ω = 337.835°, Ω = 328.760°.
+/// Paper headline: a ≈ 830 AU, q ≈ 45 AU, dwarf-planet-sized (H ≈ 3.5).
+/// Its ϖ ≈ 307° sits far from the clustered ETNO mean (~52°): an object that
+/// Planet Nine should herd, yet is not aligned.
+pub fn of201() -> NewDiscovery {
+    NewDiscovery {
+        etno: Etno {
+            name: "2017 OF201",
+            a: 823.637,
+            e: 0.945188,
+            i_deg: 16.221,
+            omega_deg: 337.835,
+            omega_big_deg: 328.760,
+            h_mag: 3.49,
+        },
+        arxiv: "2505.15806",
+        paper_a_au: 830.0,
+        paper_q_au: 45.0,
+        note: "very distant ETNO with ϖ outside the clustered group",
+    }
+}
+
+/// Ammonite / 2023 KQ14 — Chen, Kavelaars, et al. 2025 (arXiv:2508.02162).
+///
+/// JPL SBDB solution 3 (soln 2026-05-26, 88 obs, arc 2005–2025):
+/// a = 247.43 AU, e = 0.73357, i = 11.001°, ω = 198.704°, Ω = 72.079°.
+/// Paper headline: a ≈ 252 AU, q ≈ 66 AU, i ≈ 11° (H ≈ 6.98). Reported as the
+/// FOURTH sednoid, but with ϖ ≈ 271° misaligned with the other three sednoids,
+/// reducing the apparent sednoid apsidal alignment.
+pub fn ammonite() -> NewDiscovery {
+    NewDiscovery {
+        etno: Etno {
+            name: "Ammonite (2023 KQ14)",
+            a: 247.429,
+            e: 0.733566,
+            i_deg: 11.001,
+            omega_deg: 198.704,
+            omega_big_deg: 72.079,
+            h_mag: 6.98,
+        },
+        arxiv: "2508.02162",
+        paper_a_au: 252.0,
+        paper_q_au: 66.0,
+        note: "fourth sednoid whose ϖ is misaligned with the other three",
+    }
+}
+
+/// Published headline semi-major axis for 2017 OF201 (AU), Cheng et al. 2025.
+pub const OF201_PAPER_A_AU: f64 = 830.0;
+
+/// Ammonite is reported as the FOURTH (misaligned) sednoid, Chen et al. 2025.
+pub const AMMONITE_SEDNOID_RANK: u32 = 4;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn of201_is_very_distant() {
+        let d = of201();
+        // Paper headline a ≈ 830 AU; JPL osculating a within ~1% of it.
+        assert_relative_eq!(d.paper_a_au, OF201_PAPER_A_AU);
+        assert!(
+            (d.etno.a - OF201_PAPER_A_AU).abs() < 10.0,
+            "JPL a = {} AU vs paper 830 AU",
+            d.etno.a
+        );
+        assert!(d.etno.a > 800.0, "a = {} AU", d.etno.a);
+        // Perihelion q = a(1-e) matches the published q ≈ 45 AU.
+        assert!(
+            (d.etno.perihelion() - d.paper_q_au).abs() < 1.0,
+            "q = {:.2} AU vs paper {} AU",
+            d.etno.perihelion(),
+            d.paper_q_au
+        );
+        assert!(d.etno.e > 0.9, "e = {}", d.etno.e);
+    }
+
+    #[test]
+    fn ammonite_is_a_sednoid() {
+        let d = ammonite();
+        assert_eq!(AMMONITE_SEDNOID_RANK, 4);
+        // Sednoid hallmark: detached, q well beyond Neptune's reach.
+        assert!(
+            d.etno.perihelion() > 50.0,
+            "q = {:.2} AU",
+            d.etno.perihelion()
+        );
+        assert!(
+            (d.etno.perihelion() - d.paper_q_au).abs() < 1.0,
+            "q = {:.2} AU vs paper {} AU",
+            d.etno.perihelion(),
+            d.paper_q_au
+        );
+        // Paper headline a ≈ 252 AU; JPL osculating within a few AU.
+        assert!((d.etno.a - 252.0).abs() < 6.0, "a = {} AU", d.etno.a);
+        assert!((d.etno.i_deg - 11.0).abs() < 0.5, "i = {}", d.etno.i_deg);
+    }
+}

--- a/crates/p9-2025-new-discoveries/src/lib.rs
+++ b/crates/p9-2025-new-discoveries/src/lib.rs
@@ -1,0 +1,28 @@
+//! Two 2025 distant-TNO discoveries that STRESS the Planet Nine clustering
+//! hypothesis.
+//!
+//! Both papers report extreme trans-Neptunian objects (ETNOs) whose
+//! longitude of perihelion ϖ = ω + Ω lies *outside* the clustered group that
+//! motivates Planet Nine. Each is an object Planet Nine should have herded
+//! into apsidal alignment, yet it is not aligned — so adding it to the
+//! clustered sample *weakens* the clustering significance.
+//!
+//! 1. Cheng, Yang, et al. 2025, "2017 OF201" (arXiv:2505.15806): a very
+//!    distant (a ≈ 830 AU, q ≈ 45 AU, e ≈ 0.95) dwarf-planet-sized ETNO whose
+//!    ϖ is far from the clustered ETNO mean.
+//! 2. Chen, Kavelaars, et al. 2025, "Ammonite / 2023 KQ14"
+//!    (arXiv:2508.02162): a fourth "sednoid" (q ≈ 66 AU, a ≈ 252 AU, i ≈ 11°)
+//!    whose ϖ is misaligned with the other three sednoids (Sedna, 2012 VP113,
+//!    Leleakuhonua), reducing the apparent sednoid apsidal alignment.
+//!
+//! Everything here is computed from real orbital elements reusing
+//! `p9_core::analysis::circular` and the `p9_core::data::etno` machinery; the
+//! published headline numbers (830 AU; "fourth misaligned sednoid") are kept
+//! only as labelled reference constants. See [`discoveries`] for element
+//! provenance and [`stress`] for the clustering-degradation analysis.
+
+pub mod discoveries;
+pub mod stress;
+
+pub use discoveries::{ammonite, of201, NewDiscovery};
+pub use stress::{clustering_stat, ClusteringStat, StressResult};

--- a/crates/p9-2025-new-discoveries/src/stress.rs
+++ b/crates/p9-2025-new-discoveries/src/stress.rs
@@ -1,0 +1,191 @@
+//! How the two new objects degrade the ETNO apsidal-clustering signal.
+//!
+//! For the longitude of perihelion ϖ = ω + Ω we compute, reusing
+//! `p9_core::analysis::circular`:
+//!   - the mean resultant length R̄ (clustering strength), and
+//!   - the small-n-corrected Rayleigh p-value (significance vs isotropy)
+//! for the baseline `BROWN_2017_SAMPLE` and for that sample with each new
+//! object (and both) appended. We also report each object's angular offset of
+//! ϖ from the baseline circular mean.
+//!
+//! The Planet Nine "stress" is that adding an object the planet should have
+//! aligned *lowers* R̄ and *raises* the Rayleigh p — i.e. it pushes the
+//! clustering toward non-significance rather than reinforcing it.
+
+use p9_core::analysis::circular::{circular_mean, mean_resultant_length, rayleigh_p_value};
+use p9_core::constants::{RAD2DEG, TWO_PI};
+use p9_core::data::etno::{Etno, BROWN_2017_SAMPLE};
+
+use crate::discoveries::NewDiscovery;
+
+/// Clustering statistics for one sample of longitudes of perihelion.
+#[derive(Debug, Clone, Copy)]
+pub struct ClusteringStat {
+    /// Number of objects in the sample.
+    pub n: usize,
+    /// Mean resultant length R̄ ∈ [0, 1].
+    pub r_bar: f64,
+    /// Small-n-corrected Rayleigh p-value (vs circular uniformity).
+    pub rayleigh_p: f64,
+    /// Circular mean of ϖ (degrees, [0, 360)).
+    pub mean_varpi_deg: f64,
+}
+
+/// Compute R̄, the Rayleigh p-value and the circular mean ϖ for a slice of
+/// `Etno` entries.
+pub fn clustering_stat(sample: &[Etno]) -> ClusteringStat {
+    let varpis: Vec<f64> = sample.iter().map(|e| e.longitude_of_perihelion()).collect();
+    ClusteringStat {
+        n: sample.len(),
+        r_bar: mean_resultant_length(&varpis),
+        rayleigh_p: rayleigh_p_value(&varpis),
+        mean_varpi_deg: circular_mean(&varpis)
+            .map(|m| m * RAD2DEG)
+            .unwrap_or(f64::NAN),
+    }
+}
+
+/// Angular offset (degrees, in [0, 180]) of an object's ϖ from a reference
+/// longitude of perihelion (radians).
+pub fn varpi_offset_deg(object: &Etno, reference_varpi: f64) -> f64 {
+    let mut d = (object.longitude_of_perihelion() - reference_varpi).rem_euclid(TWO_PI);
+    if d > TWO_PI / 2.0 {
+        d = TWO_PI - d;
+    }
+    d * RAD2DEG
+}
+
+/// Full stress analysis: baseline, +OF201, +Ammonite, +both, plus each
+/// object's ϖ offset from the baseline circular mean.
+#[derive(Debug, Clone, Copy)]
+pub struct StressResult {
+    /// Baseline `BROWN_2017_SAMPLE` clustering.
+    pub baseline: ClusteringStat,
+    /// Baseline + 2017 OF201.
+    pub with_of201: ClusteringStat,
+    /// Baseline + Ammonite.
+    pub with_ammonite: ClusteringStat,
+    /// Baseline + both new objects.
+    pub with_both: ClusteringStat,
+    /// 2017 OF201 ϖ offset from the baseline circular mean (deg).
+    pub of201_offset_deg: f64,
+    /// Ammonite ϖ offset from the baseline circular mean (deg).
+    pub ammonite_offset_deg: f64,
+}
+
+/// Run the stress analysis on the vetted baseline sample and the two new
+/// objects from [`crate::discoveries`].
+pub fn run_stress(of201: &NewDiscovery, ammonite: &NewDiscovery) -> StressResult {
+    let baseline_vec: Vec<Etno> = BROWN_2017_SAMPLE.to_vec();
+
+    let mut with_of201 = baseline_vec.clone();
+    with_of201.push(of201.etno);
+
+    let mut with_ammonite = baseline_vec.clone();
+    with_ammonite.push(ammonite.etno);
+
+    let mut with_both = baseline_vec.clone();
+    with_both.push(of201.etno);
+    with_both.push(ammonite.etno);
+
+    let baseline = clustering_stat(&baseline_vec);
+    let baseline_mean_varpi = baseline.mean_varpi_deg / RAD2DEG;
+
+    StressResult {
+        baseline,
+        with_of201: clustering_stat(&with_of201),
+        with_ammonite: clustering_stat(&with_ammonite),
+        with_both: clustering_stat(&with_both),
+        of201_offset_deg: varpi_offset_deg(&of201.etno, baseline_mean_varpi),
+        ammonite_offset_deg: varpi_offset_deg(&ammonite.etno, baseline_mean_varpi),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discoveries::{ammonite, of201};
+
+    fn result() -> StressResult {
+        run_stress(&of201(), &ammonite())
+    }
+
+    #[test]
+    fn baseline_is_clustered() {
+        let r = result();
+        // The defining baseline feature: clustered ϖ, significant Rayleigh.
+        assert!(r.baseline.r_bar > 0.5, "R̄ = {:.3}", r.baseline.r_bar);
+        assert!(
+            r.baseline.rayleigh_p < 0.05,
+            "p = {:.4}",
+            r.baseline.rayleigh_p
+        );
+        assert_eq!(r.baseline.n, 10);
+    }
+
+    #[test]
+    fn both_new_objects_far_from_cluster() {
+        let r = result();
+        // Each new object's ϖ offset from the baseline circular mean
+        // exceeds ~60° — they are NOT apsidally aligned with the cluster.
+        assert!(
+            r.of201_offset_deg > 60.0,
+            "2017 OF201 offset = {:.1}°",
+            r.of201_offset_deg
+        );
+        assert!(
+            r.ammonite_offset_deg > 60.0,
+            "Ammonite offset = {:.1}°",
+            r.ammonite_offset_deg
+        );
+    }
+
+    #[test]
+    fn adding_objects_reduces_clustering() {
+        let r = result();
+        // Each addition lowers R̄ relative to baseline.
+        assert!(r.with_of201.r_bar < r.baseline.r_bar);
+        assert!(r.with_ammonite.r_bar < r.baseline.r_bar);
+        assert!(r.with_both.r_bar < r.baseline.r_bar);
+        // And the strongest degradation is from adding both.
+        assert!(r.with_both.r_bar < r.with_of201.r_bar);
+        assert!(r.with_both.r_bar < r.with_ammonite.r_bar);
+    }
+
+    #[test]
+    fn adding_objects_raises_rayleigh_p() {
+        let r = result();
+        // Adding either object weakens the significance; adding both pushes
+        // the clustering across the conventional p = 0.05 threshold into
+        // non-significance.
+        assert!(r.with_of201.rayleigh_p > r.baseline.rayleigh_p);
+        assert!(r.with_ammonite.rayleigh_p > r.baseline.rayleigh_p);
+        assert!(r.with_both.rayleigh_p > r.baseline.rayleigh_p);
+        assert!(
+            r.with_both.rayleigh_p > 0.05,
+            "p(baseline+both) = {:.4} should lose significance",
+            r.with_both.rayleigh_p
+        );
+    }
+
+    #[test]
+    fn residuals_documented() {
+        // Honest record of the computed numbers (JPL elements, epoch
+        // 2461200.5). These are the values the assertions above key on:
+        //   baseline      : R̄ ≈ 0.649, p ≈ 0.011, mean ϖ ≈ 52°
+        //   +2017 OF201   : R̄ ≈ 0.572, p ≈ 0.024  (offset ≈ 106°)
+        //   +Ammonite     : R̄ ≈ 0.522, p ≈ 0.047  (offset ≈ 141°)
+        //   +both         : R̄ ≈ 0.472, p ≈ 0.067  (no longer significant)
+        let r = result();
+        assert!((r.baseline.r_bar - 0.649).abs() < 0.02, "{:?}", r.baseline);
+        assert!((r.baseline.mean_varpi_deg - 52.3).abs() < 2.0);
+        assert!(
+            (r.with_both.r_bar - 0.472).abs() < 0.02,
+            "{:?}",
+            r.with_both
+        );
+        assert!((r.with_both.rayleigh_p - 0.067).abs() < 0.02);
+        assert!((r.of201_offset_deg - 105.7).abs() < 2.0);
+        assert!((r.ammonite_offset_deg - 141.5).abs() < 2.0);
+    }
+}


### PR DESCRIPTION
New crate `p9-2025-new-discoveries` reproducing two 2025 distant-TNO discoveries that stress the Planet Nine apsidal-clustering argument.

## Objects encoded
- **2017 OF201** (Cheng et al. 2025, arXiv:2505.15806): a ≈ 824 AU (paper headline ~830 AU), e ≈ 0.945, q ≈ 45 AU, i ≈ 16.2°, dwarf-planet-sized (H ≈ 3.5).
- **Ammonite / 2023 KQ14** (Chen et al. 2025, arXiv:2508.02162): a ≈ 247 AU (paper ~252 AU), q ≈ 66 AU, i ≈ 11° — reported as the fourth, misaligned sednoid.

Both encoded as `Etno`-style entries from JPL SBDB osculating solutions (epoch JD 2461200.5, fetched 2026-06-14); provenance documented at each definition. The arXiv abstracts give only rounded headline numbers, so the angular elements ω, Ω needed for ϖ come from the matching JPL fits.

## Computed results (reusing `p9_core::analysis::circular`)
Longitude-of-perihelion ϖ clustering R̄ and small-n-corrected Rayleigh p:

| Sample | R̄ | Rayleigh p |
|---|---|---|
| baseline (BROWN_2017_SAMPLE, n=10) | 0.649 | 0.011 |
| + 2017 OF201 | 0.572 | 0.024 |
| + Ammonite | 0.522 | 0.047 |
| + both | 0.472 | 0.067 |

Each new object's ϖ is far from the baseline circular mean (~52°): OF201 offset ≈ 106°, Ammonite ≈ 141° (both > 60°). Adding either object lowers R̄ and raises p; adding both crosses p = 0.05 into non-significance.

Headline reference constants (830 AU; "fourth sednoid") kept labelled, not asserted as computed. Residuals documented in a test.

7 tests pass; `cargo fmt` clean.

Closes #60