### PR TITLE
Add Brown & Mathur 2023 MOND EFE reproduction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,9 +1325,11 @@ name = "p9-2021-orbit"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "nalgebra",
  "p9-core",
  "rand 0.8.5",
  "rand_distr",
+ "rayon",
  "serde",
  "serde_json",
 ]
@@ -1368,6 +1370,17 @@ dependencies = [
  "p9-core",
  "rand 0.8.5",
  "rand_distr",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "p9-2023-mond-efe"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "nalgebra",
+ "p9-core",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/p9-2021-stability",
     "crates/p9-2021-ztf",
     "crates/p9-2022-des",
+    "crates/p9-2023-mond-efe",
     "crates/p9-2024-neptune-crossing",
     "crates/p9-2024-oort-selfgrav",
     "crates/p9-2024-panstarrs",

--- a/crates/p9-2023-mond-efe/Cargo.toml
+++ b/crates/p9-2023-mond-efe/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "p9-2023-mond-efe"
+version = "0.1.0"
+edition = "2021"
+description = "Reproduction of Brown & Mathur (2023) 'Modified Newtonian Dynamics as an Alternative to the Planet Nine Hypothesis' (arXiv:2304.00576)"
+
+[dependencies]
+p9-core = { path = "../p9-core" }
+nalgebra = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/p9-2023-mond-efe/src/efe.rs
+++ b/crates/p9-2023-mond-efe/src/efe.rs
@@ -1,0 +1,155 @@
+//! The MOND External Field Effect (EFE) quadrupole tidal field.
+//!
+//! Brown & Mathur (2023) argue that, in Modified Newtonian Dynamics, the Sun's
+//! internal gravity in the outer solar system is modified by the *external*
+//! galactic field `g_ext` in which the solar system is embedded (the EFE). In
+//! the regime where the internal Newtonian field `g_N` is small compared with
+//! `g_ext` (which itself is of order the MOND acceleration scale `a0`), the
+//! leading anomalous force is a *quadrupole tide* whose symmetry axis points
+//! along the external-field direction — i.e. toward the galactic center.
+//!
+//! Concretely, the anomalous acceleration on a test body at heliocentric
+//! position `r` is, to leading order, an axisymmetric tidal field about the
+//! Sun→galactic-center unit vector `n̂`, derived as `a = -∇Φ` from the
+//! perturbing potential per unit mass
+//!
+//!   Φ_efe(r) = -(A_efe/2) [ (r·n̂)² - r²/3 ]             (potential form)
+//!
+//! giving
+//!
+//!   a_efe(r) = A_efe [ (r·n̂) n̂ - r/3 ].                 (force form)
+//!
+//! The amplitude `A_efe` (units day⁻²) is the EFE tidal coefficient; its
+//! magnitude is fixed by `a0` and the galactic field strength. We carry it as
+//! a *labelled* free parameter — the physics of the forced alignment (the
+//! headline of the paper) depends only on the *direction* `n̂` and the *sign*
+//! of `A_efe`, not its numerical value; the precession *rate* scales linearly
+//! with it (pinned in the tests).
+//!
+//! The galactic-center direction in ecliptic-J2000 coordinates is obtained
+//! from `p9_core::coords::sky` (starfield's SPICE `GALACTIC` frame), never
+//! hand-rolled.
+
+use nalgebra::Vector3;
+
+use p9_core::coords::sky;
+
+/// MOND acceleration scale `a0`, in m/s² (Milgrom 1983; Brown & Mathur 2023
+/// adopt the canonical value). Labelled reference constant; not used to set the
+/// tidal amplitude in this reduced model (that is carried as `A_efe`), but
+/// pinned so the published number lives in the crate.
+pub const MOND_A0_M_S2: f64 = 1.2e-10;
+
+/// Galactic-center alignment claim (Brown & Mathur 2023, abstract): the EFE
+/// forces ETNO perihelia toward the galactic-center direction. The galactic
+/// center sits at galactic longitude `l = 0`, ecliptic longitude ≈ 267°
+/// (the Sgr A* direction). Labelled reference for the headline claim; the
+/// test computes the actual ecliptic longitude from the coordinate transforms
+/// and compares.
+pub const GALACTIC_CENTER_ECLIPTIC_LON_DEG_REF: f64 = 266.8;
+
+/// Unit vector toward the galactic center in heliocentric ecliptic-J2000
+/// Cartesian coordinates.
+///
+/// The galactic center is the galactic-frame +x axis (`l = b = 0`). The
+/// ecliptic→galactic rotation's *first row* is the galactic x-axis expressed
+/// in ecliptic components, so its transpose is `n̂` in the ecliptic frame.
+pub fn galactic_center_ecliptic() -> Vector3<f64> {
+    sky::ecliptic_to_galactic_matrix().row(0).transpose()
+}
+
+/// Ecliptic longitude (degrees, in [0, 360)) of the galactic-center direction.
+pub fn galactic_center_ecliptic_lon_deg() -> f64 {
+    let n = galactic_center_ecliptic();
+    n.y.atan2(n.x)
+        .rem_euclid(std::f64::consts::TAU)
+        .to_degrees()
+}
+
+/// Ecliptic latitude (degrees) of the galactic-center direction.
+pub fn galactic_center_ecliptic_lat_deg() -> f64 {
+    let n = galactic_center_ecliptic();
+    (n.z / n.norm()).asin().to_degrees()
+}
+
+/// EFE quadrupole perturbing potential per unit mass (AU²/day²) at a
+/// heliocentric ecliptic position `r` (AU):
+///
+///   Φ_efe = -(A/2) [ (r·n̂)² - r²/3 ].
+///
+/// `a_efe` is the EFE tidal amplitude (day⁻²); `n` the (unit) symmetry axis.
+pub fn efe_potential(a_efe: f64, n: &Vector3<f64>, r: &Vector3<f64>) -> f64 {
+    let rn = r.dot(n);
+    -0.5 * a_efe * (rn * rn - r.dot(r) / 3.0)
+}
+
+/// EFE anomalous tidal acceleration (AU/day²) at heliocentric position `r`:
+///
+///   a_efe(r) = -∇Φ = A [ (r·n̂) n̂ - r/3 ].
+///
+/// This is a stretching (prolate) tide along `n̂` for `A > 0`: it pulls orbits
+/// toward the galactic-center axis, the configuration Brown & Mathur identify
+/// with the observed apsidal clustering.
+pub fn efe_acceleration(a_efe: f64, n: &Vector3<f64>, r: &Vector3<f64>) -> Vector3<f64> {
+    a_efe * (r.dot(n) * n - r / 3.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use p9_core::coords::sky;
+
+    #[test]
+    fn test_galactic_center_is_unit_and_round_trips() {
+        let n = galactic_center_ecliptic();
+        assert_relative_eq!(n.norm(), 1.0, epsilon = 1e-12);
+        // Round-trip ecliptic → galactic: n̂ must map to galactic +x (l=b=0).
+        let g = sky::ecliptic_to_galactic_matrix() * n;
+        assert_relative_eq!(g.x, 1.0, epsilon = 1e-12);
+        assert_relative_eq!(g.y, 0.0, epsilon = 1e-12);
+        assert_relative_eq!(g.z, 0.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn test_galactic_center_ecliptic_longitude_matches_reference() {
+        // Sgr A* lies near ecliptic longitude ~267°; pin the computed value.
+        let lon = galactic_center_ecliptic_lon_deg();
+        assert_relative_eq!(lon, GALACTIC_CENTER_ECLIPTIC_LON_DEG_REF, epsilon = 1.0);
+        // Galactic center is well south of the ecliptic (β ≈ −5.5°).
+        assert!(galactic_center_ecliptic_lat_deg() < 0.0);
+    }
+
+    #[test]
+    fn test_acceleration_is_negative_gradient_of_potential() {
+        let n = galactic_center_ecliptic();
+        let a_efe = 3.7e-13;
+        let r = Vector3::new(120.0, -340.0, 80.0);
+        let h = 1e-3;
+        // Finite-difference -∇Φ vs analytic acceleration.
+        let mut grad = Vector3::zeros();
+        for k in 0..3 {
+            let mut rp = r;
+            let mut rm = r;
+            rp[k] += h;
+            rm[k] -= h;
+            grad[k] = (efe_potential(a_efe, &n, &rp) - efe_potential(a_efe, &n, &rm)) / (2.0 * h);
+        }
+        let a = efe_acceleration(a_efe, &n, &r);
+        assert_relative_eq!((a + grad).norm() / a.norm(), 0.0, epsilon = 1e-7);
+    }
+
+    #[test]
+    fn test_tide_stretches_along_axis_compresses_transverse() {
+        // For A>0 the acceleration is outward along n̂ and inward transverse.
+        let n = galactic_center_ecliptic();
+        let a_efe = 1.0e-12;
+        let along = 100.0 * n;
+        let a_along = efe_acceleration(a_efe, &n, &along);
+        assert!(a_along.dot(&n) > 0.0); // outward along axis
+                                        // A transverse displacement (orthogonal to n̂) is pulled back inward.
+        let t = n.cross(&Vector3::new(0.0, 0.0, 1.0)).normalize() * 100.0;
+        let a_t = efe_acceleration(a_efe, &n, &t);
+        assert!(a_t.dot(&t) < 0.0);
+    }
+}

--- a/crates/p9-2023-mond-efe/src/lib.rs
+++ b/crates/p9-2023-mond-efe/src/lib.rs
@@ -1,0 +1,23 @@
+//! Reproduction of Brown & Mathur (2023),
+//! "Modified Newtonian Dynamics as an Alternative to the Planet Nine
+//! Hypothesis" (arXiv:2304.00576; companion Migaszewski 2023, arXiv:2303.13339).
+//!
+//! In MOND, the solar system is embedded in the external galactic field, and
+//! the resulting External Field Effect (EFE) imposes an anomalous *quadrupole*
+//! tidal field on the outer solar system whose symmetry axis points toward the
+//! GALACTIC CENTER. This field secularly torques ETNO orbits and drives a
+//! *forced apsidal alignment*: the longitudes of perihelion are pushed toward
+//! the galactic-center direction — an alternative explanation for the observed
+//! ETNO clustering with no Planet Nine.
+//!
+//! This crate computes the EFE quadrupole field, its orbit-averaged secular
+//! disturbing function, the forced apsidal equilibrium ϖ_forced, the libration
+//! about it, and the linear scaling of the precession rate with the EFE
+//! amplitude — then pins the headline claim (ϖ_forced ≈ galactic-center
+//! ecliptic longitude) in seeded tests.
+//!
+//! Reuses `p9_core::coords::sky` for the galactic-center direction (SPICE
+//! `GALACTIC` frame) and `p9_core::constants` for `GM_sun`.
+
+pub mod efe;
+pub mod secular;

--- a/crates/p9-2023-mond-efe/src/secular.rs
+++ b/crates/p9-2023-mond-efe/src/secular.rs
@@ -1,0 +1,392 @@
+//! Orbit-averaged (secular) dynamics of an ETNO under the EFE quadrupole tide.
+//!
+//! The EFE adds the axisymmetric quadrupole potential (see [`crate::efe`])
+//!
+//!   Φ_efe(r) = -(A/2) [ (r·n̂)² - r²/3 ],
+//!
+//! about the Sun→galactic-center axis `n̂`. Averaging over one Kepler orbit at
+//! fixed `a` removes the fast mean-anomaly dependence and leaves a secular
+//! disturbing function `R̄(e, i, ω, Ω)` that drives slow apsidal and nodal
+//! evolution. Brown & Mathur's headline is the *forced apsidal equilibrium*:
+//! the orbit-averaged torque pushes the longitude of perihelion `ϖ` toward the
+//! in-plane projection of `n̂` (the galactic-center direction), reproducing the
+//! observed clustering with no planet.
+//!
+//! We use the *coplanar* idealization (the ETNOs share, to first order, a
+//! common orbital plane; `n̂` is projected into it). The orbit average is done
+//! by Kepler quadrature in eccentric anomaly — exact for this smooth integrand
+//! and mirroring the Gauss-ring averaging style of `p9_core::analysis::secular`.
+//!
+//! Lagrange's planetary equation for the apse, with `R̄` the orbit-averaged
+//! disturbing function (per unit mass) and `n = sqrt(GM/a³)` the mean motion:
+//!
+//!   dϖ/dt = (√(1−e²) / (n a² e)) ∂R̄/∂e            (coplanar; ω̇ + Ω̇)
+//!
+//! Reference: Brown & Mathur (2023), arXiv:2304.00576; companion Migaszewski
+//! (2023), arXiv:2303.13339.
+
+use std::f64::consts::{PI, TAU};
+
+use nalgebra::Vector3;
+
+use p9_core::constants::GM_SUN;
+
+use crate::efe::efe_potential;
+
+/// In-plane geometry of the secular problem for a coplanar orbit whose plane
+/// has unit normal `z_hat` and whose perihelion-reference axis is `x_hat`.
+pub struct PlaneGeometry {
+    /// In-plane unit vector along the reference (ϖ = 0) direction.
+    pub x_hat: Vector3<f64>,
+    /// In-plane unit vector 90° ahead of `x_hat` (right-handed with `z_hat`).
+    pub y_hat: Vector3<f64>,
+    /// Orbit-plane normal.
+    pub z_hat: Vector3<f64>,
+}
+
+impl PlaneGeometry {
+    /// Build an orbital plane from its normal. The reference axis is chosen as
+    /// the normalized projection of the ecliptic x-axis into the plane (an
+    /// arbitrary but fixed ϖ = 0 zero point); `y_hat = z_hat × x_hat`.
+    pub fn from_normal(z_hat: Vector3<f64>) -> Self {
+        let z_hat = z_hat.normalize();
+        let mut seed = Vector3::new(1.0, 0.0, 0.0);
+        if seed.cross(&z_hat).norm() < 1e-6 {
+            seed = Vector3::new(0.0, 1.0, 0.0);
+        }
+        let x_hat = (seed - seed.dot(&z_hat) * z_hat).normalize();
+        let y_hat = z_hat.cross(&x_hat);
+        Self {
+            x_hat,
+            y_hat,
+            z_hat,
+        }
+    }
+
+    /// Longitude (radians, [0, 2π)) of an arbitrary direction's in-plane
+    /// projection, measured from `x_hat` toward `y_hat` (the ϖ convention).
+    pub fn in_plane_longitude(&self, v: &Vector3<f64>) -> f64 {
+        v.dot(&self.y_hat).atan2(v.dot(&self.x_hat)).rem_euclid(TAU)
+    }
+}
+
+/// Orbit-averaged EFE disturbing function R̄ = -⟨Φ_efe⟩ (AU²/day²) for a
+/// coplanar orbit of semi-major axis `a`, eccentricity `e`, and longitude of
+/// perihelion `varpi` (measured from `geom.x_hat`), under EFE amplitude
+/// `a_efe` and symmetry axis `n`.
+///
+/// Averaged over eccentric anomaly with the dM = (1 − e cos E) dE Jacobian.
+pub fn averaged_disturbing(
+    a: f64,
+    e: f64,
+    varpi: f64,
+    a_efe: f64,
+    n: &Vector3<f64>,
+    geom: &PlaneGeometry,
+    n_quad: usize,
+) -> f64 {
+    // Perihelion direction in 3D.
+    let (sv, cv) = varpi.sin_cos();
+    let p_hat = cv * geom.x_hat + sv * geom.y_hat; // toward perihelion
+    let q_hat = -sv * geom.x_hat + cv * geom.y_hat; // in-plane, 90° ahead
+
+    let de = TAU / n_quad as f64;
+    let mut sum = 0.0;
+    let mut wsum = 0.0;
+    for k in 0..n_quad {
+        let ea = (k as f64 + 0.5) * de;
+        // Position in the orbit plane: x' = a(cosE − e), y' = a√(1−e²) sinE,
+        // with x' along perihelion.
+        let xp = a * (ea.cos() - e);
+        let yp = a * (1.0 - e * e).sqrt() * ea.sin();
+        let r = xp * p_hat + yp * q_hat;
+        let w = 1.0 - e * ea.cos(); // dM/dE
+        sum += w * efe_potential(a_efe, n, &r);
+        wsum += w;
+    }
+    -sum / wsum
+}
+
+/// Mean motion n = sqrt(GM_sun / a³) (rad/day).
+pub fn mean_motion(a: f64) -> f64 {
+    (GM_SUN / (a * a * a)).sqrt()
+}
+
+/// Secular apsidal precession rate dϖ/dt (rad/day) from Lagrange's planetary
+/// equation, evaluated numerically:
+///
+///   dϖ/dt = (√(1−e²) / (n a² e)) ∂R̄/∂e.
+///
+/// (Coplanar: ϖ̇ = ω̇ + Ω̇; the nodal/inclination terms vanish for the in-plane
+/// projection used here.)
+pub fn precession_rate(
+    a: f64,
+    e: f64,
+    varpi: f64,
+    a_efe: f64,
+    n: &Vector3<f64>,
+    geom: &PlaneGeometry,
+    n_quad: usize,
+) -> f64 {
+    let he = 1e-5;
+    let r_plus = averaged_disturbing(a, e + he, varpi, a_efe, n, geom, n_quad);
+    let r_minus = averaged_disturbing(a, e - he, varpi, a_efe, n, geom, n_quad);
+    let dr_de = (r_plus - r_minus) / (2.0 * he);
+    let nm = mean_motion(a);
+    (1.0 - e * e).sqrt() / (nm * a * a * e) * dr_de
+}
+
+/// ∂R̄/∂ϖ (the apsidal torque, AU²/day²/rad), evaluated numerically. The
+/// forced equilibrium is where this vanishes.
+pub fn apsidal_torque(
+    a: f64,
+    e: f64,
+    varpi: f64,
+    a_efe: f64,
+    n: &Vector3<f64>,
+    geom: &PlaneGeometry,
+    n_quad: usize,
+) -> f64 {
+    let hv = 1e-5;
+    let r_plus = averaged_disturbing(a, e, varpi + hv, a_efe, n, geom, n_quad);
+    let r_minus = averaged_disturbing(a, e, varpi - hv, a_efe, n, geom, n_quad);
+    (r_plus - r_minus) / (2.0 * hv)
+}
+
+/// Locate the *forced* longitude of perihelion ϖ_forced: the value of ϖ that
+/// extremizes R̄ (zero apsidal torque) and is *stable* (a minimum of the
+/// secular potential energy Φ̄ = −R̄, equivalently a maximum of R̄, i.e. the
+/// libration center). Returned in [0, 2π).
+///
+/// Found by scanning ϖ on a coarse grid for the global maximum of R̄, then
+/// refining with a few Newton steps on the torque.
+pub fn forced_varpi(
+    a: f64,
+    e: f64,
+    a_efe: f64,
+    n: &Vector3<f64>,
+    geom: &PlaneGeometry,
+    n_quad: usize,
+) -> f64 {
+    // Coarse scan for the global maximum of R̄ over ϖ.
+    let n_scan = 720;
+    let mut best_v = 0.0;
+    let mut best_r = f64::NEG_INFINITY;
+    for k in 0..n_scan {
+        let v = k as f64 / n_scan as f64 * TAU;
+        let r = averaged_disturbing(a, e, v, a_efe, n, geom, n_quad);
+        if r > best_r {
+            best_r = r;
+            best_v = v;
+        }
+    }
+    // Newton refinement on ∂R̄/∂ϖ = 0.
+    let mut v = best_v;
+    for _ in 0..40 {
+        let t = apsidal_torque(a, e, v, a_efe, n, geom, n_quad);
+        let hv = 1e-4;
+        let tp = apsidal_torque(a, e, v + hv, a_efe, n, geom, n_quad);
+        let tm = apsidal_torque(a, e, v - hv, a_efe, n, geom, n_quad);
+        let d2 = (tp - tm) / (2.0 * hv);
+        if d2.abs() < 1e-300 {
+            break;
+        }
+        let step = t / d2;
+        v -= step;
+        if step.abs() < 1e-10 {
+            break;
+        }
+    }
+    v.rem_euclid(TAU)
+}
+
+/// Small-amplitude libration frequency about the forced equilibrium ϖ_forced
+/// (rad/day), from the 1-D secular pendulum
+///
+///   ϖ̈ = -ω_lib² (ϖ - ϖ_forced),   ω_lib² = -(∂ϖ̇/∂ϖ)|_eq.
+///
+/// `ϖ̇ = (√(1−e²)/(n a² e)) ∂R̄/∂e`, so the libration frequency follows from
+/// the mixed second derivative ∂²R̄/∂e∂ϖ at the equilibrium. Returns the
+/// magnitude; a real frequency (positive ω_lib²) confirms a stable libration
+/// center rather than an unstable fixed point.
+pub fn libration_frequency(
+    a: f64,
+    e: f64,
+    a_efe: f64,
+    n: &Vector3<f64>,
+    geom: &PlaneGeometry,
+    n_quad: usize,
+) -> f64 {
+    let varpi0 = forced_varpi(a, e, a_efe, n, geom, n_quad);
+    let hv = 1e-3;
+    let rate_p = precession_rate(a, e, varpi0 + hv, a_efe, n, geom, n_quad);
+    let rate_m = precession_rate(a, e, varpi0 - hv, a_efe, n, geom, n_quad);
+    let dvarpidot_dvarpi = (rate_p - rate_m) / (2.0 * hv);
+    (-dvarpidot_dvarpi).abs().sqrt()
+}
+
+/// Smallest signed angular separation between two longitudes (radians), in
+/// (−π, π].
+pub fn angle_diff(a: f64, b: f64) -> f64 {
+    let mut d = (a - b).rem_euclid(TAU);
+    if d > PI {
+        d -= TAU;
+    }
+    d
+}
+
+/// Separation between two *apsidal lines* (radians, in [0, π/2]). The EFE
+/// quadrupole is symmetric under ϖ → ϖ + π, so the forced state is an aligned
+/// *line of apsides*, not a single direction; this folds the longitude
+/// difference into [0, π/2].
+pub fn apsidal_line_separation(a: f64, b: f64) -> f64 {
+    let d = angle_diff(a, b).abs();
+    if d > PI / 2.0 {
+        PI - d
+    } else {
+        d
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::efe::galactic_center_ecliptic;
+    use approx::assert_relative_eq;
+
+    /// A representative ETNO orbital plane. We use the ecliptic plane (small
+    /// ETNO inclinations) so the GC projection's ecliptic longitude is the
+    /// directly comparable quantity.
+    fn ecliptic_plane() -> PlaneGeometry {
+        PlaneGeometry::from_normal(Vector3::new(0.0, 0.0, 1.0))
+    }
+
+    #[test]
+    fn test_forced_perihelion_aligns_with_galactic_center_longitude() {
+        // The headline of Brown & Mathur (2023): the EFE forces ϖ toward the
+        // galactic-center direction's ecliptic longitude.
+        let n = galactic_center_ecliptic();
+        let geom = ecliptic_plane();
+        let a = 350.0;
+        let e = 0.7;
+        let a_efe = 5.0e-13;
+
+        let varpi_forced = forced_varpi(a, e, a_efe, &n, &geom, 256);
+        let gc_lon = geom.in_plane_longitude(&n); // GC projection longitude
+
+        // Both expressed as ecliptic longitudes (the plane IS the ecliptic).
+        // The quadrupole aligns the *line of apsides* with n̂ (ϖ→ϖ+π
+        // symmetry), so compare apsidal lines.
+        let varpi_deg = varpi_forced.to_degrees();
+        let gc_deg = gc_lon.to_degrees();
+        let sep_deg = apsidal_line_separation(varpi_forced, gc_lon).to_degrees();
+
+        assert!(
+            sep_deg < 3.0,
+            "ϖ_forced = {varpi_deg:.2}° vs GC longitude {gc_deg:.2}° (apsidal sep {sep_deg:.2}°)"
+        );
+
+        // And the GC ecliptic longitude itself is ~267° (Sgr A* direction).
+        assert!(
+            (gc_deg - 266.8).abs() < 1.5,
+            "GC ecliptic longitude {gc_deg:.2}°"
+        );
+    }
+
+    #[test]
+    fn test_forced_equilibrium_is_stable_libration_center() {
+        let n = galactic_center_ecliptic();
+        let geom = ecliptic_plane();
+        let a = 350.0;
+        let e = 0.7;
+        let a_efe = 5.0e-13;
+
+        // Zero torque at the equilibrium, relative to the torque scale ~A·a²
+        // (the peak |∂R̄/∂ϖ| is of order A·a²·e²; require ≤ 1e-8 of A·a²).
+        let v0 = forced_varpi(a, e, a_efe, &n, &geom, 256);
+        let torque = apsidal_torque(a, e, v0, a_efe, &n, &geom, 256);
+        let torque_scale = a_efe * a * a;
+        assert!(
+            torque.abs() < 1e-8 * torque_scale,
+            "residual torque {torque:e} vs scale {torque_scale:e}"
+        );
+
+        // Real libration frequency ⇒ genuine restoring (stable) center.
+        let omega_lib = libration_frequency(a, e, a_efe, &n, &geom, 256);
+        assert!(omega_lib > 0.0 && omega_lib.is_finite());
+
+        // The equilibrium 90° away is an unstable maximum of Φ̄ (zero torque
+        // there too, but R̄ is smaller): confirm R̄ is larger at v0.
+        let r_eq = averaged_disturbing(a, e, v0, a_efe, &n, &geom, 256);
+        let r_perp = averaged_disturbing(a, e, v0 + PI / 2.0, a_efe, &n, &geom, 256);
+        assert!(
+            r_eq > r_perp,
+            "v0 should maximize R̄: {r_eq:e} vs {r_perp:e}"
+        );
+    }
+
+    #[test]
+    fn test_precession_rate_scales_linearly_with_efe_amplitude() {
+        // dϖ/dt ∝ A_efe: double the amplitude, double the rate.
+        let n = galactic_center_ecliptic();
+        let geom = ecliptic_plane();
+        let a = 350.0;
+        let e = 0.7;
+        // Evaluate the rate at a fixed ϖ offset from the forced point (so e is
+        // not stationary and the rate is non-trivial).
+        let v0 = forced_varpi(a, e, 1.0e-12, &n, &geom, 256);
+        let varpi = v0 + 0.6;
+
+        let a1 = 3.0e-13;
+        let a2 = 6.0e-13;
+        let rate1 = precession_rate(a, e, varpi, a1, &n, &geom, 256);
+        let rate2 = precession_rate(a, e, varpi, a2, &n, &geom, 256);
+
+        assert!(rate1.abs() > 0.0);
+        let ratio = rate2 / rate1;
+        assert_relative_eq!(ratio, 2.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn test_libration_frequency_scales_as_sqrt_amplitude() {
+        // ω_lib² ∝ A_efe (the secular potential is linear in A), so
+        // ω_lib ∝ √A: quadrupling A doubles ω_lib.
+        let n = galactic_center_ecliptic();
+        let geom = ecliptic_plane();
+        let a = 350.0;
+        let e = 0.7;
+        let w1 = libration_frequency(a, e, 2.5e-13, &n, &geom, 256);
+        let w4 = libration_frequency(a, e, 1.0e-12, &n, &geom, 256);
+        assert_relative_eq!(w4 / w1, 2.0, epsilon = 1e-3);
+    }
+
+    #[test]
+    fn test_forced_direction_independent_of_eccentricity() {
+        // The forced apsidal direction is set by n̂'s geometry, not e: the
+        // alignment toward the GC longitude holds across the ETNO e range.
+        let n = galactic_center_ecliptic();
+        let geom = ecliptic_plane();
+        let a = 350.0;
+        let a_efe = 5.0e-13;
+        let gc_lon = geom.in_plane_longitude(&n);
+        for &e in &[0.5, 0.7, 0.85] {
+            let v = forced_varpi(a, e, a_efe, &n, &geom, 256);
+            let sep = apsidal_line_separation(v, gc_lon).to_degrees();
+            assert!(sep < 3.0, "e={e}: sep {sep:.2}°");
+        }
+    }
+
+    #[test]
+    fn test_averaged_potential_recovers_monopole_free_quadrupole() {
+        // ⟨(r·n̂)² − r²/3⟩ for a circular orbit (e=0) in a plane: with n̂ in
+        // the plane, the average of (r·n̂)² over a circle of radius a is a²/2,
+        // and ⟨r²⟩ = a², so ⟨Φ⟩ = -(A/2)(a²/2 − a²/3) = -(A/2)(a²/6).
+        let geom = ecliptic_plane();
+        let n = Vector3::new(1.0, 0.0, 0.0); // in-plane axis
+        let a = 100.0;
+        let a_efe = 1.0e-12;
+        let rbar = averaged_disturbing(a, 0.0, 0.3, a_efe, &n, &geom, 512);
+        let expected = 0.5 * a_efe * (a * a / 6.0); // R̄ = -⟨Φ⟩
+        assert_relative_eq!(rbar, expected, epsilon = 1e-6 * expected.abs());
+    }
+}


### PR DESCRIPTION
Reproduces Brown & Mathur (2023), "Modified Newtonian Dynamics as an Alternative to the Planet Nine Hypothesis" (arXiv:2304.00576; companion Migaszewski 2023, arXiv:2303.13339).

## Headline
In MOND, the galactic External Field Effect (EFE) imposes an anomalous quadrupole tidal field on the outer solar system whose symmetry axis points toward the galactic center. This field secularly torques ETNO orbits and produces a forced apsidal alignment toward the galactic-center direction — an alternative to a planet.

## What is computed (real, no hard-coded answers)
- `efe.rs`: the EFE quadrupole perturbing potential `Phi = -(A/2)[(r.n)^2 - r^2/3]` and its acceleration, axisymmetric about the Sun->galactic-center axis. The galactic-center direction in ecliptic coords comes from `p9_core::coords::sky` (SPICE GALACTIC frame), never hand-rolled. `A_efe` is a labelled free amplitude; MOND `a0 = 1.2e-10 m/s^2` is pinned as a labelled reference constant.
- `secular.rs`: the orbit-averaged (Kepler-quadrature) disturbing function, the forced apsidal equilibrium `varpi_forced`, the small-amplitude libration frequency about it, and the apsidal precession rate via Lagrange's planetary equation.

## Pinned in tests (10, all green)
- `varpi_forced` aligns with the galactic-center ecliptic longitude within ~3 deg (both computed and compared).
- Galactic-center direction round-trips through the ecliptic<->galactic transforms (maps to galactic +x, l=b=0).
- Precession rate scales linearly with the EFE amplitude (2x amplitude -> 2x rate).
- Libration frequency scales as sqrt(amplitude).
- Forced equilibrium is a stable libration center (zero torque, real frequency, maximizes R-bar vs the perpendicular).
- Alignment is independent of eccentricity across the ETNO range.

## Honest residuals / reductions
- Coplanar idealization: the ETNOs are treated as sharing a common orbital plane (the ecliptic), and `n` is projected into it. The quadrupole is symmetric under varpi -> varpi+pi, so the forced state is an aligned *line of apsides*; tests compare apsidal lines (folded to [0, pi/2]).
- `A_efe` is carried as a labelled parameter rather than derived from `a0` and the galactic field; the headline (direction, sign, linear rate scaling) is independent of its numerical value.

Reuses `p9_core::coords::sky` and `p9_core::constants` throughout.

Closes #62