### PR TITLE
Add OSSOS XV scattering/detached boundary and P9 perihelion lift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,6 +1296,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p9-2019-ossos-scattering"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "p9-core",
+ "rand 0.8.5",
+ "rand_distr",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "p9-2019-review"
 version = "0.1.0"
 dependencies = [
@@ -1325,9 +1337,11 @@ name = "p9-2021-orbit"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "nalgebra",
  "p9-core",
  "rand 0.8.5",
  "rand_distr",
+ "rayon",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/p9-2018-kuiper-belt",
     "crates/p9-2018-resonance",
     "crates/p9-2019-clustering",
+    "crates/p9-2019-ossos-scattering",
     "crates/p9-2019-review",
     "crates/p9-2021-oort-cloud",
     "crates/p9-2021-orbit",

--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -126,6 +126,42 @@ the P9 orientation angles (ϖ₉, Ω₉) profiled out of the KDE likelihood over
 rather than sampled as MCMC dimensions. The cluster-scattering Fréchet prior is not
 implemented (uniform prior only; needs the Batygin & Brown 2021b scattering suite).
 
+### 10. p9-2019-ossos-scattering — scattering/detached boundary and the P9 lift are analytic/secular, not N-body
+
+Kaib et al. (2019, OSSOS XV) constrain P9 with the observed actively-scattering TNO population.
+This crate reproduces the two pieces of physics from p9-core machinery rather than an N-body
+suite, with documented reductions:
+
+- **Scattering/detached boundary.** The divide is the Chirikov 2:j resonance-overlap criterion
+  from `p9_core::analysis::resonance` (K = 1 root, `critical_perihelion`). The honest output is
+  that the Neptune 2:j chain only overlaps (q_crit > 0) above a ≈ 226 AU; below that there is no
+  chaos at any q. q_crit(a) rises monotonically, passing the paper's q ≈ 37 AU scattering-disk
+  scale between a = 400 and 500 AU and continuing to climb (≈ 41 AU at 500, ≈ 53 AU at 800 AU).
+  The published "q ≈ 37 AU" is a single scattering-disk definition, not the a-dependent boundary;
+  it is kept as `published::SCATTERING_Q_BOUNDARY_AU` and used only as a scale cross-check.
+  Pinned: `crates/p9-2019-ossos-scattering/src/boundary.rs` (q_crit ≡ p9-core to 1e-12,
+  K(a, q_crit) = 1 to 1e-10, the 37 AU crossing between a = 400/500).
+
+- **P9 perihelion lifting.** Modelled as a coplanar test-particle secular cycle: the conserved
+  Hamiltonian is P9's numerical Gauss-ring term (`p9_core::analysis::secular`) plus the giants'
+  axisymmetric J2 precession term (`p9_core::forces::j2_secular::combined_j2_jsu`). The
+  single-perturber Gauss-ring Hamiltonian scales as GM₉, so its level-curve *amplitude* is
+  P9-mass-independent (a real property of linear secular theory — only the precession *rate*
+  scales with mass). To recover the OSSOS-relevant mass dependence the lift is **rate-limited**:
+  the secular eccentricity-forcing rate |de/dt| ∝ GM₉ (centred finite difference of ∂H/∂ϖ) drives
+  q up over a sculpting time, capped at the cycle amplitude. The baseline time
+  `SECULAR_SCULPTING_DAYS = 50 Myr` is a documented model choice (a coherent scattering episode
+  before a Neptune encounter resets the orbit), not a derived quantity; it places the nominal-P9
+  lift in the rate-limited (un-saturated) regime so the detached fraction responds monotonically
+  to P9's mass. At this scale a nominal 6.2 M⊕ P9 over-detaches the seeded large-a scattering
+  population (detached fraction → ~1.0 vs 0 with no P9), which is the qualitative OSSOS XV result:
+  such P9 configurations are disfavored because they would deplete the observed scattering
+  population. Not asserted as a quantitative reproduction — no published scalar exists for the
+  detached fraction at fixed time.
+  Pinned: `crates/p9-2019-ossos-scattering/src/planet_nine.rs` (rate ∝ GM₉ to 1e-6; lift > 0 for
+  real P9, ≈ 0 for none; heavier ≥ lighter), `src/population.rs` (P9 raises detached fraction by
+  a non-zero amount > 0.5; heavier P9 detaches ≥ as many).
+
 ---
 
 ## Agreements within tolerance (for completeness)

--- a/crates/p9-2019-ossos-scattering/Cargo.toml
+++ b/crates/p9-2019-ossos-scattering/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "p9-2019-ossos-scattering"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+p9-core = { path = "../p9-core" }
+rand = { workspace = true }
+rand_distr = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/p9-2019-ossos-scattering/src/boundary.rs
+++ b/crates/p9-2019-ossos-scattering/src/boundary.rs
@@ -1,0 +1,159 @@
+//! The scattering/detached divide in the (a, q) plane.
+//!
+//! An actively-scattering TNO has its perihelion deep enough in the Neptune
+//! region that the overlapping 2:j mean-motion resonances drive a chaotic
+//! random walk in semi-major axis (Kaib et al. 2019, OSSOS XV). As perihelion
+//! rises, the resonances cease to overlap and the object *detaches*: it stops
+//! exchanging energy with Neptune and freezes its semi-major axis.
+//!
+//! The divide is the Chirikov resonance-overlap criterion, sourced entirely
+//! from `p9_core::analysis::resonance`: an object at (a, q) is actively
+//! scattering iff the overlap parameter K(a, q) > 1, i.e. iff q < q_crit(a),
+//! the K = 1 root. We do not reimplement any of that machinery here; this
+//! module maps the boundary curve and classifies orbits with it.
+
+use p9_core::analysis::resonance::{chirikov_overlap_parameter, critical_perihelion, is_chaotic};
+
+/// Dynamical state of a TNO relative to the Neptune-scattering region.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DynamicalClass {
+    /// Resonances overlap (K > 1): Neptune-coupled chaotic random walk in a.
+    Scattering,
+    /// Resonances do not overlap (K < 1): semi-major axis frozen.
+    Detached,
+}
+
+/// Classify an orbit at semi-major axis `a_au` and perihelion `q_au`.
+///
+/// Thin wrapper over `p9_core::analysis::resonance::is_chaotic` — the single
+/// source of the overlap criterion.
+pub fn classify(a_au: f64, q_au: f64) -> DynamicalClass {
+    if is_chaotic(a_au, q_au) {
+        DynamicalClass::Scattering
+    } else {
+        DynamicalClass::Detached
+    }
+}
+
+/// The critical perihelion q_crit(a) (AU) separating scattering from detached
+/// at semi-major axis `a_au`. Re-exported from p9-core so callers map the
+/// boundary through the same root that `classify` uses.
+pub fn boundary_perihelion(a_au: f64) -> f64 {
+    critical_perihelion(a_au)
+}
+
+/// A point on the scattering/detached boundary curve.
+#[derive(Debug, Clone, Copy)]
+pub struct BoundaryPoint {
+    pub a_au: f64,
+    pub q_crit_au: f64,
+}
+
+/// Sample the scattering/detached boundary q_crit(a) on a logarithmic grid in
+/// semi-major axis from `a_min` to `a_max` (AU), `n` points inclusive.
+///
+/// Covers the OSSOS XV scattering range a ≈ 50–1000 AU. Points where
+/// q_crit = 0 (no chaos at any q) are still returned so the caller sees the
+/// full curve.
+pub fn boundary_curve(a_min: f64, a_max: f64, n: usize) -> Vec<BoundaryPoint> {
+    assert!(n >= 2 && a_min > 0.0 && a_max > a_min);
+    let log_lo = a_min.ln();
+    let log_hi = a_max.ln();
+    (0..n)
+        .map(|i| {
+            let a = (log_lo + (log_hi - log_lo) * i as f64 / (n as f64 - 1.0)).exp();
+            BoundaryPoint {
+                a_au: a,
+                q_crit_au: critical_perihelion(a),
+            }
+        })
+        .collect()
+}
+
+/// Overlap parameter K(a, q), re-exported for direct inspection of how deep
+/// into (or out of) the chaotic regime an orbit sits.
+pub fn overlap(a_au: f64, q_au: f64) -> f64 {
+    chirikov_overlap_parameter(a_au, q_au)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn boundary_matches_analytic_critical_perihelion() {
+        // q_crit(a) here must be exactly p9-core's analytic relation, and
+        // the overlap parameter must equal 1 there (cross-check at several a).
+        // The 2:j chain only overlaps (q_crit > 0) above a ~ 226 AU; below
+        // that the overlap argument < 1 and there is no chaos at any q.
+        for &a in &[250.0, 500.0, 1000.0] {
+            let q = boundary_perihelion(a);
+            assert!(q > 0.0, "expected nonzero q_crit at a = {a}");
+            assert_relative_eq!(q, critical_perihelion(a), epsilon = 1e-12);
+            assert_relative_eq!(overlap(a, q), 1.0, epsilon = 1e-10);
+        }
+        // Below the overlap threshold the boundary collapses to q_crit = 0.
+        assert_eq!(boundary_perihelion(100.0), 0.0);
+    }
+
+    #[test]
+    fn scattering_region_is_chaotic_detached_is_not() {
+        for &a in &[300.0, 500.0, 1000.0] {
+            let q = boundary_perihelion(a);
+            // Just below the boundary: scattering (chaotic).
+            assert_eq!(classify(a, q - 1.0), DynamicalClass::Scattering);
+            assert!(overlap(a, q - 1.0) > 1.0);
+            // Just above: detached (stable).
+            assert_eq!(classify(a, q + 1.0), DynamicalClass::Detached);
+            assert!(overlap(a, q + 1.0) < 1.0);
+        }
+    }
+
+    #[test]
+    fn boundary_scale_near_published_neptune_region() {
+        use crate::published::SCATTERING_Q_BOUNDARY_AU;
+        // OSSOS XV: the scattering population detaches near the Neptune region,
+        // q ~ 37 AU. The 2:j overlap boundary q_crit(a) rises monotonically
+        // through this scale; it crosses the published ~37 AU somewhere in the
+        // large-a scattering range and sits in the trans-Neptunian 30-60 AU
+        // band there. (q_crit keeps climbing past 37 at the largest a, which is
+        // the resolved physics, not a tuned cutoff.)
+        let q400 = boundary_perihelion(400.0);
+        let q500 = boundary_perihelion(500.0);
+        assert!(
+            q400 < SCATTERING_Q_BOUNDARY_AU && q500 > SCATTERING_Q_BOUNDARY_AU,
+            "published 37 AU should fall between q_crit(400)={q400} and q_crit(500)={q500}"
+        );
+        for &a in &[300.0, 500.0, 800.0] {
+            let q = boundary_perihelion(a);
+            assert!((20.0..60.0).contains(&q), "q_crit({a}) = {q}");
+        }
+    }
+
+    #[test]
+    fn critical_perihelion_rises_with_semi_major_axis() {
+        // Larger a => resonances are wider in the (a) direction relative to
+        // their spacing, so chaos persists to higher q.
+        let curve = boundary_curve(50.0, 1000.0, 40);
+        let nonzero: Vec<f64> = curve
+            .iter()
+            .filter(|p| p.q_crit_au > 0.0)
+            .map(|p| p.q_crit_au)
+            .collect();
+        // Roughly half the log-grid lies above the a ~ 226 AU overlap
+        // threshold where q_crit becomes nonzero.
+        assert!(nonzero.len() > 15, "only {} nonzero", nonzero.len());
+        for w in nonzero.windows(2) {
+            assert!(w[1] >= w[0] - 1e-9, "q_crit not monotone: {w:?}");
+        }
+    }
+
+    #[test]
+    fn boundary_curve_spans_requested_range() {
+        let curve = boundary_curve(50.0, 1000.0, 10);
+        assert_eq!(curve.len(), 10);
+        assert_relative_eq!(curve[0].a_au, 50.0, epsilon = 1e-9);
+        assert_relative_eq!(curve[9].a_au, 1000.0, epsilon = 1e-9);
+    }
+}

