### PR TITLE
Add Holman 2025 PS1 shift-and-stack search crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,9 +1325,11 @@ name = "p9-2021-orbit"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "nalgebra",
  "p9-core",
  "rand 0.8.5",
  "rand_distr",
+ "rayon",
  "serde",
  "serde_json",
 ]
@@ -1442,6 +1444,20 @@ name = "p9-2025-perturbation"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "p9-core",
+ "rand 0.8.5",
+ "rand_distr",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "p9-2025-ps1-holman"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "p9-2021-orbit",
+ "p9-2022-des",
  "p9-core",
  "rand 0.8.5",
  "rand_distr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/p9-2024-neptune-crossing",
     "crates/p9-2024-oort-selfgrav",
     "crates/p9-2024-panstarrs",
+    "crates/p9-2025-ps1-holman",
     "crates/p9-2025-clustering",
     "crates/p9-2025-iras-akari",
     "crates/p9-2025-perturbation",

--- a/crates/p9-2025-ps1-holman/Cargo.toml
+++ b/crates/p9-2025-ps1-holman/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "p9-2025-ps1-holman"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+p9-core = { path = "../p9-core" }
+rand = { workspace = true }
+rand_distr = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+p9-2021-orbit = { version = "0.1.0", path = "../p9-2021-orbit" }
+p9-2022-des = { version = "0.1.0", path = "../p9-2022-des" }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/p9-2025-ps1-holman/src/exclusion.rs
+++ b/crates/p9-2025-ps1-holman/src/exclusion.rs
@@ -1,0 +1,226 @@
+//! Parameter-space exclusion for the Holman et al. (2025) PS1 search.
+//!
+//! Mirrors the ZTF/panstarrs exclusion pattern: a seeded reference P9
+//! population (the `p9-2021-orbit` posterior emulator) is piped through the
+//! shift-and-stack survey model. Each orbit's declination places it in or
+//! out of the 3-pi footprint, and its apparent r magnitude sets its
+//! recovery efficiency. Since Holman et al. find no Planet Nine, the
+//! expected exclusion fraction is the mean per-orbit detection probability.
+//!
+//! Independent of and complementary to `p9-2024-panstarrs`: that crate
+//! models the catalog-linking search; this one the pixel-level
+//! shift-and-stack search of the same PS1 3-pi data.
+
+use rand::{Rng, SeedableRng};
+use serde::{Deserialize, Serialize};
+
+use p9_2021_orbit::reference_population::generate_reference_population;
+use p9_2022_des::sky::apparent_position_deg;
+use p9_core::types::OrbitalElements;
+
+use crate::survey_model::Ps1StackSurvey;
+
+/// A reference-population member reduced to the observables the survey model
+/// needs: an equatorial declination and an apparent r magnitude.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct DetectionTarget {
+    pub dec_deg: f64,
+    pub r_magnitude: f64,
+}
+
+/// Result of the exclusion analysis.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExclusionResult {
+    /// Expected fraction of the reference population this PS1 search detects
+    /// (and so excludes, given the non-detection).
+    pub fraction_excluded: f64,
+    /// Number of reference draws evaluated.
+    pub n_total: u32,
+    /// Expected number of draws detected (sum of per-orbit probabilities).
+    pub expected_excluded: f64,
+}
+
+/// Equatorial declination (deg) of an orbit at its stored epoch, via the
+/// shared `p9-2022-des` ecliptic->equatorial apparent-position conversion.
+pub fn declination_deg(elements: &OrbitalElements) -> f64 {
+    let (_, dec, _) = apparent_position_deg(elements, 0.0);
+    dec
+}
+
+/// Generate a seeded reference population reduced to detection targets,
+/// drawn from the `p9-2021-orbit` posterior emulator.
+pub fn reference_targets(n: usize, seed: u64) -> Vec<DetectionTarget> {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    generate_reference_population(n, &mut rng)
+        .into_iter()
+        .map(|p| {
+            let elements = OrbitalElements {
+                a: p.a,
+                e: p.e,
+                i: p.i,
+                omega: p.omega,
+                omega_big: p.omega_big,
+                mean_anomaly: p.mean_anomaly,
+            };
+            DetectionTarget {
+                dec_deg: declination_deg(&elements),
+                r_magnitude: p.v_magnitude,
+            }
+        })
+        .collect()
+}
+
+/// Expected exclusion fraction: mean per-target detection probability under
+/// the survey model.
+pub fn compute_exclusion(survey: &Ps1StackSurvey, targets: &[DetectionTarget]) -> ExclusionResult {
+    let n_total = targets.len() as u32;
+    let expected_excluded: f64 = targets
+        .iter()
+        .map(|t| survey.detection_probability(t.r_magnitude, t.dec_deg))
+        .sum();
+    let fraction_excluded = if n_total > 0 {
+        expected_excluded / n_total as f64
+    } else {
+        0.0
+    };
+    ExclusionResult {
+        fraction_excluded,
+        n_total,
+        expected_excluded,
+    }
+}
+
+/// Seeded Monte-Carlo realization of the detected count (one Bernoulli per
+/// target at its detection probability).
+pub fn monte_carlo_detected(
+    survey: &Ps1StackSurvey,
+    targets: &[DetectionTarget],
+    seed: u64,
+) -> u32 {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    targets
+        .iter()
+        .filter(|t| rng.gen::<f64>() < survey.detection_probability(t.r_magnitude, t.dec_deg))
+        .count() as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::published;
+
+    #[test]
+    fn exclusion_fraction_in_open_unit_interval() {
+        let targets = reference_targets(4000, 2025);
+        let survey = Ps1StackSurvey::default();
+        let result = compute_exclusion(&survey, &targets);
+        // PINNED: a genuine fraction in (0, 1), neither trivially 0 nor 1.
+        assert!(
+            result.fraction_excluded > 0.0 && result.fraction_excluded < 1.0,
+            "fraction = {}",
+            result.fraction_excluded
+        );
+        // Order-of-magnitude anchor: a few tens of percent.
+        assert!(
+            result.fraction_excluded > 0.1 && result.fraction_excluded < 0.9,
+            "fraction {} not in plausible range around {}",
+            result.fraction_excluded,
+            published::EXCLUDED_FRACTION_ORDER
+        );
+    }
+
+    #[test]
+    fn exclusion_increases_with_assumed_mass() {
+        // Re-evaluate the same orbits but assign each the apparent magnitude
+        // of a P9 of fixed assumed mass at the orbit's heliocentric distance.
+        // More massive => brighter => larger excluded fraction.
+        use crate::photometry::apparent_r_magnitude;
+        use p9_2021_orbit::reference_population::heliocentric_distance;
+        use p9_core::types::P9Params;
+        use rand::SeedableRng;
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(2025);
+        let pop = generate_reference_population(4000, &mut rng);
+
+        let survey = Ps1StackSurvey::default();
+        let exclusion_at_mass = |mass: f64| -> f64 {
+            let targets: Vec<DetectionTarget> = pop
+                .iter()
+                .map(|p| {
+                    let elements = OrbitalElements {
+                        a: p.a,
+                        e: p.e,
+                        i: p.i,
+                        omega: p.omega,
+                        omega_big: p.omega_big,
+                        mean_anomaly: p.mean_anomaly,
+                    };
+                    let params = P9Params {
+                        mass_earth: mass,
+                        a: p.a,
+                        e: p.e,
+                        i: p.i,
+                        omega: p.omega,
+                        omega_big: p.omega_big,
+                        mean_anomaly: p.mean_anomaly,
+                    };
+                    let r = heliocentric_distance(&params);
+                    DetectionTarget {
+                        dec_deg: declination_deg(&elements),
+                        r_magnitude: apparent_r_magnitude(mass, r),
+                    }
+                })
+                .collect();
+            compute_exclusion(&survey, &targets).fraction_excluded
+        };
+
+        let f5 = exclusion_at_mass(5.0);
+        let f10 = exclusion_at_mass(10.0);
+        let f20 = exclusion_at_mass(20.0);
+        // PINNED: exclusion fraction increases with assumed mass.
+        assert!(f10 > f5, "f10 {f10:.3} should exceed f5 {f5:.3}");
+        assert!(f20 > f10, "f20 {f20:.3} should exceed f10 {f10:.3}");
+    }
+
+    #[test]
+    fn footprint_reduces_exclusion_vs_all_sky() {
+        let targets = reference_targets(4000, 7);
+        let ps1 = Ps1StackSurvey::default();
+        let all_sky = Ps1StackSurvey {
+            dec_limit_deg: -90.0,
+            ..Ps1StackSurvey::default()
+        };
+        let f_ps1 = compute_exclusion(&ps1, &targets).fraction_excluded;
+        let f_all = compute_exclusion(&all_sky, &targets).fraction_excluded;
+        // PINNED: the dec > -30 footprint excludes less than all-sky.
+        assert!(
+            f_all > f_ps1,
+            "all-sky {f_all:.3} should exceed dec-limited {f_ps1:.3}"
+        );
+    }
+
+    #[test]
+    fn monte_carlo_seeded_reproducible() {
+        let targets = reference_targets(2000, 11);
+        let survey = Ps1StackSurvey::default();
+        let a = monte_carlo_detected(&survey, &targets, 99);
+        let b = monte_carlo_detected(&survey, &targets, 99);
+        assert_eq!(a, b, "same seed must reproduce");
+        // And it tracks the expected count.
+        let expected = compute_exclusion(&survey, &targets).expected_excluded;
+        assert!((a as f64 - expected).abs() < 0.1 * targets.len() as f64);
+    }
+
+    #[test]
+    fn all_faint_nothing_excluded() {
+        let survey = Ps1StackSurvey::default();
+        let targets: Vec<DetectionTarget> = (0..200)
+            .map(|k| DetectionTarget {
+                dec_deg: 10.0 + (k % 30) as f64,
+                r_magnitude: 26.0,
+            })
+            .collect();
+        let result = compute_exclusion(&survey, &targets);
+        assert!(result.fraction_excluded < 1e-4);
+    }
+}

