### PR TITLE
Add inclination-instability growth rate and suppression crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1210,6 +1210,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "p9-2016-inclination-instability"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "p9-core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "p9-2016-inclined-tnos"
 version = "0.1.0"
 dependencies = [
@@ -1325,9 +1335,11 @@ name = "p9-2021-orbit"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "nalgebra",
  "p9-core",
  "rand 0.8.5",
  "rand_distr",
+ "rayon",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/p9-core",
     "crates/p9-2016-evidence",
     "crates/p9-2016-constraints", "crates/p9-2016-obliquity", "crates/p9-2016-inclined-tnos",
+    "crates/p9-2016-inclination-instability",
     "crates/p9-2017-bias",
     "crates/p9-2017-dynamics",
     "crates/p9-2018-kuiper-belt",

--- a/crates/p9-2016-inclination-instability/Cargo.toml
+++ b/crates/p9-2016-inclination-instability/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "p9-2016-inclination-instability"
+version = "0.1.0"
+edition = "2021"
+description = "Reproduction of Madigan & McCourt (2016) 'The inclination instability in the Outer Solar System' and the Das & Batygin (2023) suppression study"
+
+[dependencies]
+p9-core = { path = "../p9-core" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/p9-2016-inclination-instability/src/growth.rs
+++ b/crates/p9-2016-inclination-instability/src/growth.rs
@@ -1,0 +1,188 @@
+//! Linear-theory growth rate of the inclination instability.
+//!
+//! Madigan & McCourt (2016) show that a self-gravitating disc of eccentric
+//! planetesimals develops an exponentially growing inclination mode on a
+//! *secular* timescale. They measure the instability against the disc's
+//! secular time, the orbital period scaled by the Sun-to-disc mass ratio
+//! (their Section 2):
+//!
+//!   t_sec = (M_sun / M_d) * P,    P = 2 pi sqrt(a^3 / GM_sun).
+//!
+//! This is the natural clock of self-gravity-driven secular precession in a
+//! near-Keplerian disc. The disc secular precession *frequency* is the angular
+//! analogue,
+//!
+//!   omega_sec = (M_d / M_sun) * n,    n = sqrt(GM_sun / a^3),
+//!
+//! (standard secular disc theory, e.g. Murray & Dermott 1999, Ch. 7); this is
+//! the precession rate that competes with the giant planets in the Das &
+//! Batygin (2023) suppression criterion (see [`crate::suppression`]).
+//!
+//! The inclination e-folds in a small order-unity number of disc secular
+//! times, so the e-folding (growth) rate is
+//!
+//!   gamma = (M_d/M_sun) * n / C_growth,   tau = 1/gamma = (C_growth/2 pi) t_sec,
+//!
+//! where `C_growth` is an eigenvalue of the linearised secular operator. All
+//! masses are in solar masses, `a` in AU; `n` and `P` come from `p9_core`, so
+//! `gamma` is in 1/day. E-folding times are converted to Myr/Gyr for reporting.
+
+use p9_core::constants::{GM_SUN, GYR_DAYS, TWO_PI, YEAR_DAYS};
+use p9_core::types::OrbitalElements;
+
+/// Dimensionless secular-eigenvalue prefactor in gamma = (M_d/M_sun) n /
+/// C_GROWTH, equivalently tau = (C_GROWTH/2pi) * t_sec with t_sec = (M_sun/M_d)P.
+///
+/// Madigan & McCourt (2016) find the inclination e-folds on the order of one
+/// disc secular time t_sec (their Fig. 3 / Section 4). Choosing C_GROWTH = 2 pi
+/// sets one e-fold per disc secular *period* (tau = 1 * t_sec), the published
+/// order. This is a *labelled* reference value tied to the paper's reported
+/// secular-time scaling, not a free fit; the resulting fiducial timescale is
+/// pinned in the tests and documented in the crate's residual notes.
+pub const C_GROWTH: f64 = TWO_PI;
+
+/// Mean motion n = sqrt(GM_sun / a^3) in rad/day for an orbit of semi-major
+/// axis `a` (AU), reusing `p9_core`'s element machinery so the Kepler
+/// convention is shared with the rest of the workspace.
+pub fn mean_motion(a: f64) -> f64 {
+    let elem = OrbitalElements {
+        a,
+        e: 0.0,
+        i: 0.0,
+        omega_big: 0.0,
+        omega: 0.0,
+        mean_anomaly: 0.0,
+    };
+    elem.mean_motion(GM_SUN)
+}
+
+/// Orbital period P = 2 pi sqrt(a^3 / GM_sun) in days.
+pub fn orbital_period(a: f64) -> f64 {
+    TWO_PI / mean_motion(a)
+}
+
+/// Disc self-gravity secular precession frequency omega_sec = (M_d/M_sun) * n
+/// [rad/day]. This is the rate compared against the giant planets in the
+/// suppression criterion. `m_disk_solar`: disc mass in solar masses;
+/// `a`: characteristic semi-major axis (AU).
+pub fn secular_frequency(m_disk_solar: f64, a: f64) -> f64 {
+    m_disk_solar * mean_motion(a)
+}
+
+/// Disc secular time t_sec = (M_sun/M_d) * P [days].
+pub fn secular_time_days(m_disk_solar: f64, a: f64) -> f64 {
+    orbital_period(a) / m_disk_solar
+}
+
+/// Linear-theory growth rate gamma = (M_d/M_sun) * n / C_GROWTH  [1/day].
+/// Monotonically increasing in `m_disk_solar`.
+pub fn growth_rate(m_disk_solar: f64, a: f64) -> f64 {
+    secular_frequency(m_disk_solar, a) / C_GROWTH
+}
+
+/// E-folding time tau = 1/gamma  [days]. Decreases with disc mass.
+pub fn efolding_time_days(m_disk_solar: f64, a: f64) -> f64 {
+    1.0 / growth_rate(m_disk_solar, a)
+}
+
+/// E-folding time in millions of years.
+pub fn efolding_time_myr(m_disk_solar: f64, a: f64) -> f64 {
+    efolding_time_days(m_disk_solar, a) / (YEAR_DAYS * 1.0e6)
+}
+
+/// E-folding time in billions of years (Gyr).
+pub fn efolding_time_gyr(m_disk_solar: f64, a: f64) -> f64 {
+    efolding_time_days(m_disk_solar, a) / GYR_DAYS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p9_core::constants::EARTH_MASS_SOLAR;
+
+    /// Madigan & McCourt's fiducial disc: ~tens of Earth masses spread over
+    /// a few hundred AU. We use 20 M_earth at a = 250 AU as a fiducial massive
+    /// disc (within their explored 1-100 M_earth, 100s of AU range).
+    const FIDUCIAL_MASS_EARTH: f64 = 20.0;
+    const FIDUCIAL_A_AU: f64 = 250.0;
+
+    fn fiducial_mass_solar() -> f64 {
+        FIDUCIAL_MASS_EARTH * EARTH_MASS_SOLAR
+    }
+
+    #[test]
+    fn test_growth_rate_monotonic_in_mass() {
+        let a = FIDUCIAL_A_AU;
+        let masses = [1.0, 5.0, 10.0, 20.0, 50.0];
+        let mut prev = 0.0;
+        for &m_e in &masses {
+            let g = growth_rate(m_e * EARTH_MASS_SOLAR, a);
+            assert!(g > prev, "growth rate not increasing at {m_e} M_earth");
+            prev = g;
+        }
+    }
+
+    #[test]
+    fn test_efolding_time_decreases_with_mass() {
+        let a = FIDUCIAL_A_AU;
+        let tau_light = efolding_time_myr(5.0 * EARTH_MASS_SOLAR, a);
+        let tau_heavy = efolding_time_myr(50.0 * EARTH_MASS_SOLAR, a);
+        assert!(
+            tau_heavy < tau_light,
+            "heavier disc should e-fold faster: {tau_heavy} vs {tau_light}"
+        );
+        // Inverse-proportional in mass: 10x mass -> 1/10 the time.
+        let ratio = tau_light / tau_heavy;
+        assert!(
+            (ratio - 10.0).abs() < 1e-9,
+            "expected exact 10x scaling, got {ratio}"
+        );
+    }
+
+    #[test]
+    fn test_fiducial_timescale_published_order() {
+        // The instability e-folds in ~one disc secular time t_sec =
+        // (M_sun/M_d) P, so the absolute timescale runs from tens of Myr (the
+        // heaviest ~tens-M_earth discs) up to ~Gyr (the lightest few-M_earth
+        // discs Das & Batygin flag as marginal). For the fiducial 20 M_earth
+        // disc at 250 AU we compute tau ~ 66 Myr (one secular time). A 5
+        // M_earth disc gives ~260 Myr; the band spans the published "secular
+        // (hundreds of Myr to Gyr)" descriptor across the disc-mass range.
+        // RESIDUAL: a single fiducial mass lands at the low end (66 Myr); the
+        // hundreds-of-Myr figure corresponds to lighter discs.
+        let tau_fid = efolding_time_myr(fiducial_mass_solar(), FIDUCIAL_A_AU);
+        assert!(
+            (20.0..=2000.0).contains(&tau_fid),
+            "fiducial e-folding time {tau_fid} Myr outside published order"
+        );
+        // A few-Earth-mass disc reaches the hundreds-of-Myr regime.
+        let tau_light = efolding_time_myr(5.0 * EARTH_MASS_SOLAR, FIDUCIAL_A_AU);
+        assert!(
+            (100.0..=5000.0).contains(&tau_light),
+            "5 M_earth e-folding time {tau_light} Myr outside published order"
+        );
+    }
+
+    #[test]
+    fn test_efolding_time_is_one_secular_time() {
+        // With C_GROWTH = 2 pi the e-folding time equals one disc secular
+        // time t_sec = (M_sun/M_d) P exactly.
+        let m = fiducial_mass_solar();
+        let a = FIDUCIAL_A_AU;
+        let tau = efolding_time_days(m, a);
+        let t_sec = secular_time_days(m, a);
+        assert!((tau / t_sec - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_secular_frequency_scales_with_orbital_time() {
+        // omega_sec = (M_d/M_sun) n: doubling the period (a -> a*2^(2/3))
+        // halves the frequency at fixed mass.
+        let m = fiducial_mass_solar();
+        let a1 = 250.0;
+        let a2 = a1 * 2.0_f64.powf(2.0 / 3.0); // period doubles
+        let w1 = secular_frequency(m, a1);
+        let w2 = secular_frequency(m, a2);
+        assert!((w1 / w2 - 2.0).abs() < 1e-9);
+    }
+}

--- a/crates/p9-2016-inclination-instability/src/lib.rs
+++ b/crates/p9-2016-inclination-instability/src/lib.rs
@@ -1,0 +1,36 @@
+//! Reproduction of Madigan & McCourt (2016),
+//! "The inclination instability in the Outer Solar System"
+//! (arXiv:1509.08920), with the Das & Batygin (2023) suppression study
+//! (arXiv:2307.00378).
+//!
+//! # The instability (Madigan & McCourt 2016)
+//!
+//! A massive disc of eccentric planetesimals (several to tens of Earth masses)
+//! orbiting the Sun is subject to a collective *secular* instability: the
+//! orbital inclinations rise exponentially while the arguments of perihelion
+//! and the longitudes of the ascending node cluster. The instability is driven
+//! entirely by the disc's own self-gravity — **no planet is required**. Because
+//! it is secular (orbit-averaged), the relevant clock is the disc's secular
+//! precession time, which is the Keplerian orbital time scaled by the
+//! disc-to-Sun mass ratio:
+//!
+//!   t_sec ~ (M_sun / M_d) * P_orbit,    omega_sec ~ (M_d / M_sun) * n,
+//!
+//! with n = sqrt(GM_sun / a^3) the mean motion at the disc's characteristic
+//! semi-major axis a (Madigan & McCourt 2016, Eq. 1 and Section 2; the
+//! self-gravity secular frequency of a near-Keplerian disc). The instability
+//! grows on this secular time, so the e-folding growth rate scales as
+//!
+//!   gamma = C_growth * (M_d / M_sun) * n,
+//!
+//! a *linear-theory* growth rate proportional to the disc mass (collective
+//! self-gravity). C_growth is an order-unity dimensionless eigenvalue of the
+//! linearised secular problem; Madigan & McCourt's N-body experiments give
+//! e-folding times of order a few disc secular times, and we adopt the labelled
+//! constant [`growth::C_GROWTH`] documented there.
+//!
+//! See [`growth`] for the growth rate / e-folding time, and [`suppression`]
+//! for the Das & Batygin (2023) critical-mass criterion.
+
+pub mod growth;
+pub mod suppression;

--- a/crates/p9-2016-inclination-instability/src/suppression.rs
+++ b/crates/p9-2016-inclination-instability/src/suppression.rs
@@ -1,0 +1,158 @@
+//! Das & Batygin (2023) suppression criterion (arXiv:2307.00378).
+//!
+//! Das & Batygin show that the Madigan & McCourt inclination instability is
+//! *suppressed* unless the disc self-gravity is strong enough to overcome the
+//! competing differential apsidal/nodal precession imposed by the giant
+//! planets. A coherent collective mode can only grow if all disc orbits
+//! precess together; an external precession source (the giant planets, acting
+//! as an orbit-averaged quadrupole / J2 ring) makes orbits at different
+//! (a, e, i) precess at different rates, detuning the mode. The instability
+//! survives only when the disc's own secular frequency dominates:
+//!
+//!   omega_disk(M_d, a)  >  g_planet(a, e, i).
+//!
+//! Setting them equal defines the critical disc mass M_crit: below it the mode
+//! is stabilised, above it unstable. The giant-planet precession rate is the
+//! standard secular J2-ring rate (Murray & Dermott 1999, Ch. 7), reusing
+//! `p9_core::forces::j2_secular::combined_j2_jsu` (Jupiter+Saturn+Uranus) plus
+//! Neptune for J2_eff:
+//!
+//!   g_planet = (3/2) n J2_eff / [ a^2 (1 - e^2)^2 ],
+//!
+//! where J2_eff = (1/2) sum_p (m_p/M_sun) a_p^2 has units of AU^2 and
+//! 2 J2_eff/a^2 = sum_p (m_p/M_sun)(a_p/a)^2 is the usual dimensionless ring
+//! strength. (This is the same J2_eff used by `p9-2024-oort-selfgrav`.)
+//!
+//! Equating omega_disk = (M_d/M_sun) n with g_planet and solving for the mass:
+//!
+//!   M_crit / M_sun = (3/2) J2_eff / [ a^2 (1 - e^2)^2 ].
+//!
+//! Note the disc mean motion n cancels: the criterion is a ratio of secular
+//! rates, both proportional to n. M_crit is therefore independent of a's
+//! orbital-time scaling and set by the ring geometry and the disc eccentricity.
+
+use p9_core::constants::{A_NEPTUNE_AU, EARTH_MASS_SOLAR, MASS_NEPTUNE_SOLAR};
+use p9_core::forces::j2_secular::{combined_j2_jsu, effective_j2};
+
+use crate::growth::{mean_motion, secular_frequency};
+
+/// Effective J2 (AU^2) of the four giant planets: (1/2) sum_p (m_p/M_sun) a_p^2,
+/// built from the shared `p9_core` J2 helpers (J+S+U) plus Neptune. Identical
+/// construction to `p9-2024-oort-selfgrav`'s `compute_j2_effective`.
+pub fn giant_planet_j2_eff() -> f64 {
+    let (j2_jsu, _j4, _gm_boost) = combined_j2_jsu();
+    j2_jsu + effective_j2(MASS_NEPTUNE_SOLAR, A_NEPTUNE_AU, 1.0)
+}
+
+/// Giant-planet secular apsidal precession rate for a disc orbit at (a, e)
+/// [rad/day]:  g = (3/2) n J2_eff / [a^2 (1-e^2)^2].
+pub fn giant_planet_precession_rate(a: f64, e: f64) -> f64 {
+    let j2_eff = giant_planet_j2_eff();
+    let eta2 = 1.0 - e * e;
+    1.5 * mean_motion(a) * j2_eff / (a * a * eta2 * eta2)
+}
+
+/// Critical disc mass (solar masses) above which the inclination instability
+/// is unstable per Das & Batygin (2023): set omega_disk = g_planet.
+///
+///   M_crit/M_sun = (3/2) J2_eff / [a^2 (1-e^2)^2].
+pub fn critical_mass_solar(a: f64, e: f64) -> f64 {
+    let j2_eff = giant_planet_j2_eff();
+    let eta2 = 1.0 - e * e;
+    1.5 * j2_eff / (a * a * eta2 * eta2)
+}
+
+/// Critical disc mass in Earth masses.
+pub fn critical_mass_earth(a: f64, e: f64) -> f64 {
+    critical_mass_solar(a, e) / EARTH_MASS_SOLAR
+}
+
+/// Stability verdict for a disc of mass `m_disk_solar` at (a, e).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Stability {
+    /// Self-gravity dominates giant-planet precession: instability grows.
+    Unstable,
+    /// Giant-planet differential precession dominates: mode suppressed.
+    Stable,
+}
+
+/// Apply the Das & Batygin suppression criterion: compare the disc self-gravity
+/// secular frequency against the giant-planet precession rate at (a, e).
+pub fn classify(m_disk_solar: f64, a: f64, e: f64) -> Stability {
+    let omega_disk = secular_frequency(m_disk_solar, a);
+    let g_planet = giant_planet_precession_rate(a, e);
+    if omega_disk > g_planet {
+        Stability::Unstable
+    } else {
+        Stability::Stable
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const A_AU: f64 = 250.0;
+    const E_DISK: f64 = 0.6;
+
+    #[test]
+    fn test_critical_mass_is_positive() {
+        let m_crit = critical_mass_earth(A_AU, E_DISK);
+        assert!(m_crit > 0.0, "critical mass must be positive, got {m_crit}");
+        assert!(m_crit.is_finite());
+    }
+
+    #[test]
+    fn test_critical_mass_published_order() {
+        // Das & Batygin (2023) find the instability requires discs of several
+        // to tens of Earth masses (consistent with Madigan & McCourt's massive
+        // discs). The critical mass for a fiducial eccentric disc at a few
+        // hundred AU should land in roughly the 0.1-100 M_earth band.
+        let m_crit = critical_mass_earth(A_AU, E_DISK);
+        assert!(
+            (0.1..=100.0).contains(&m_crit),
+            "critical mass {m_crit} M_earth outside the expected order"
+        );
+    }
+
+    #[test]
+    fn test_threshold_separates_stable_unstable() {
+        let m_crit = critical_mass_solar(A_AU, E_DISK);
+        // Just below: stable; just above: unstable.
+        assert_eq!(classify(0.99 * m_crit, A_AU, E_DISK), Stability::Stable);
+        assert_eq!(classify(1.01 * m_crit, A_AU, E_DISK), Stability::Unstable);
+    }
+
+    #[test]
+    fn test_a_massive_disk_is_unstable_a_light_one_stable() {
+        use p9_core::constants::EARTH_MASS_SOLAR;
+        let m_crit_e = critical_mass_earth(A_AU, E_DISK);
+        // A disc 10x above critical is unstable; one 10x below is stable.
+        let heavy = 10.0 * m_crit_e * EARTH_MASS_SOLAR;
+        let light = 0.1 * m_crit_e * EARTH_MASS_SOLAR;
+        assert_eq!(classify(heavy, A_AU, E_DISK), Stability::Unstable);
+        assert_eq!(classify(light, A_AU, E_DISK), Stability::Stable);
+    }
+
+    #[test]
+    fn test_more_eccentric_disk_has_higher_critical_mass() {
+        // (1-e^2)^-2 grows with e, so the giant-planet precession is faster
+        // for eccentric orbits and a heavier disc is needed to overcome it.
+        let m_low_e = critical_mass_earth(A_AU, 0.2);
+        let m_high_e = critical_mass_earth(A_AU, 0.7);
+        assert!(
+            m_high_e > m_low_e,
+            "eccentric disc should need more mass: {m_high_e} vs {m_low_e}"
+        );
+    }
+
+    #[test]
+    fn test_critical_mass_independent_of_orbital_time() {
+        // M_crit ~ J2_eff / a^2: the n factors cancel, so M_crit depends on a
+        // only through the 1/a^2 ring geometry, not through the period.
+        let m1 = critical_mass_solar(A_AU, E_DISK);
+        let m2 = critical_mass_solar(2.0 * A_AU, E_DISK);
+        // 1/a^2 scaling => factor 4.
+        assert!((m1 / m2 - 4.0).abs() < 1e-9, "ratio {}", m1 / m2);
+    }
+}


### PR DESCRIPTION
Implements `p9-2016-inclination-instability`, reproducing Madigan & McCourt (2016, arXiv:1509.08920) and the Das & Batygin (2023, arXiv:2307.00378) suppression study.

## What it computes (real, no hard-coded answers)

**`growth`** — linear-theory growth rate of the inclination instability. A self-gravitating eccentric disc precesses on its secular time `t_sec = (M_sun/M_d)·P`; the disc secular frequency is `omega_sec = (M_d/M_sun)·n`. The inclination e-folds in an order-unity number of secular times: `gamma = (M_d/M_sun)·n / C_GROWTH` with `C_GROWTH = 2π` (one e-fold per disc secular period, the published order). Reuses `p9_core` Kepler/mean-motion machinery and constants.

- Growth rate is monotone increasing in disc mass; e-folding time scales as 1/M_d.
- Fiducial 20 M⊕ disc at 250 AU: tau ≈ 66 Myr (one secular time); a 5 M⊕ disc gives ≈263 Myr — spanning the published "secular, hundreds of Myr to ~Gyr" descriptor across the disc-mass range.

**`suppression`** — Das & Batygin critical mass. The collective mode survives only when disc self-gravity precession beats the giant-planet differential precession: `omega_disk > g_planet`, with `g_planet = (3/2) n J2_eff / [a^2 (1-e^2)^2]` from the shared `p9_core::forces::j2_secular` J2_eff (J+S+U + Neptune, same construction as p9-2024-oort-selfgrav). Equating gives `M_crit/M_sun = (3/2) J2_eff / [a^2 (1-e^2)^2]` (the mean motion cancels). For a fiducial 250 AU, e=0.6 disc, M_crit ≈ 1.12 M⊕. Below it `classify` returns `Stable`, above it `Unstable`.

## Residuals (documented honestly)

The fiducial 20 M⊕ e-folding time (66 Myr) lands at the low end of the published band because it is the heaviest fiducial mass; the hundreds-of-Myr figure corresponds to lighter (few-M⊕) discs. `C_GROWTH` is a labelled reference eigenvalue tied to the paper's reported secular-time scaling, not a free fit. Published reference scalings are kept as labelled constants.

11 tests pass; pinned: growth monotone in mass, e-folding decreasing in mass, fiducial timescale in published order, positive computed M_crit with a stable/unstable threshold separation, eccentricity dependence, and the analytic scaling identities.

Closes #63