--- a/crates/p9-2019-ossos-scattering/src/lib.rs
+++ b/crates/p9-2019-ossos-scattering/src/lib.rs
@@ -1,0 +1,50 @@
+//! Reproduction of Kaib et al. (2019), "OSSOS XV: Probing the Distant Solar
+//! System with Observed Scattering TNOs" (arXiv:1905.09286).
+//!
+//! Headline: the observed actively-scattering TNO population — large
+//! semi-major axis objects whose perihelia lie near Neptune (q ≈ 30–38 AU) and
+//! which undergo a semimajor-axis random walk — constrains Planet Nine. A
+//! massive distant P9 lifts perihelia at large a (a secular effect) and so
+//! sculpts the scattering → detached transition; the properties of the
+//! observed scattering population (its a-distribution and the perihelion at
+//! which objects detach from Neptune) DISFAVOR some P9 configurations.
+//!
+//! What this crate computes, all from real (seeded) calculations reusing
+//! `p9_core`, with no hard-coded answers:
+//!
+//! - `boundary`: the scattering/detached divide in the (a, q) plane from the
+//!   Chirikov resonance-overlap criterion in `p9_core::analysis::resonance`
+//!   (overlap parameter K and the critical perihelion q_crit(a), the K = 1
+//!   root). Maps the boundary for a ≈ 50–1000 AU.
+//! - `planet_nine`: P9's secular perihelion lifting, from the numerical
+//!   Gauss-ring secular Hamiltonian in `p9_core::analysis::secular`.
+//! - `population`: a seeded synthetic scattering population and the detached
+//!   fraction with vs without P9 — the perihelion lift pushes a computed,
+//!   non-zero fraction across the divide.
+//!
+//! Documented model reductions (see `REPRODUCTION_NOTES.md`): the boundary is
+//! the analytic 2:j overlap criterion, not a fitted N-body diffusion map; the
+//! P9 lift is a coplanar test-particle secular cycle, capturing apsidal-driven
+//! perihelion raising but not Neptune's simultaneous a random walk or Kozai
+//! inclination coupling.
+
+pub mod boundary;
+pub mod planet_nine;
+pub mod population;
+
+/// Published reference values from Kaib et al. (2019) and the P9 literature,
+/// kept as labelled constants for cross-checks (never asserted as if computed).
+pub mod published {
+    /// Scattering/detached boundary scale: the observed scattering population
+    /// detaches with perihelia near the Neptune region, q ≈ 37 AU at the
+    /// relevant large semi-major axes (Kaib et al. 2019; the scattering disk
+    /// is conventionally defined out to q ≈ 37–38 AU). Used to sanity-check the
+    /// computed q_crit(a) scale.
+    pub const SCATTERING_Q_BOUNDARY_AU: f64 = 37.0;
+
+    /// Qualitative constraint: a sufficiently massive, distant P9 over-detaches
+    /// the large-a scattering population relative to what OSSOS observes, which
+    /// is the basis for disfavoring some P9 configurations. There is no single
+    /// published scalar for this; recorded as a flag for documentation.
+    pub const P9_DISFAVORS_OVER_DETACHMENT: bool = true;
+}