--- a/crates/p9-2025-ps1-holman/src/lib.rs
+++ b/crates/p9-2025-ps1-holman/src/lib.rs
@@ -1,0 +1,50 @@
+//! Reproduction of Holman et al. (2025)
+//! "A search for Planet Nine and distant solar system objects in
+//! Pan-STARRS1, Part 1" (arXiv:2506.02144).
+//!
+//! An INDEPENDENT shift-and-stack / moving-object search of the
+//! Pan-STARRS1 (PS1) 3-pi survey. By co-adding the multi-epoch PS1
+//! exposures along trial Planet Nine motion vectors ("shift-and-stack"),
+//! the search reaches fainter than any single PS1 exposure (r ~ 21.5
+//! single-epoch, gaining ~1 mag in the stack), over the 3-pi footprint
+//! (declination > -30 deg). No Planet Nine is found, so the search sets
+//! exclusion limits across the P9 mass-distance parameter space.
+//!
+//! ## Relationship to `p9-2024-panstarrs`
+//!
+//! This crate is INDEPENDENT OF AND COMPLEMENTARY TO the existing
+//! `p9-2024-panstarrs` crate (Brown, Holman & Batygin 2024), which models
+//! the catalog-level moving-object linking search of the same PS1 3-pi
+//! data. Holman et al. (2025) instead perform a pixel-level
+//! shift-and-stack search that recovers fainter (hence more distant /
+//! lower-mass) objects below the catalog detection threshold. Both share
+//! the same survey depth anchor (PS1 3pi r = 21.5) and the same
+//! declination > -30 deg footprint from `p9-core`; this crate reuses that
+//! shared survey/photometry logic rather than duplicating it.
+
+pub mod exclusion;
+pub mod photometry;
+pub mod survey_model;
+
+/// Published reference figures from Holman et al. (2025), kept as labelled
+/// constants (no computed quantity is hard-coded to these — they are pinned
+/// against in tests as sanity anchors).
+pub mod published {
+    /// PS1 3-pi single-epoch r-band 50%-completeness depth (Chambers et al.
+    /// 2016; shared `p9-core` survey table entry "PS1 3pi").
+    pub const PS1_R_DEPTH: f64 = 21.5;
+
+    /// Effective depth gain from co-adding the multi-epoch PS1 stack along a
+    /// trial motion vector. Holman et al. report reaching ~1 mag deeper than
+    /// a single exposure in the shift-and-stack search.
+    pub const SHIFT_STACK_DEPTH_GAIN_MAG: f64 = 1.0;
+
+    /// Southern declination limit of the PS1 3-pi footprint (degrees).
+    pub const PS1_DEC_LIMIT_DEG: f64 = -30.0;
+
+    /// Order-of-magnitude scale of the parameter-space fraction this single
+    /// independent PS1 search excludes for a Brown & Batygin reference P9
+    /// population: a few tens of percent (the search is sensitive but does
+    /// not cover the whole prior). Used only to bound test assertions.
+    pub const EXCLUDED_FRACTION_ORDER: f64 = 0.5;
+}

