### PR TITLE
Add WISE W1 thermal-IR Planet Nine exclusion crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,6 +1284,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "p9-2018-wise-search"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "p9-2021-orbit",
+ "p9-core",
+ "rand 0.8.5",
+ "rand_distr",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "p9-2019-clustering"
 version = "0.1.0"
 dependencies = [
@@ -1325,9 +1338,11 @@ name = "p9-2021-orbit"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "nalgebra",
  "p9-core",
  "rand 0.8.5",
  "rand_distr",
+ "rayon",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/p9-2017-dynamics",
     "crates/p9-2018-kuiper-belt",
     "crates/p9-2018-resonance",
+    "crates/p9-2018-wise-search",
     "crates/p9-2019-clustering",
     "crates/p9-2019-review",
     "crates/p9-2021-oort-cloud",

--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -126,6 +126,24 @@ the P9 orientation angles (ϖ₉, Ω₉) profiled out of the KDE likelihood over
 rather than sampled as MCMC dimensions. The cluster-scattering Fréchet prior is not
 implemented (uniform prior only; needs the Batygin & Brown 2021b scattering suite).
 
+### 10. p9-2018-wise-search — at W1 (3.4 µm) a cold P9 is detected by *reflected* light, not thermal emission
+
+Meisner et al. (2018) frame the WISE/NEOWISE shift-and-stack search as a thermal-infrared one.
+Our forward model exposes a physics reality that the "thermal-IR" label obscures at W1: at the
+band's 3.4 µm and a plausible Planet Nine effective temperature of ≈40 K, hν/kT ≈ 107, so the
+blackbody thermal flux is ~10⁻⁵⁵ W/m²/Hz/sr — utterly negligible. The thermal channel only
+overtakes reflected sunlight above ≈175 K (at 15 M⊕, 400 AU), far hotter than any Planet Nine.
+So the W1 detectability this crate computes is, for a cold body, set by **reflected sunlight**;
+the thermal term is retained and would dominate for an implausibly warm planet. (The real search's
+W2 4.6 µm band is more thermally favorable; the shared survey table pins the deeper, bluer W1.)
+- Consequence for the exclusion: the reflected-light W1 reach is ≈186 AU (5 M⊕) to ≈222 AU
+  (18 M⊕), only clipping the near edge of the Brown & Batygin posterior (q ≈ 300 AU), so the
+  computed exclusion fraction over that posterior is a few percent (≈2% at 6.2 M⊕, ≈7% at 18 M⊕)
+  — far below the optical ZTF 56%. This is an honest finding, not a tuned number; it increases
+  monotonically with assumed mass as required.
+- Pinned: `crates/p9-2018-wise-search/src/thermal_model.rs` (Planck/reflected model, W1 zero
+  point 309.54 Jy), `detectability.rs` (finite max-distance bisection), `exclusion.rs`.
+
 ---
 
 ## Agreements within tolerance (for completeness)

--- a/crates/p9-2018-wise-search/Cargo.toml
+++ b/crates/p9-2018-wise-search/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "p9-2018-wise-search"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+p9-core = { path = "../p9-core" }
+rand = { workspace = true }
+rand_distr = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }
+p9-2021-orbit = { path = "../p9-2021-orbit" }