--- a/crates/p9-2019-ossos-scattering/src/planet_nine.rs
+++ b/crates/p9-2019-ossos-scattering/src/planet_nine.rs
@@ -1,0 +1,329 @@
+//! Planet Nine's secular perihelion lifting.
+//!
+//! A distant, massive, eccentric P9 exerts a secular (orbit-averaged) torque
+//! on a scattering TNO. Because the TNO's semi-major axis is (between Neptune
+//! encounters) fixed, the secular dynamics conserve the doubly-averaged
+//! Hamiltonian H(e, Δϖ); the angular momentum and hence the perihelion
+//! q = a(1−e) oscillate. The relevant effect for OSSOS XV is that P9 *lifts*
+//! perihelion at large a, pushing objects across the scattering/detached
+//! divide and depleting the high-a scattering population.
+//!
+//! We do not invent the secular field: the Hamiltonian is the numerical
+//! Gauss-ring average `p9_core::analysis::secular::numerical_secular_hamiltonian`
+//! (the multipole expansion does not converge for the α = a/a₉ of this
+//! problem), plus the giants' axisymmetric J2 precession term from
+//! `p9_core::forces::j2_secular`.
+//!
+//! Two quantities are exposed:
+//!  - `max_perihelion`: the cycle *amplitude* — the highest q reachable on the
+//!    conserved level curve H(e, Δϖ) at fixed a (a Δϖ scan, restricted to the
+//!    high-e branch where scattering TNOs live).
+//!  - `forcing_rate` / `perihelion_lift`: the secular eccentricity-forcing
+//!    rate |de/dt| ∝ GM₉ (from ∂H/∂ϖ), integrated over a sculpting time and
+//!    capped at the amplitude. Because the single-perturber Gauss-ring
+//!    Hamiltonian scales as GM₉, its level-curve amplitude is P9-mass-
+//!    independent (a real feature of linear secular theory); the OSSOS-relevant
+//!    mass dependence enters through the *rate*, hence the rate-limited lift.
+//!
+//! This is a coplanar, test-particle, secular model: it captures apsidal-driven
+//! perihelion raising (the mechanism Kaib et al. invoke for the
+//! scattering→detached transition) but not Neptune's simultaneous random walk
+//! in a, nor the Kozai inclination coupling. Documented as such (see
+//! `REPRODUCTION_NOTES.md`).
+
+use p9_core::analysis::secular::numerical_secular_hamiltonian;
+use p9_core::constants::{EARTH_MASS_SOLAR, GM_SUN, TWO_PI};
+use p9_core::forces::j2_secular::combined_j2_jsu;
+
+/// Planet Nine orbital/mass parameters. Defaults are the Batygin & Brown
+/// (2021) nominal P9: 6.2 M⊕, a₉ = 380 AU, e₉ = 0.2.
+#[derive(Debug, Clone, Copy)]
+pub struct PlanetNine {
+    /// Mass in Earth masses.
+    pub mass_earth: f64,
+    /// Semi-major axis (AU).
+    pub a_au: f64,
+    /// Eccentricity.
+    pub e: f64,
+}
+
+impl Default for PlanetNine {
+    fn default() -> Self {
+        // Batygin & Brown (2021) nominal P9.
+        PlanetNine {
+            mass_earth: 6.2,
+            a_au: 380.0,
+            e: 0.2,
+        }
+    }
+}
+
+impl PlanetNine {
+    /// Heliocentric gravitational parameter GM₉ (AU³/day²).
+    pub fn gm(&self) -> f64 {
+        self.mass_earth * EARTH_MASS_SOLAR * GM_SUN
+    }
+}
+
+/// Number of apsidal-angle samples used to trace a secular level curve.
+const N_DVARPI: usize = 48;
+/// Quadrature nodes per mean anomaly in the Gauss-ring average. 48 is enough
+/// for the smooth (non-crossing) interior-particle geometry here and keeps the
+/// population sweep affordable (N_DVARPI · n² evaluations per object).
+const N_QUAD: usize = 48;
+
+/// Coplanar secular (orbit-averaged J2) energy of a test particle in the
+/// combined Jupiter+Saturn+Uranus quadrupole field (AU²/day²):
+///
+///   H_J2(a, e) = −(GM_sun / 2a) · J2_eff · (R_ref / a)² · (1 − e²)^{−3/2}
+///
+/// with `J2_eff` and `R_ref = 1 AU` the effective coefficients from
+/// `p9_core::forces::j2_secular::combined_j2_jsu`. This axisymmetric term
+/// drives the inner giants' apsidal precession; it depends on (a, e) only (no
+/// Δϖ), so it does *not* by itself change e — but added to P9's
+/// Δϖ-dependent torque it sets the competition that makes the P9 lift depend
+/// on P9's mass and distance. Without it the pure single-perturber secular
+/// Hamiltonian scales as GM₉ and its level curves (hence the e-excursion) are
+/// independent of P9's mass, which is unphysical for OSSOS XV.
+fn giants_secular_energy(a_au: f64) -> impl Fn(f64) -> f64 {
+    let (j2_eff, _j4, _gm) = combined_j2_jsu();
+    let r_ref = 1.0_f64;
+    let coef = -(GM_SUN / (2.0 * a_au)) * j2_eff * (r_ref / a_au).powi(2);
+    move |e: f64| coef * (1.0 - e * e).powf(-1.5)
+}
+
+/// E below which a scattering TNO would sit on the low-e branch of the
+/// Gauss-ring Hamiltonian; the scattering population is always above this.
+const E_BRANCH_MIN: f64 = 0.7;
+
+/// Maximum perihelion (AU) the secular cycle can reach: the largest q on the
+/// conserved level curve H(e, Δϖ) = H(e₀, Δϖ₀) at fixed a, the *amplitude* of
+/// the perihelion oscillation regardless of how long the cycle takes.
+///
+/// The conserved Hamiltonian is P9's Δϖ-dependent torque
+/// (`p9_core::analysis::secular::numerical_secular_hamiltonian`, softened by
+/// 1% of a₉ as `phase_portrait` does) plus the giants' axisymmetric J2 term
+/// (`giants_secular_energy`). The Gauss-ring H(e) is non-monotone (it peaks in
+/// magnitude near e ≈ 0.5); scattering TNOs live on the high-e branch
+/// (e ≳ 0.9), where H is monotone, so the level-set search is restricted to
+/// e ≥ `E_BRANCH_MIN` — both the physics and a guard against spurious low-e
+/// roots past the peak.
+pub fn max_perihelion(p9: &PlanetNine, a_au: f64, q0_au: f64, dvarpi0: f64) -> f64 {
+    let e0 = 1.0 - q0_au / a_au;
+    let gm = p9.gm();
+    let soft = 0.01 * p9.a_au;
+    if e0 <= E_BRANCH_MIN {
+        return q0_au;
+    }
+    let h_giants = giants_secular_energy(a_au);
+    let h_total = |e: f64, dv: f64| {
+        numerical_secular_hamiltonian(a_au, e, 0.0, dv, 0.0, p9.a_au, p9.e, gm, N_QUAD, soft)
+            + h_giants(e)
+    };
+    let h0 = h_total(e0, dvarpi0);
+
+    let mut e_min = e0;
+    for j in 0..N_DVARPI {
+        let dv = j as f64 / N_DVARPI as f64 * TWO_PI;
+        let h_at = |e: f64| h_total(e, dv);
+        let h_lo = h_at(E_BRANCH_MIN);
+        let h_hi = h_at(e0);
+        if (h0 - h_lo) * (h0 - h_hi) <= 0.0 {
+            let (mut lo, mut hi) = (E_BRANCH_MIN, e0);
+            for _ in 0..40 {
+                let mid = 0.5 * (lo + hi);
+                let hm = h_at(mid);
+                if (hm - h0) * (h_hi - h0) <= 0.0 {
+                    lo = mid;
+                } else {
+                    hi = mid;
+                }
+            }
+            e_min = e_min.min(0.5 * (lo + hi));
+        }
+    }
+    a_au * (1.0 - e_min)
+}
+
+/// Magnitude of P9's secular eccentricity-forcing rate |de/dt| (per day) for a
+/// coplanar TNO at (a, q), evaluated at the apsidal phase of strongest torque.
+///
+/// From the orbit-averaged Lagrange planetary equation
+///   de/dt = −(√(1−e²) / (n a² e)) ∂H/∂ϖ ,
+/// with n the TNO mean motion and ∂H/∂ϖ taken from a centred finite difference
+/// of P9's Gauss-ring Hamiltonian (the giants' term is axisymmetric and drops
+/// out). This rate is ∝ GM₉, so a heavier / closer P9 drives the perihelion up
+/// faster — the lever the OSSOS XV constraint pulls on.
+pub fn forcing_rate(p9: &PlanetNine, a_au: f64, q0_au: f64) -> f64 {
+    let e0 = 1.0 - q0_au / a_au;
+    if e0 <= E_BRANCH_MIN || e0 <= 0.0 {
+        return 0.0;
+    }
+    let gm = p9.gm();
+    let soft = 0.01 * p9.a_au;
+    let n = (GM_SUN / a_au.powi(3)).sqrt(); // mean motion (rad/day)
+    let dphi = 1e-3;
+    // Maximum |∂H/∂ϖ| over apsidal phase (the strongest-torque phase).
+    let mut max_dh = 0.0_f64;
+    for j in 0..N_DVARPI {
+        let dv = j as f64 / N_DVARPI as f64 * TWO_PI;
+        let hp = numerical_secular_hamiltonian(
+            a_au,
+            e0,
+            0.0,
+            dv + dphi,
+            0.0,
+            p9.a_au,
+            p9.e,
+            gm,
+            N_QUAD,
+            soft,
+        );
+        let hm = numerical_secular_hamiltonian(
+            a_au,
+            e0,
+            0.0,
+            dv - dphi,
+            0.0,
+            p9.a_au,
+            p9.e,
+            gm,
+            N_QUAD,
+            soft,
+        );
+        let dh = (hp - hm) / (2.0 * dphi);
+        max_dh = max_dh.max(dh.abs());
+    }
+    (1.0 - e0 * e0).sqrt() / (n * a_au * a_au * e0) * max_dh
+}
+
+/// The perihelion lift Δq (AU) a TNO accumulates over `time_days` of secular
+/// evolution under P9, capped at the secular-cycle amplitude.
+///
+/// The eccentricity drifts at `forcing_rate` (∝ GM₉) toward lower e (higher q);
+/// over a time T the lift is a·|de/dt|·T, but it cannot exceed the conserved
+/// cycle's reachable maximum (`max_perihelion`, averaged over starting apsidal
+/// phase). The two together give the correct limits: a heavier P9 reaches the
+/// cap sooner (so detaches more within a fixed cluster age), while no P9 gives
+/// zero rate and zero lift.
+pub fn perihelion_lift(p9: &PlanetNine, a_au: f64, q0_au: f64, time_days: f64) -> f64 {
+    let rate = forcing_rate(p9, a_au, q0_au); // |de/dt|, per day
+    let dq_rate = a_au * rate * time_days;
+
+    // Cycle-amplitude cap, averaged over starting apsidal phase.
+    const N_PHASE: usize = 8;
+    let mut cap = 0.0;
+    for k in 0..N_PHASE {
+        let dv0 = k as f64 / N_PHASE as f64 * TWO_PI;
+        cap += (max_perihelion(p9, a_au, q0_au, dv0) - q0_au).max(0.0);
+    }
+    cap /= N_PHASE as f64;
+
+    dq_rate.min(cap).max(0.0)
+}
+
+/// Baseline secular-sculpting time used by the population detachment test
+/// (50 Myr). This is the duration of a scattering episode over which P9's
+/// secular torque acts coherently before a Neptune encounter resets the orbit;
+/// it is short enough that the perihelion lift is in the rate-limited regime
+/// (∝ GM₉) rather than saturated at the cycle-amplitude cap, so the detached
+/// fraction responds monotonically to P9's mass. Documented as a model choice,
+/// not a derived quantity (see `REPRODUCTION_NOTES.md`).
+pub const SECULAR_SCULPTING_DAYS: f64 = 50.0e6 * 365.25;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn gm_scales_with_mass() {
+        let small = PlanetNine {
+            mass_earth: 5.0,
+            ..Default::default()
+        };
+        let big = PlanetNine {
+            mass_earth: 10.0,
+            ..Default::default()
+        };
+        assert_relative_eq!(big.gm() / small.gm(), 2.0, epsilon = 1e-12);
+        // Sanity: 6.2 M⊕ in solar masses times GM_SUN.
+        let nominal = PlanetNine::default();
+        assert_relative_eq!(
+            nominal.gm(),
+            6.2 * EARTH_MASS_SOLAR * GM_SUN,
+            epsilon = 1e-18
+        );
+    }
+
+    #[test]
+    fn lift_is_non_negative_and_bounded() {
+        let p9 = PlanetNine::default();
+        let dq = perihelion_lift(&p9, 600.0, 35.0, SECULAR_SCULPTING_DAYS);
+        assert!(dq >= 0.0, "lift {dq}");
+        // A secular cycle cannot raise q above a (e cannot go negative), and
+        // the lift never exceeds the cycle-amplitude cap.
+        assert!(35.0 + dq <= 600.0);
+    }
+
+    #[test]
+    fn forcing_rate_scales_with_p9_mass() {
+        // The secular eccentricity-forcing rate is linear in GM₉ -> doubling
+        // the mass doubles the rate (the lever the OSSOS XV constraint pulls).
+        let a = 500.0;
+        let q0 = 35.0;
+        let m1 = PlanetNine {
+            mass_earth: 5.0,
+            ..Default::default()
+        };
+        let m2 = PlanetNine {
+            mass_earth: 10.0,
+            ..Default::default()
+        };
+        let r1 = forcing_rate(&m1, a, q0);
+        let r2 = forcing_rate(&m2, a, q0);
+        assert!(r1 > 0.0);
+        assert_relative_eq!(r2 / r1, 2.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn massive_p9_lifts_more_than_no_p9() {
+        // With essentially no perturber the secular torque -> 0 -> no lift.
+        let none = PlanetNine {
+            mass_earth: 1e-6,
+            ..Default::default()
+        };
+        let real = PlanetNine::default();
+        let q0 = 35.0;
+        let a = 600.0;
+        let t = SECULAR_SCULPTING_DAYS;
+        let dq_none = perihelion_lift(&none, a, q0, t);
+        let dq_real = perihelion_lift(&real, a, q0, t);
+        assert!(dq_none < 0.5, "negligible perturber lift {dq_none}");
+        assert!(
+            dq_real > dq_none + 1.0,
+            "real P9 lift {dq_real} should exceed null {dq_none}"
+        );
+    }
+
+    #[test]
+    fn heavier_p9_lifts_at_least_as_much() {
+        // In the rate-limited regime a heavier P9 raises perihelion further
+        // within the same sculpting time.
+        let a = 500.0;
+        let q0 = 36.0;
+        let t = SECULAR_SCULPTING_DAYS;
+        let light = PlanetNine {
+            mass_earth: 2.0,
+            ..Default::default()
+        };
+        let heavy = PlanetNine {
+            mass_earth: 8.0,
+            ..Default::default()
+        };
+        let dl = perihelion_lift(&light, a, q0, t);
+        let dh = perihelion_lift(&heavy, a, q0, t);
+        assert!(dh >= dl, "heavier P9 lift {dh} >= lighter {dl}");
+        assert!(dl > 0.0, "even a light P9 should lift somewhat: {dl}");
+    }
+}

--- a/crates/p9-2019-ossos-scattering/src/population.rs
+++ b/crates/p9-2019-ossos-scattering/src/population.rs
@@ -1,0 +1,190 @@
+//! Synthetic actively-scattering TNO population and the P9 detachment test.
+//!
+//! Kaib et al. (2019) constrain P9 with the *observed* scattering population:
+//! large-a objects with perihelia near Neptune (q ≈ 30–38 AU) undergoing a
+//! semimajor-axis random walk. The high-q edge of that population — the q at
+//! which objects stop scattering and detach — is the diagnostic. A massive
+//! distant P9 lifts perihelia secularly (`planet_nine`), pushing a fraction of
+//! the scattering objects above the resonance-overlap divide (`boundary`) and
+//! into the detached class, raising the detached fraction.
+//!
+//! Here we draw a seeded synthetic scattering population, evolve each object's
+//! perihelion under the secular P9 lift, and measure the detached fraction
+//! with and without P9. The increase is computed, non-zero, and reproducible.
+
+use crate::boundary::{classify, DynamicalClass};
+use crate::planet_nine::{perihelion_lift, PlanetNine};
+use p9_core::constants::A_NEPTUNE_AU;
+use rand::SeedableRng;
+use rand_distr::{Distribution, Uniform};
+
+/// One synthetic scattering TNO.
+#[derive(Debug, Clone, Copy)]
+pub struct ScatteringTno {
+    pub a_au: f64,
+    pub q_au: f64,
+}
+
+/// Draw `n` synthetic actively-scattering TNOs (seeded).
+///
+/// Semi-major axes are log-uniform over [`a_min`, `a_max`] (the survey detects
+/// objects across decades in a); perihelia are uniform over the Neptune-coupled
+/// band q ∈ [q_lo, q_hi] with q_lo just outside Neptune's orbit. We then keep
+/// only objects that are actually scattering at draw time (q < q_crit(a)), so
+/// the sample is, by construction, the actively-scattering population the
+/// paper studies.
+pub fn synthetic_scattering_population(
+    seed: u64,
+    n: usize,
+    a_min: f64,
+    a_max: f64,
+    q_lo: f64,
+    q_hi: f64,
+) -> Vec<ScatteringTno> {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    let log_a = Uniform::new(a_min.ln(), a_max.ln());
+    let q_dist = Uniform::new(q_lo, q_hi);
+
+    let mut out = Vec::with_capacity(n);
+    // Oversample then filter to the scattering class to reach n members.
+    while out.len() < n {
+        let a = log_a.sample(&mut rng).exp();
+        let q = q_dist.sample(&mut rng);
+        if q <= A_NEPTUNE_AU {
+            continue; // inside Neptune: not a scattering-disk object
+        }
+        if classify(a, q) == DynamicalClass::Scattering {
+            out.push(ScatteringTno { a_au: a, q_au: q });
+        }
+    }
+    out
+}
+
+/// Result of the detachment comparison.
+#[derive(Debug, Clone, Copy)]
+pub struct DetachmentResult {
+    /// Detached fraction with no Planet Nine (control).
+    pub detached_fraction_no_p9: f64,
+    /// Detached fraction after applying the P9 secular perihelion lift.
+    pub detached_fraction_with_p9: f64,
+    /// Number of objects in the population.
+    pub n: usize,
+}
+
+impl DetachmentResult {
+    /// The increase in detached fraction attributable to P9.
+    pub fn delta(&self) -> f64 {
+        self.detached_fraction_with_p9 - self.detached_fraction_no_p9
+    }
+}
+
+/// For each object, raise perihelion by the secular P9 lift accumulated over
+/// `time_days` and re-classify. Returns the detached fraction with and without
+/// P9.
+pub fn detached_fraction_comparison(
+    p9: &PlanetNine,
+    population: &[ScatteringTno],
+    time_days: f64,
+) -> DetachmentResult {
+    let n = population.len();
+    assert!(n > 0);
+
+    // Without P9 the population is, by construction, fully scattering: 0
+    // detached. We still compute it so the comparison is symmetric and would
+    // catch any boundary inconsistency.
+    let detached_no = population
+        .iter()
+        .filter(|t| classify(t.a_au, t.q_au) == DynamicalClass::Detached)
+        .count();
+
+    let detached_with = population
+        .iter()
+        .filter(|t| {
+            let dq = perihelion_lift(p9, t.a_au, t.q_au, time_days);
+            classify(t.a_au, t.q_au + dq) == DynamicalClass::Detached
+        })
+        .count();
+
+    DetachmentResult {
+        detached_fraction_no_p9: detached_no as f64 / n as f64,
+        detached_fraction_with_p9: detached_with as f64 / n as f64,
+        n,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::planet_nine::SECULAR_SCULPTING_DAYS;
+
+    fn standard_population() -> Vec<ScatteringTno> {
+        // Large-a scattering disk: a 150-900 AU, q in the Neptune-coupled band.
+        synthetic_scattering_population(1905, 300, 150.0, 900.0, 31.0, 40.0)
+    }
+
+    #[test]
+    fn synthetic_population_is_all_scattering() {
+        let pop = standard_population();
+        assert_eq!(pop.len(), 300);
+        for t in &pop {
+            assert_eq!(classify(t.a_au, t.q_au), DynamicalClass::Scattering);
+            assert!(t.q_au > A_NEPTUNE_AU);
+        }
+    }
+
+    #[test]
+    fn population_is_reproducible() {
+        let a = standard_population();
+        let b = standard_population();
+        assert_eq!(a.len(), b.len());
+        for (x, y) in a.iter().zip(b.iter()) {
+            assert_eq!(x.a_au, y.a_au);
+            assert_eq!(x.q_au, y.q_au);
+        }
+    }
+
+    #[test]
+    fn p9_raises_detached_fraction_by_nonzero_amount() {
+        let pop = standard_population();
+        let p9 = PlanetNine::default();
+        let res = detached_fraction_comparison(&p9, &pop, SECULAR_SCULPTING_DAYS);
+        // Control population is fully scattering.
+        assert_eq!(res.detached_fraction_no_p9, 0.0);
+        // P9 lifts perihelia -> a non-zero fraction detaches.
+        assert!(
+            res.delta() > 0.0,
+            "P9 should raise detached fraction; delta = {}",
+            res.delta()
+        );
+        assert!(res.detached_fraction_with_p9 <= 1.0);
+        // OSSOS XV: a nominal P9 over-detaches the large-a scattering
+        // population, the basis for disfavoring such configurations.
+        assert!(
+            res.detached_fraction_with_p9 > 0.5,
+            "nominal P9 should strongly deplete the scattering population: {}",
+            res.detached_fraction_with_p9
+        );
+    }
+
+    #[test]
+    fn more_massive_p9_detaches_at_least_as_many() {
+        let pop = standard_population();
+        let light = PlanetNine {
+            mass_earth: 2.0,
+            ..Default::default()
+        };
+        let heavy = PlanetNine {
+            mass_earth: 6.0,
+            ..Default::default()
+        };
+        let dl = detached_fraction_comparison(&light, &pop, SECULAR_SCULPTING_DAYS)
+            .detached_fraction_with_p9;
+        let dh = detached_fraction_comparison(&heavy, &pop, SECULAR_SCULPTING_DAYS)
+            .detached_fraction_with_p9;
+        assert!(
+            dh >= dl,
+            "heavier P9 should detach >= as many: light {dl} heavy {dh}"
+        );
+        assert!(dl > 0.0, "even a light P9 should detach some: {dl}");
+    }
+}


### PR DESCRIPTION
Reproduces Kaib et al. 2019, "OSSOS XV: Probing the Distant Solar System with Observed Scattering TNOs" (arXiv:1905.09286).

New crate `p9-2019-ossos-scattering`, reusing `p9-core` machinery (no duplicated resonance/secular code):

- `boundary`: the scattering/detached divide in the (a, q) plane from the Chirikov resonance-overlap criterion in `p9_core::analysis::resonance` (overlap parameter K, critical perihelion q_crit(a) as the K=1 root). The honest result: the Neptune 2:j chain only overlaps (q_crit > 0) above a ~ 226 AU; q_crit rises monotonically and crosses the paper's q ~ 37 AU scattering-disk scale between a = 400 and 500 AU.
- `planet_nine`: P9's secular perihelion lifting. Conserved Hamiltonian is P9's numerical Gauss-ring term (`p9_core::analysis::secular`) plus the giants' axisymmetric J2 precession (`p9_core::forces::j2_secular`). Because the single-perturber Gauss-ring Hamiltonian scales as GM9, its cycle amplitude is P9-mass-independent (a real feature of linear secular theory); the OSSOS-relevant mass dependence enters through the eccentricity-forcing rate |de/dt| proportional to GM9, so the lift is rate-limited over a documented 50 Myr sculpting time.
- `population`: a seeded synthetic actively-scattering population; the P9 lift pushes a computed, non-zero fraction across the divide. A nominal 6.2 M-earth P9 over-detaches the large-a scattering population (detached fraction ~1.0 vs 0 with no P9) - the qualitative OSSOS XV result that disfavors such configurations.

Pinned tests cross-check q_crit against the analytic p9-core relation at several a, confirm the scattering region is chaotic and detached is not, the rate scales as GM9, and adding P9 raises the detached fraction by a non-zero, mass-monotone amount. Residuals and model reductions documented in REPRODUCTION_NOTES.md (entry 10).

cargo build / cargo test (14 pass) / cargo fmt all green.

Closes #59