--- a/crates/p9-2025-ps1-holman/src/photometry.rs
+++ b/crates/p9-2025-ps1-holman/src/photometry.rs
@@ -1,0 +1,117 @@
+//! Reflected-light photometry for the Holman PS1 search.
+//!
+//! Reuses `p9_core::analysis::photometry` entirely (Neptune-anchored
+//! mass-radius relation, reflected-sunlight distance law, Neptune albedo
+//! 0.41). The crate-specific quantity is the *maximum heliocentric
+//! distance* at which a P9 of a given mass is still brighter than the
+//! shift-and-stack effective depth — i.e. the outer edge of the search's
+//! sensitivity, which grows with assumed mass.
+
+use p9_core::analysis::photometry::{planet_apparent_magnitude, ALBEDO_NEPTUNE};
+
+use crate::survey_model::Ps1StackSurvey;
+
+/// Apparent r magnitude (Neptune albedo, at opposition) of a P9 of
+/// `mass_earth` at heliocentric distance `r_au`. Thin wrapper over the
+/// shared `p9-core` reflected-sunlight law.
+pub fn apparent_r_magnitude(mass_earth: f64, r_au: f64) -> f64 {
+    planet_apparent_magnitude(mass_earth, ALBEDO_NEPTUNE, r_au)
+}
+
+/// Maximum heliocentric distance (AU) at which a P9 of `mass_earth` is still
+/// at or brighter than the survey's effective (shift-and-stack) depth, i.e.
+/// `apparent_r_magnitude(mass, r) == survey.effective_depth()`.
+///
+/// Apparent magnitude rises monotonically with distance (reflected light
+/// dims as r^4 at opposition: m ~ H + 5 log10(r(r-1))), so the equation has
+/// a unique root, found by bisection on [`R_MIN_AU`, `R_MAX_AU`]. Returns
+/// `R_MAX_AU` if even there the object is detectable, `R_MIN_AU` if it is
+/// never detectable.
+pub fn max_detectable_distance(survey: &Ps1StackSurvey, mass_earth: f64) -> f64 {
+    let target = survey.effective_depth();
+    let mut lo = R_MIN_AU;
+    let mut hi = R_MAX_AU;
+    // At lo the object is brightest (smallest m); detectable means m <= target.
+    if apparent_r_magnitude(mass_earth, lo) > target {
+        return R_MIN_AU; // not detectable anywhere in range
+    }
+    if apparent_r_magnitude(mass_earth, hi) <= target {
+        return R_MAX_AU; // detectable everywhere in range
+    }
+    for _ in 0..100 {
+        let mid = 0.5 * (lo + hi);
+        if apparent_r_magnitude(mass_earth, mid) <= target {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    0.5 * (lo + hi)
+}
+
+/// Inner bound of the bisection bracket (AU). Objects closer than the giant
+/// planets are outside the P9 search regime.
+pub const R_MIN_AU: f64 = 30.0;
+
+/// Outer bound of the bisection bracket (AU): well beyond any plausible P9
+/// aphelion.
+pub const R_MAX_AU: f64 = 5000.0;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn magnitude_matches_core_law() {
+        // The wrapper must be exactly the shared p9-core law (no local copy).
+        assert_relative_eq!(
+            apparent_r_magnitude(6.0, 500.0),
+            planet_apparent_magnitude(6.0, ALBEDO_NEPTUNE, 500.0),
+            epsilon = 1e-12
+        );
+    }
+
+    #[test]
+    fn max_distance_is_finite_and_at_threshold() {
+        let s = Ps1StackSurvey::default();
+        let r = max_detectable_distance(&s, 6.0);
+        // PINNED: a finite AU value strictly inside the bracket.
+        assert!(r.is_finite());
+        assert!(r > R_MIN_AU && r < R_MAX_AU, "r_max = {r:.1}");
+        // At the root the apparent magnitude equals the effective depth.
+        assert!(
+            (apparent_r_magnitude(6.0, r) - s.effective_depth()).abs() < 1e-3,
+            "m(r_max) = {:.3} vs depth {:.3}",
+            apparent_r_magnitude(6.0, r),
+            s.effective_depth()
+        );
+    }
+
+    #[test]
+    fn max_distance_increases_with_mass() {
+        let s = Ps1StackSurvey::default();
+        let r5 = max_detectable_distance(&s, 5.0);
+        let r10 = max_detectable_distance(&s, 10.0);
+        let r20 = max_detectable_distance(&s, 20.0);
+        // PINNED: more massive (larger, brighter) P9 detectable farther out.
+        assert!(r10 > r5, "r10 {r10:.1} should exceed r5 {r5:.1}");
+        assert!(r20 > r10, "r20 {r20:.1} should exceed r10 {r10:.1}");
+    }
+
+    #[test]
+    fn deeper_stack_reaches_farther() {
+        // The shift-and-stack gain extends the reach versus single-epoch.
+        let stack = Ps1StackSurvey::default();
+        let single = Ps1StackSurvey {
+            stack_depth_gain: 0.0,
+            ..Ps1StackSurvey::default()
+        };
+        let r_stack = max_detectable_distance(&stack, 6.0);
+        let r_single = max_detectable_distance(&single, 6.0);
+        assert!(
+            r_stack > r_single,
+            "stack reach {r_stack:.1} should exceed single-epoch {r_single:.1}"
+        );
+    }
+}

--- a/crates/p9-2025-ps1-holman/src/survey_model.rs
+++ b/crates/p9-2025-ps1-holman/src/survey_model.rs
@@ -1,0 +1,136 @@
+//! Survey model for the Holman et al. (2025) shift-and-stack PS1 search.
+//!
+//! The single-epoch PS1 3-pi r-band depth (21.5) comes from the shared
+//! `p9_core::analysis::surveys` table. The distinguishing feature of this
+//! search, relative to the catalog-linking search in `p9-2024-panstarrs`,
+//! is the *shift-and-stack* depth gain: co-adding the N multi-epoch
+//! exposures along a trial motion vector lowers the noise by ~sqrt(N),
+//! pushing the effective 50%-completeness magnitude fainter by
+//! `stack_depth_gain` mag. The effective depth is therefore
+//!
+//!   m_eff = m_single + stack_depth_gain.
+//!
+//! Detection probability is a logistic roll-off centered on `m_eff`,
+//! gated by the declination > -30 deg 3-pi footprint.
+
+use serde::{Deserialize, Serialize};
+
+use crate::published;
+
+/// PS1 3-pi shift-and-stack survey model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Ps1StackSurvey {
+    /// Single-epoch 50%-completeness r magnitude (21.5), from the shared
+    /// `p9-core` "PS1 3pi" survey-depth table.
+    pub single_epoch_depth: f64,
+    /// Magnitudes of effective depth gained by the shift-and-stack co-add
+    /// (~sqrt(N) noise reduction over N epochs). Holman et al. (2025) reach
+    /// ~1 mag deeper than a single exposure.
+    pub stack_depth_gain: f64,
+    /// Southern declination limit of the 3-pi footprint (degrees).
+    pub dec_limit_deg: f64,
+    /// Logistic steepness of the efficiency roll-off (mag^-1).
+    pub efficiency_steepness: f64,
+}
+
+impl Default for Ps1StackSurvey {
+    fn default() -> Self {
+        Self {
+            single_epoch_depth: p9_core::analysis::surveys::limiting_magnitude("PS1 3pi")
+                .expect("PS1 3pi in shared survey table"),
+            stack_depth_gain: published::SHIFT_STACK_DEPTH_GAIN_MAG,
+            dec_limit_deg: published::PS1_DEC_LIMIT_DEG,
+            efficiency_steepness: 3.0,
+        }
+    }
+}
+
+impl Ps1StackSurvey {
+    /// Effective 50%-completeness depth after the shift-and-stack co-add:
+    /// `single_epoch_depth + stack_depth_gain`.
+    pub fn effective_depth(&self) -> f64 {
+        self.single_epoch_depth + self.stack_depth_gain
+    }
+
+    /// Whether an equatorial declination falls in the 3-pi footprint.
+    pub fn in_footprint(&self, dec_deg: f64) -> bool {
+        dec_deg > self.dec_limit_deg
+    }
+
+    /// Logistic recovery efficiency at apparent r magnitude `m`, centered on
+    /// the effective (stacked) depth. 0.5 exactly at `effective_depth()`.
+    pub fn recovery_efficiency(&self, apparent_magnitude: f64) -> f64 {
+        1.0 / (1.0
+            + ((apparent_magnitude - self.effective_depth()) * self.efficiency_steepness).exp())
+    }
+
+    /// End-to-end detection probability for an object of apparent r
+    /// magnitude `m` at equatorial declination `dec_deg`: the footprint cut
+    /// times the logistic recovery efficiency.
+    pub fn detection_probability(&self, apparent_magnitude: f64, dec_deg: f64) -> f64 {
+        if !self.in_footprint(dec_deg) {
+            return 0.0;
+        }
+        self.recovery_efficiency(apparent_magnitude)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn depth_anchored_to_shared_table() {
+        let s = Ps1StackSurvey::default();
+        // PINNED: PS1 3-pi single-epoch r depth == 21.5 from p9-core.
+        assert!((s.single_epoch_depth - 21.5).abs() < 1e-12);
+        assert!(
+            (s.single_epoch_depth
+                - p9_core::analysis::surveys::limiting_magnitude("PS1 3pi").unwrap())
+            .abs()
+                < 1e-12
+        );
+    }
+
+    #[test]
+    fn footprint_is_dec_minus_30() {
+        let s = Ps1StackSurvey::default();
+        assert!((s.dec_limit_deg - (-30.0)).abs() < 1e-12);
+        assert!(s.in_footprint(-29.0));
+        assert!(!s.in_footprint(-31.0));
+        assert_eq!(s.detection_probability(20.0, -45.0), 0.0);
+    }
+
+    #[test]
+    fn shift_stack_deepens_the_search() {
+        let s = Ps1StackSurvey::default();
+        // The stack reaches fainter than the single-epoch depth.
+        assert!(s.effective_depth() > s.single_epoch_depth);
+        assert!((s.effective_depth() - 22.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn efficiency_half_at_effective_depth() {
+        let s = Ps1StackSurvey::default();
+        let e = s.recovery_efficiency(s.effective_depth());
+        assert!((e - 0.5).abs() < 1e-12, "eff(m_eff) = {e}");
+        assert!(s.recovery_efficiency(19.0) > 0.99);
+        assert!(s.recovery_efficiency(24.5) < 0.01);
+    }
+
+    #[test]
+    fn stack_detects_fainter_than_single_epoch() {
+        // At r = 22.2 (fainter than single-epoch 21.5) the stack still
+        // recovers most objects; without the gain it would be sub-threshold.
+        let stack = Ps1StackSurvey::default();
+        let no_stack = Ps1StackSurvey {
+            stack_depth_gain: 0.0,
+            ..Ps1StackSurvey::default()
+        };
+        let p_stack = stack.detection_probability(22.2, 0.0);
+        let p_single = no_stack.detection_probability(22.2, 0.0);
+        assert!(p_stack > 0.6, "stack p = {p_stack}");
+        assert!(p_single < 0.2, "single-epoch p = {p_single}");
+        assert!(p_stack > p_single);
+    }
+}


### PR DESCRIPTION
Reproduces Holman et al. (2025), "A search for Planet Nine and distant solar system objects in Pan-STARRS1, Part 1" (arXiv:2506.02144) as crate p9-2025-ps1-holman.

This is an INDEPENDENT pixel-level shift-and-stack / moving-object search of the PS1 3-pi survey, complementary to the existing catalog-linking analysis in p9-2024-panstarrs (Brown, Holman & Batygin 2024). Both share the same PS1 3-pi depth anchor and dec > -30 deg footprint from p9-core; this crate reuses that shared survey/photometry logic rather than duplicating it.

## What it computes (real quantities, no hard-coded answers)
- survey_model.rs: shift-and-stack survey model. Single-epoch r depth (21.5) comes from p9_core::analysis::surveys ("PS1 3pi"); co-adding the multi-epoch stack gains ~1 mag of effective depth. Logistic recovery efficiency gated by the dec > -30 deg 3-pi footprint.
- photometry.rs: maximum heliocentric distance at which a P9 of a given mass stays brighter than the effective depth, by bisection on the shared p9-core reflected-light law (Neptune-anchored mass-radius, albedo 0.41). Grows with assumed mass.
- exclusion.rs: expected exclusion fraction over a seeded p9-2021-orbit reference population, with footprint vs all-sky comparison and a seeded Monte-Carlo realization.

## Pinned in tests
- PS1 3-pi r depth == 21.5 from the shared p9-core table.
- Max detectable distance is a finite AU value that increases with mass.
- Exclusion fraction lies in (0,1) and increases with assumed mass.
- The dec > -30 deg footprint reduces exclusion versus an all-sky assumption.

Published reference numbers (PS1 r depth, dec > -30 deg, shift-and-stack ~1 mag gain, exclusion-fraction order) are kept as labelled constants in the published module.

## Residuals / honesty notes
- The ~1 mag shift-and-stack depth gain is a documented round-number stand-in for the paper's per-cell stacking gain (which depends on N usable epochs per trial vector); it is parameterized, not fit.
- The detection model is a logistic completeness curve, not a full per-epoch cadence/linking simulation; the catalog-linking k-of-n model lives in the sibling p9-2024-panstarrs crate.
- Declinations come from each orbit's stored epoch (single apparent position), not a multi-epoch arc.

Hard gate (all green): cargo build -p p9-2025-ps1-holman; cargo test -p p9-2025-ps1-holman (14 passed); cargo fmt.

Closes #68