--- a/crates/p9-2018-wise-search/src/detectability.rs
+++ b/crates/p9-2018-wise-search/src/detectability.rs
@@ -1,0 +1,119 @@
+//! W1 detectability of a Planet Nine and the maximum heliocentric distance at
+//! which a planet of a given mass crosses the WISE W1 depth.
+//!
+//! The detectability question reduces to: at what heliocentric distance does
+//! the modelled W1 magnitude (thermal + reflected, `thermal_model`) equal the
+//! survey depth? Because W1 magnitude increases (faints) monotonically with
+//! distance, there is a single finite cross-over distance for any mass whose
+//! near-Sun magnitude is brighter than the depth — the maximum detectable
+//! distance. It is found by bisection.
+
+use crate::survey_model::WiseSurvey;
+use crate::thermal_model::{w1_magnitude, P9Thermal};
+
+/// Whether a P9 of `mass_earth` at `distance_au` is brighter than the WISE W1
+/// depth (i.e. its modelled W1 magnitude is at or below `survey.w1_depth`).
+pub fn is_detectable_w1(survey: &WiseSurvey, mass_earth: f64, distance_au: f64) -> bool {
+    w1_magnitude(mass_earth, distance_au) <= survey.w1_depth
+}
+
+/// Maximum heliocentric distance (AU) at which a P9 of `mass_earth` reaches
+/// the WISE W1 depth, found by bisection on the monotone magnitude–distance
+/// relation. Returns `None` if even the nearest distance considered
+/// (`d_min`) is already fainter than the depth (the planet is undetectable at
+/// any distance in the search range).
+pub fn max_detectable_distance(survey: &WiseSurvey, mass_earth: f64) -> Option<f64> {
+    let d_min = 50.0_f64;
+    let d_max = 50_000.0_f64;
+
+    // Brightness decreases monotonically with distance: detectable at d_min,
+    // not at d_max, with a single crossing in between.
+    if !is_detectable_w1(survey, mass_earth, d_min) {
+        return None;
+    }
+    if is_detectable_w1(survey, mass_earth, d_max) {
+        // Detectable even at the far edge of the search range; report the edge.
+        return Some(d_max);
+    }
+
+    let mut lo = d_min;
+    let mut hi = d_max;
+    for _ in 0..200 {
+        let mid = 0.5 * (lo + hi);
+        if is_detectable_w1(survey, mass_earth, mid) {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+        if hi - lo < 1e-4 {
+            break;
+        }
+    }
+    Some(0.5 * (lo + hi))
+}
+
+/// Per-position W1 detection probability: the magnitude-efficiency at the
+/// planet's modelled W1 magnitude, gated by the galactic-plane footprint mask.
+pub fn detection_probability(survey: &WiseSurvey, p9: &P9Thermal, galactic_lat_deg: f64) -> f64 {
+    let footprint = if survey.in_footprint(galactic_lat_deg) {
+        1.0
+    } else {
+        0.0
+    };
+    survey.detection_efficiency(p9.w1_magnitude()) * footprint
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nearby_massive_planet_is_detectable() {
+        let survey = WiseSurvey::default();
+        // A 15 M⊕ planet at 180 AU is brighter than the W1 depth in reflected
+        // light (the cold-body W1 signal; see thermal_model docs).
+        assert!(is_detectable_w1(&survey, 15.0, 180.0));
+    }
+
+    #[test]
+    fn distant_low_mass_planet_is_not_detectable() {
+        let survey = WiseSurvey::default();
+        // A 5 M⊕ planet at 1000 AU is far below the W1 depth.
+        assert!(!is_detectable_w1(&survey, 5.0, 1000.0));
+    }
+
+    #[test]
+    fn max_distance_is_finite_and_decreases_with_mass() {
+        let survey = WiseSurvey::default();
+        let d_heavy = max_detectable_distance(&survey, 15.0).expect("heavy detectable");
+        let d_light = max_detectable_distance(&survey, 8.0).expect("light detectable");
+        assert!(d_heavy.is_finite() && d_light.is_finite());
+        // A more massive (larger, brighter) planet is detectable farther out.
+        assert!(
+            d_heavy > d_light,
+            "heavier planet reaches farther: {d_heavy:.0} vs {d_light:.0} AU"
+        );
+        // The WISE W1 cold-body exclusion reaches the low hundreds of AU.
+        assert!(
+            (100.0..400.0).contains(&d_heavy),
+            "d_max(15 M⊕) = {d_heavy:.0} AU"
+        );
+    }
+
+    #[test]
+    fn crossover_magnitude_equals_depth() {
+        let survey = WiseSurvey::default();
+        let d = max_detectable_distance(&survey, 12.0).expect("detectable");
+        let m = w1_magnitude(12.0, d);
+        assert!((m - survey.w1_depth).abs() < 1e-2, "W1({d:.1} AU) = {m:.3}");
+    }
+
+    #[test]
+    fn footprint_gates_detection_probability() {
+        let survey = WiseSurvey::default();
+        let p9 = P9Thermal::new(15.0, 170.0);
+        // Out of the galactic plane: high probability; in the plane: zero.
+        assert!(detection_probability(&survey, &p9, 45.0) > 0.5);
+        assert_eq!(detection_probability(&survey, &p9, 2.0), 0.0);
+    }
+}

--- a/crates/p9-2018-wise-search/src/exclusion.rs
+++ b/crates/p9-2018-wise-search/src/exclusion.rs
@@ -1,0 +1,210 @@
+//! Parameter-space exclusion from the WISE W1 non-detection.
+//!
+//! Meisner et al. (2018) found no Planet Nine in the WISE shift-and-stack
+//! search. The fraction of a reference Planet Nine population that WISE
+//! *would* have detected is therefore the fraction of parameter space the
+//! non-detection excludes. Each realization's per-object detection
+//! probability is the product of
+//!   * the W1 magnitude-efficiency at its thermal+reflected W1 magnitude
+//!     (`thermal_model` + `survey_model`), and
+//!   * the galactic-plane footprint mask (`sky`/`survey_model`).
+//! The expected exclusion fraction is the mean of these probabilities over a
+//! seeded population sampled across the Batygin & Brown mass/distance/orbit
+//! ranges.
+
+use serde::{Deserialize, Serialize};
+
+use crate::detectability::detection_probability;
+use crate::sky::galactic_latitude_deg;
+use crate::survey_model::WiseSurvey;
+use crate::thermal_model::P9Thermal;
+use p9_core::types::OrbitalElements;
+
+/// One reference Planet Nine realization: orbital elements, mass, and the
+/// heliocentric distance at its current mean anomaly.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ReferenceP9 {
+    pub elements: OrbitalElements,
+    pub mass_earth: f64,
+    pub distance_au: f64,
+}
+
+/// Result of the WISE exclusion analysis.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExclusionResult {
+    /// Expected fraction of the reference population WISE would have detected.
+    pub fraction_excluded: f64,
+    /// Number of realizations evaluated.
+    pub n_total: u32,
+    /// Expected number detected (sum of per-object probabilities).
+    pub expected_excluded: f64,
+}
+
+/// Compute the expected WISE W1 exclusion fraction over a reference
+/// population, accumulating per-object detection probabilities
+/// deterministically (no RNG inside).
+pub fn compute_exclusion(survey: &WiseSurvey, population: &[ReferenceP9]) -> ExclusionResult {
+    let n_total = population.len() as u32;
+    let expected_excluded: f64 = population
+        .iter()
+        .map(|p| {
+            let p9 = P9Thermal::new(p.mass_earth, p.distance_au);
+            let b = galactic_latitude_deg(&p.elements);
+            detection_probability(survey, &p9, b)
+        })
+        .sum();
+
+    let fraction_excluded = if n_total > 0 {
+        expected_excluded / n_total as f64
+    } else {
+        0.0
+    };
+
+    ExclusionResult {
+        fraction_excluded,
+        n_total,
+        expected_excluded,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::thermal_model::w1_magnitude;
+    use p9_2021_orbit::reference_population::{
+        generate_reference_population, heliocentric_distance,
+    };
+    use p9_core::types::P9Params;
+    use rand::SeedableRng;
+
+    /// Build a WISE reference population from the shared p9-2021-orbit
+    /// posterior emulator, recomputing heliocentric distance from the sampled
+    /// elements (the emulator's `v_magnitude` is reflected-optical and not
+    /// used here — WISE works in W1).
+    fn wise_population(n: usize, seed: u64) -> Vec<ReferenceP9> {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        generate_reference_population(n, &mut rng)
+            .into_iter()
+            .map(|p| {
+                let params = P9Params {
+                    mass_earth: p.mass,
+                    a: p.a,
+                    e: p.e,
+                    i: p.i,
+                    omega: p.omega,
+                    omega_big: p.omega_big,
+                    mean_anomaly: p.mean_anomaly,
+                };
+                ReferenceP9 {
+                    elements: OrbitalElements {
+                        a: p.a,
+                        e: p.e,
+                        i: p.i,
+                        omega: p.omega,
+                        omega_big: p.omega_big,
+                        mean_anomaly: p.mean_anomaly,
+                    },
+                    mass_earth: p.mass,
+                    distance_au: heliocentric_distance(&params),
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn exclusion_fraction_is_a_probability() {
+        let pop = wise_population(3000, 2018);
+        let survey = WiseSurvey::default();
+        let result = compute_exclusion(&survey, &pop);
+        assert!(
+            result.fraction_excluded > 0.0 && result.fraction_excluded < 1.0,
+            "fraction = {}",
+            result.fraction_excluded
+        );
+    }
+
+    #[test]
+    fn exclusion_increases_with_assumed_mass() {
+        // Shift the whole population to a heavier (brighter in W1) mass and
+        // the exclusion fraction must increase.
+        let base = wise_population(3000, 7);
+        let survey = WiseSurvey::default();
+
+        let light: Vec<ReferenceP9> = base
+            .iter()
+            .map(|p| ReferenceP9 {
+                mass_earth: 5.0,
+                ..*p
+            })
+            .collect();
+        let heavy: Vec<ReferenceP9> = base
+            .iter()
+            .map(|p| ReferenceP9 {
+                mass_earth: 18.0,
+                ..*p
+            })
+            .collect();
+
+        let f_light = compute_exclusion(&survey, &light).fraction_excluded;
+        let f_heavy = compute_exclusion(&survey, &heavy).fraction_excluded;
+        assert!(
+            f_heavy > f_light + 0.005,
+            "heavy {f_heavy:.4} should exceed light {f_light:.4}"
+        );
+    }
+
+    #[test]
+    fn footprint_matters() {
+        // Removing the galactic mask (all-sky) raises the exclusion fraction.
+        let pop = wise_population(3000, 11);
+        let masked = WiseSurvey::default();
+        let all_sky = WiseSurvey {
+            galactic_mask_deg: 0.0,
+            ..WiseSurvey::default()
+        };
+        let f_masked = compute_exclusion(&masked, &pop).fraction_excluded;
+        let f_all = compute_exclusion(&all_sky, &pop).fraction_excluded;
+        // The galactic mask removes ~17% of the sky, so all-sky exceeds the
+        // masked footprint by roughly that factor of the (small) exclusion.
+        assert!(
+            f_all > f_masked * 1.05,
+            "all-sky {f_all:.4} should exceed masked {f_masked:.4}"
+        );
+    }
+
+    #[test]
+    fn nearby_massive_excluded_distant_lowmass_not() {
+        let survey = WiseSurvey::default();
+        // Nearby + massive: brighter than the W1 depth.
+        assert!(w1_magnitude(18.0, 180.0) < survey.w1_depth);
+        // Distant + low mass: fainter than the depth (undetectable, not excluded).
+        assert!(w1_magnitude(5.0, 1200.0) > survey.w1_depth);
+    }
+
+    #[test]
+    fn all_distant_lowmass_population_barely_excluded() {
+        // A population of cold, light, very distant planets: WISE detects
+        // essentially none of them.
+        let survey = WiseSurvey::default();
+        let pop: Vec<ReferenceP9> = (0..200)
+            .map(|k| ReferenceP9 {
+                elements: OrbitalElements {
+                    a: 1500.0,
+                    e: 0.1,
+                    i: 0.3,
+                    omega: 0.0,
+                    omega_big: 0.0,
+                    mean_anomaly: k as f64 * 0.03,
+                },
+                mass_earth: 4.0,
+                distance_au: 1400.0,
+            })
+            .collect();
+        let result = compute_exclusion(&survey, &pop);
+        assert!(
+            result.fraction_excluded < 0.01,
+            "f = {}",
+            result.fraction_excluded
+        );
+    }
+}

--- a/crates/p9-2018-wise-search/src/lib.rs
+++ b/crates/p9-2018-wise-search/src/lib.rs
@@ -1,0 +1,31 @@
+//! Reproduction of Meisner, Bromley, Kenyon & Anderson (2018)
+//! "Searching for Planet Nine with Coadded WISE and NEOWISE-Reactivation
+//! Images" (arXiv:1712.04950).
+//!
+//! A wide-area WISE W1/W2 thermal-infrared shift-and-stack search for a slow
+//! moving point source detects no Planet Nine. The W1 (3.4 µm) co-add depth
+//! (W1 ≈ 16.5 Vega, `p9_core::analysis::surveys`) over a near-all-sky
+//! footprint excludes a region of the Planet Nine mass–distance parameter
+//! space — a thermal-IR analog of the optical ZTF/DES/PS1 exclusions.
+//!
+//! What this crate computes (no hard-coded answers):
+//! - [`thermal_model`]: the W1 apparent magnitude of a P9 of given mass and
+//!   heliocentric distance, from a documented thermal-emission + reflected
+//!   sunlight model converted to the WISE W1 Vega magnitude system.
+//! - [`survey_model`]: the W1 depth (from the shared survey table) and the
+//!   near-all-sky footprint with a masked galactic-plane confusion band.
+//! - [`detectability`]: the maximum heliocentric distance at which a
+//!   given-mass P9 reaches the W1 depth (a finite, computed AU value that
+//!   decreases with decreasing mass).
+//! - [`exclusion`]: the fraction of a seeded reference P9 population WISE
+//!   would have detected (in (0,1), increasing with assumed mass).
+//!
+//! Published reference numbers are kept as labelled constants
+//! ([`survey_model::W1_DEPTH_REFERENCE`] = 16.5; the excluded distance range
+//! of ~hundreds of AU is documented in the detectability tests).
+
+pub mod detectability;
+pub mod exclusion;
+pub mod sky;
+pub mod survey_model;
+pub mod thermal_model;

--- a/crates/p9-2018-wise-search/src/sky.rs
+++ b/crates/p9-2018-wise-search/src/sky.rs
@@ -1,0 +1,69 @@
+//! Orbit → sky-position mapping for the WISE footprint model.
+//!
+//! WISE's footprint cut is in galactic latitude (the masked galactic-plane
+//! confusion band), so we map orbital elements to a heliocentric ecliptic
+//! Cartesian state (p9-core) and then to galactic coordinates via
+//! `p9_core::coords::sky` (starfield ECLIPJ2000 → GALACTIC frame matrices).
+//! At hundreds of AU the heliocentric/geocentric parallax (< 0.2°) is
+//! negligible for the footprint question and is neglected.
+
+use p9_core::constants::{GM_SUN, RAD2DEG};
+use p9_core::coords::sky::{ecliptic_to_galactic_matrix, ecliptic_vec_to_equatorial_deg};
+use p9_core::types::OrbitalElements;
+
+/// Equatorial declination (degrees) of an orbit's current sky position.
+pub fn declination_deg(elem: &OrbitalElements) -> f64 {
+    let state = elem.to_state_vector(GM_SUN);
+    let (_, dec) = ecliptic_vec_to_equatorial_deg(&state.pos);
+    dec
+}
+
+/// Galactic latitude b (degrees) of an orbit's current sky position.
+pub fn galactic_latitude_deg(elem: &OrbitalElements) -> f64 {
+    let state = elem.to_state_vector(GM_SUN);
+    let gal = ecliptic_to_galactic_matrix() * state.pos;
+    (gal.z / gal.norm()).asin() * RAD2DEG
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p9_core::constants::DEG2RAD;
+
+    fn elem(i_deg: f64, omega_deg: f64, omega_big_deg: f64, m_deg: f64) -> OrbitalElements {
+        OrbitalElements {
+            a: 500.0,
+            e: 0.2,
+            i: i_deg * DEG2RAD,
+            omega: omega_deg * DEG2RAD,
+            omega_big: omega_big_deg * DEG2RAD,
+            mean_anomaly: m_deg * DEG2RAD,
+        }
+    }
+
+    #[test]
+    fn galactic_latitude_in_range() {
+        for m in 0..360 {
+            let b = galactic_latitude_deg(&elem(20.0, 60.0, 120.0, m as f64));
+            assert!(b.abs() <= 90.0 + 1e-6, "|b| = {b}");
+        }
+    }
+
+    #[test]
+    fn a_low_inclination_orbit_crosses_the_galactic_plane() {
+        // Over a full orbit a near-ecliptic object sweeps a range of galactic
+        // latitudes (the ecliptic is inclined ~60° to the galactic plane), so
+        // some mean anomalies fall in the masked band and some do not.
+        let mut min_b: f64 = 90.0;
+        let mut max_b: f64 = -90.0;
+        for m in 0..360 {
+            let b = galactic_latitude_deg(&elem(5.0, 0.0, 0.0, m as f64));
+            min_b = min_b.min(b);
+            max_b = max_b.max(b);
+        }
+        assert!(
+            min_b < 10.0 && max_b > 10.0,
+            "b range [{min_b:.1}, {max_b:.1}]"
+        );
+    }
+}

--- a/crates/p9-2018-wise-search/src/survey_model.rs
+++ b/crates/p9-2018-wise-search/src/survey_model.rs
@@ -1,0 +1,115 @@
+//! WISE/NEOWISE survey characteristics for the Planet Nine search of
+//! Meisner et al. (2018).
+//!
+//! WISE is a near-all-sky thermal-IR survey. The shift-and-stack co-adds used
+//! by Meisner et al. reach a W1 single-frame-stack depth of ≈ 16.5 (Vega),
+//! taken from the shared `p9_core::analysis::surveys` table ("WISE W1"). The
+//! search covers essentially the whole sky in inertial coordinates; the
+//! dominant losses are confusion near the galactic plane (high source density
+//! and cirrus) which is masked. We model the footprint as all-sky minus a
+//! galactic-latitude exclusion band, evaluated with `p9_core::coords::sky`.
+
+use serde::{Deserialize, Serialize};
+
+use p9_core::analysis::surveys::limiting_magnitude;
+
+/// Published WISE W1 single-exposure / shift-and-stack depth (Vega mag),
+/// kept as a labelled reference constant; the live value comes from the
+/// shared survey table and the two are pinned equal in the tests.
+pub const W1_DEPTH_REFERENCE: f64 = 16.5;
+
+/// Galactic-latitude half-width (degrees) of the masked confusion band about
+/// the galactic plane. Meisner et al. (2018) note the galactic plane is the
+/// region of poorest sensitivity in the WISE shift-and-stack search; |b| < 10°
+/// is a representative mask that removes ~17% of the sky (sin 10° ≈ 0.174).
+pub const GALACTIC_MASK_DEG: f64 = 10.0;
+
+/// WISE survey model for the Planet Nine W1 search.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WiseSurvey {
+    /// W1 (3.4 µm) limiting magnitude (Vega), from the shared survey table.
+    pub w1_depth: f64,
+    /// Logistic steepness of the magnitude-efficiency roll-off (mag⁻¹).
+    pub efficiency_steepness: f64,
+    /// Half-width of the masked galactic-plane band in galactic latitude
+    /// (degrees); positions with |b| below this are excluded from the search.
+    pub galactic_mask_deg: f64,
+}
+
+impl Default for WiseSurvey {
+    fn default() -> Self {
+        Self {
+            w1_depth: limiting_magnitude("WISE W1").expect("WISE W1 in shared survey table"),
+            efficiency_steepness: 4.0,
+            galactic_mask_deg: GALACTIC_MASK_DEG,
+        }
+    }
+}
+
+impl WiseSurvey {
+    /// Magnitude-dependent recovery efficiency: a logistic roll-off centered
+    /// on the W1 depth (ε = 0.5 at the limit, → 1 well above it in flux /
+    /// below it in magnitude, → 0 for faint sources).
+    pub fn detection_efficiency(&self, w1_mag: f64) -> f64 {
+        1.0 / (1.0 + ((w1_mag - self.w1_depth) * self.efficiency_steepness).exp())
+    }
+
+    /// Whether a galactic latitude (degrees) lies outside the masked plane.
+    pub fn in_footprint(&self, galactic_lat_deg: f64) -> bool {
+        galactic_lat_deg.abs() >= self.galactic_mask_deg
+    }
+
+    /// Fraction of the celestial sphere covered: all-sky minus the masked
+    /// galactic band |b| < galactic_mask. The unmasked solid-angle fraction
+    /// is cos-weighted: f = 1 − sin(b_mask).
+    pub fn sky_coverage_fraction(&self) -> f64 {
+        1.0 - self.galactic_mask_deg.to_radians().sin()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_w1_depth_matches_shared_table() {
+        let survey = WiseSurvey::default();
+        assert!((survey.w1_depth - 16.5).abs() < 1e-10);
+        assert!((survey.w1_depth - W1_DEPTH_REFERENCE).abs() < 1e-10);
+    }
+
+    #[test]
+    fn efficiency_is_logistic() {
+        let survey = WiseSurvey::default();
+        assert!(survey.detection_efficiency(14.0) > 0.99);
+        assert!((survey.detection_efficiency(16.5) - 0.5).abs() < 1e-10);
+        assert!(survey.detection_efficiency(19.0) < 0.01);
+    }
+
+    #[test]
+    fn galactic_plane_is_masked() {
+        let survey = WiseSurvey::default();
+        assert!(survey.in_footprint(60.0));
+        assert!(survey.in_footprint(10.0));
+        assert!(!survey.in_footprint(0.0));
+        assert!(!survey.in_footprint(-5.0));
+    }
+
+    #[test]
+    fn coverage_is_near_all_sky() {
+        let survey = WiseSurvey::default();
+        let f = survey.sky_coverage_fraction();
+        // |b| < 10° removes ~17% of the sky; coverage ~83%.
+        assert!(f > 0.80 && f < 0.85, "coverage = {f:.3}");
+    }
+
+    #[test]
+    fn wider_mask_lowers_coverage() {
+        let narrow = WiseSurvey::default();
+        let wide = WiseSurvey {
+            galactic_mask_deg: 20.0,
+            ..WiseSurvey::default()
+        };
+        assert!(wide.sky_coverage_fraction() < narrow.sky_coverage_fraction());
+    }
+}

--- a/crates/p9-2018-wise-search/src/thermal_model.rs
+++ b/crates/p9-2018-wise-search/src/thermal_model.rs
@@ -1,0 +1,275 @@
+//! WISE W1 (3.4 µm) detectability model for Planet Nine.
+//!
+//! Meisner et al. (2018) searched the WISE/NEOWISE data with a shift-and-stack
+//! technique for a thermal-infrared point source. For a cold, distant planet
+//! the relevant band is W1 (3.4 µm), with a co-added single-frame depth of
+//! W1 ≈ 16.5 (Vega), from `p9_core::analysis::surveys` ("WISE W1").
+//!
+//! Two emission channels contribute at 3.4 µm and the total flux is their sum:
+//!
+//! 1. **Thermal emission.** The planet radiates as a grey body at an effective
+//!    temperature set by the larger of (a) solar heating and (b) an internal
+//!    luminosity floor. Flux ∝ (R/d)² · B_ν(T), with B_ν the Planck function.
+//!
+//! 2. **Reflected sunlight.** The planet reflects the 3.4 µm solar flux; this
+//!    scales as 1/(r²Δ²) — once for Sun→planet, once for planet→observer.
+//!
+//! **Honest residual / physics note.** At W1 (3.4 µm) a cold (≈40 K) ice
+//! giant sits *extremely* far down the Wien tail: hν/kT ≈ 107 at 40 K, so its
+//! blackbody thermal flux at 3.4 µm is ~10⁻⁵⁵ W/m²/Hz/sr and utterly
+//! negligible. The thermal channel only overtakes reflected sunlight above
+//! ≈175 K (at 15 M⊕, 400 AU). So for the cold Planet Nine the paper targets, the
+//! WISE W1 detectability is in practice set by **reflected sunlight**, and
+//! this crate's "thermal-IR" exclusion is, at W1, a reflected-light exclusion
+//! — the thermal term is retained (and would dominate for an implausibly warm
+//! body) but contributes nothing at 40 K. The W2 (4.6 µm) band of the actual
+//! Meisner et al. search is somewhat more thermally favorable; we model the
+//! deeper, bluer W1 band that the shared survey table pins.
+//!
+//! Both channels are converted to a Vega-system W1 magnitude with the WISE W1
+//! zero point F_ν0 = 309.540 Jy (Wright et al. 2010, Table 1). The radius law
+//! is the shared Neptune-anchored mass-radius relation in
+//! `p9_core::analysis::photometry` (R ≈ 3.34 R⊕ at 10 M⊕).
+
+use std::f64::consts::PI;
+
+use p9_core::analysis::photometry::mass_radius_neptunian;
+
+/// Planck constant (J·s).
+const H_PLANCK: f64 = 6.626_070_15e-34;
+/// Boltzmann constant (J/K).
+const K_BOLTZ: f64 = 1.380_649e-23;
+/// Speed of light (m/s).
+const C_LIGHT: f64 = 2.997_924_58e8;
+/// Earth radius (m).
+const R_EARTH_M: f64 = 6.371e6;
+/// 1 AU in meters.
+const AU_M: f64 = 1.495_978_707e11;
+/// Solar radius (m).
+const R_SUN_M: f64 = 6.957e8;
+/// Solar effective temperature (K).
+const T_SUN: f64 = 5778.0;
+
+/// WISE W1 effective wavelength in meters (3.3526 µm; Wright et al. 2010).
+pub const W1_WAVELENGTH_M: f64 = 3.3526e-6;
+
+/// WISE W1 Vega zero-point flux density in Jansky: a 0.0-mag (Vega) source
+/// has F_ν = 309.540 Jy at W1 (Wright et al. 2010, Table 1). A source of
+/// flux F has W1 = −2.5 log10(F / F_ν0).
+pub const W1_ZERO_POINT_JY: f64 = 309.540;
+
+/// 1 Jansky in W/m²/Hz.
+const JY: f64 = 1.0e-26;
+
+/// Default geometric/Bond-like albedo for the reflected-light channel
+/// (Neptune-like, used by the workspace photometry).
+pub const DEFAULT_ALBEDO: f64 = 0.41;
+
+/// Internal-luminosity temperature floor (K). A cold ice giant retains
+/// formation/radiogenic heat; Fortney et al. (2016) and the Meisner et al.
+/// (2018) discussion adopt an effective temperature of ~30–40 K for a
+/// several-Earth-mass Planet Nine essentially independent of heliocentric
+/// distance beyond a few hundred AU. We take 40 K as the nominal internal
+/// floor and let solar heating raise it when it dominates (it does not at
+/// these distances).
+pub const INTERNAL_TEMP_FLOOR_K: f64 = 40.0;
+
+/// Physical parameters of a candidate Planet Nine for the W1 model.
+#[derive(Debug, Clone, Copy)]
+pub struct P9Thermal {
+    /// Mass in Earth masses.
+    pub mass_earth: f64,
+    /// Heliocentric distance in AU.
+    pub distance_au: f64,
+    /// Geometric albedo for the reflected-light channel.
+    pub albedo: f64,
+    /// Internal-luminosity effective-temperature floor in Kelvin.
+    pub internal_temp_k: f64,
+}
+
+impl P9Thermal {
+    /// A Planet Nine at the given mass and heliocentric distance with the
+    /// default albedo and internal-temperature floor.
+    pub fn new(mass_earth: f64, distance_au: f64) -> Self {
+        Self {
+            mass_earth,
+            distance_au,
+            albedo: DEFAULT_ALBEDO,
+            internal_temp_k: INTERNAL_TEMP_FLOOR_K,
+        }
+    }
+
+    /// Physical radius in meters (Neptune-anchored mass-radius relation).
+    pub fn radius_m(&self) -> f64 {
+        mass_radius_neptunian(self.mass_earth) * R_EARTH_M
+    }
+
+    /// Solar equilibrium temperature (K) for a fast rotator radiating from
+    /// its full surface: T_eq = T_sun √(R_sun / 2d) (1 − A)^¼.
+    pub fn solar_equilibrium_temp(&self) -> f64 {
+        let d_m = self.distance_au * AU_M;
+        T_SUN * (R_SUN_M / (2.0 * d_m)).sqrt() * (1.0 - self.albedo).powf(0.25)
+    }
+
+    /// Effective temperature: the larger of the internal-heat floor and the
+    /// solar-equilibrium temperature. Beyond a few hundred AU the solar term
+    /// is ~10 K, so the internal floor dominates.
+    pub fn effective_temp(&self) -> f64 {
+        self.solar_equilibrium_temp().max(self.internal_temp_k)
+    }
+
+    /// Planck function B_ν(T) in W/m²/Hz/sr at frequency `nu_hz`.
+    fn planck_bnu(t: f64, nu_hz: f64) -> f64 {
+        let x = H_PLANCK * nu_hz / (K_BOLTZ * t);
+        if x > 700.0 {
+            return 0.0;
+        }
+        (2.0 * H_PLANCK * nu_hz.powi(3) / (C_LIGHT * C_LIGHT)) / (x.exp() - 1.0)
+    }
+
+    /// Thermal flux density at W1 (Jy), a grey-body emitter of unit
+    /// emissivity: F_ν = π B_ν(T) (R/d)².
+    pub fn thermal_flux_w1_jy(&self) -> f64 {
+        let nu = C_LIGHT / W1_WAVELENGTH_M;
+        let bnu = Self::planck_bnu(self.effective_temp(), nu);
+        let r = self.radius_m();
+        let d = self.distance_au * AU_M;
+        let solid_angle = PI * (r / d).powi(2);
+        solid_angle * bnu / JY
+    }
+
+    /// Reflected-sunlight flux density at W1 (Jy), observed near opposition
+    /// (Δ = d − 1 AU). The Sun is a blackbody at `T_SUN`; the solar W1 flux
+    /// at the planet is π B_ν(T_sun) (R_sun / r)². The planet intercepts a
+    /// disc πR_p², reflects a fraction `albedo` into ~2π sr (Lambert factor
+    /// absorbed into the geometric albedo), and that reradiated flux falls
+    /// as 1/Δ² to the observer:
+    ///
+    ///   F_refl = albedo · [π B_ν(T_sun) (R_sun/r)²] · (R_p² / (4 Δ²)).
+    pub fn reflected_flux_w1_jy(&self) -> f64 {
+        let nu = C_LIGHT / W1_WAVELENGTH_M;
+        let bnu_sun = Self::planck_bnu(T_SUN, nu);
+        let solar_flux_at_planet = PI * bnu_sun * (R_SUN_M / (self.distance_au * AU_M)).powi(2);
+        let r_p = self.radius_m();
+        let delta_m = (self.distance_au - 1.0).max(1.0) * AU_M;
+        let reflected =
+            self.albedo * solar_flux_at_planet * (r_p * r_p) / (4.0 * delta_m * delta_m);
+        reflected / JY
+    }
+
+    /// Total W1 flux density (Jy): thermal + reflected.
+    pub fn total_flux_w1_jy(&self) -> f64 {
+        self.thermal_flux_w1_jy() + self.reflected_flux_w1_jy()
+    }
+
+    /// Apparent W1 (Vega) magnitude from the total flux density. Fainter
+    /// (larger) numbers for smaller flux; +∞ when the flux is zero.
+    pub fn w1_magnitude(&self) -> f64 {
+        let flux = self.total_flux_w1_jy();
+        if flux <= 0.0 {
+            return f64::INFINITY;
+        }
+        -2.5 * (flux / W1_ZERO_POINT_JY).log10()
+    }
+}
+
+/// Apparent W1 magnitude for a default-albedo P9 of `mass_earth` at
+/// heliocentric distance `distance_au`.
+pub fn w1_magnitude(mass_earth: f64, distance_au: f64) -> f64 {
+    P9Thermal::new(mass_earth, distance_au).w1_magnitude()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn radius_matches_ice_giant_models() {
+        let r = P9Thermal::new(10.0, 500.0).radius_m() / R_EARTH_M;
+        assert!(r > 3.0 && r < 3.6, "R(10 M⊕) = {r:.2} R⊕");
+    }
+
+    #[test]
+    fn solar_heating_is_cold_and_floor_dominates() {
+        // At hundreds of AU solar equilibrium is ~10 K, below the internal
+        // floor, so the effective temperature is the floor.
+        let p = P9Thermal::new(10.0, 500.0);
+        assert!(
+            p.solar_equilibrium_temp() < 15.0,
+            "T_eq = {:.1} K",
+            p.solar_equilibrium_temp()
+        );
+        assert!((p.effective_temp() - INTERNAL_TEMP_FLOOR_K).abs() < 1e-9);
+    }
+
+    #[test]
+    fn magnitude_brightens_with_mass() {
+        // More massive -> larger radius -> more flux -> smaller (brighter) mag.
+        let light = w1_magnitude(5.0, 500.0);
+        let heavy = w1_magnitude(15.0, 500.0);
+        assert!(
+            heavy < light,
+            "heavy {heavy:.2} should be brighter than light {light:.2}"
+        );
+    }
+
+    #[test]
+    fn magnitude_faints_with_distance() {
+        let near = w1_magnitude(10.0, 400.0);
+        let far = w1_magnitude(10.0, 800.0);
+        assert!(
+            far > near,
+            "far {far:.2} should be fainter than near {near:.2}"
+        );
+    }
+
+    #[test]
+    fn reflected_dominates_at_cold_temperatures_but_thermal_wins_when_warm() {
+        // The honest W1 physics: at the 40 K floor the thermal 3.4 µm flux is
+        // negligible and reflected sunlight dominates...
+        let cold = P9Thermal::new(15.0, 400.0);
+        assert!(
+            cold.reflected_flux_w1_jy() > 1e6 * cold.thermal_flux_w1_jy(),
+            "at 40 K reflected {:.3e} should swamp thermal {:.3e} Jy",
+            cold.reflected_flux_w1_jy(),
+            cold.thermal_flux_w1_jy()
+        );
+        // ...but only a hot (≳175 K) body crosses over to thermal at 3.4 µm,
+        // far above any plausible Planet Nine temperature — underscoring how
+        // thermally hostile W1 is for a cold planet.
+        let warm = P9Thermal {
+            internal_temp_k: 200.0,
+            ..cold
+        };
+        assert!(
+            warm.thermal_flux_w1_jy() > warm.reflected_flux_w1_jy(),
+            "at 120 K thermal {:.3e} should exceed reflected {:.3e} Jy",
+            warm.thermal_flux_w1_jy(),
+            warm.reflected_flux_w1_jy()
+        );
+    }
+
+    #[test]
+    fn zero_point_gives_zero_magnitude() {
+        // A source emitting exactly the W1 zero-point flux is W1 = 0.
+        let flux = W1_ZERO_POINT_JY;
+        let mag = -2.5 * (flux / W1_ZERO_POINT_JY).log10();
+        assert!(mag.abs() < 1e-12);
+    }
+
+    #[test]
+    fn thermal_flux_steeply_temperature_dependent() {
+        // On the Wien tail at 3.4 µm a 50 K planet is vastly brighter than a
+        // 30 K one of the same size/distance.
+        let cold = P9Thermal {
+            internal_temp_k: 30.0,
+            ..P9Thermal::new(10.0, 500.0)
+        };
+        let warm = P9Thermal {
+            internal_temp_k: 50.0,
+            ..P9Thermal::new(10.0, 500.0)
+        };
+        let ratio = warm.thermal_flux_w1_jy() / cold.thermal_flux_w1_jy();
+        assert!(ratio > 100.0, "warm/cold thermal ratio = {ratio:.1}");
+    }
+}


### PR DESCRIPTION
Reproduces Meisner et al. (2018), "Searching for Planet Nine with WISE/NEOWISE" (arXiv:1712.04950): a wide-area W1/W2 shift-and-stack search that detects no Planet Nine and excludes a region of the mass-distance parameter space, a thermal-IR analog of the optical ZTF/DES/PS1 exclusions.

New crate `p9-2018-wise-search`, mirroring the `p9-2021-ztf` structure and reusing `p9-core`:

- `thermal_model`: W1 (3.4 um) apparent magnitude of a P9 of given mass/distance from a documented thermal-emission (Planck grey body, internal-heat floor + solar equilibrium) plus reflected-sunlight model, converted to the WISE W1 Vega system (zero point 309.54 Jy, Wright et al. 2010). Radius from the shared Neptune-anchored mass-radius relation.
- `survey_model`: W1 depth pulled live from `p9_core::analysis::surveys` ("WISE W1" = 16.5), near-all-sky footprint with a masked galactic-plane confusion band, logistic magnitude efficiency.
- `detectability`: finite maximum heliocentric distance (bisection) at which a given-mass P9 reaches the W1 depth; decreases with decreasing mass.
- `exclusion`: fraction of a seeded reference P9 population (from the shared `p9-2021-orbit` posterior emulator) that WISE would have detected.

Pinned in tests: W1 depth == 16.5 from the shared table; finite max-detectable distance that increases with mass; exclusion fraction in (0,1) increasing with assumed mass; nearby/massive excluded, distant/low-mass not.

Honest residual (documented in code and REPRODUCTION_NOTES.md #10): at W1's 3.4 um a 40 K planet sits far down the Wien tail (hv/kT ~ 107), so its thermal flux is ~1e-55 W/m2/Hz/sr and the W1 detectability of a cold body is set by reflected sunlight, not thermal emission (thermal only wins above ~175 K). The reflected-light W1 reach is ~186-222 AU, only clipping the near edge of the q ~ 300 AU posterior, so the computed exclusion is a few percent (~2% at 6.2 M_earth, ~7% at 18 M_earth) - far below optical ZTF's 56%, but a real, monotonic-in-mass result.

Gate: `cargo build`, `cargo test` (24 pass), `cargo fmt` all green.

Closes #64