### PR TITLE
Add Planet Y mean-plane warp reproduction crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,9 +1325,11 @@ name = "p9-2021-orbit"
 version = "0.1.0"
 dependencies = [
  "approx",
+ "nalgebra",
  "p9-core",
  "rand 0.8.5",
  "rand_distr",
+ "rayon",
  "serde",
  "serde_json",
 ]
@@ -1445,6 +1447,17 @@ dependencies = [
  "p9-core",
  "rand 0.8.5",
  "rand_distr",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "p9-2025-planet-y"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "nalgebra",
+ "p9-core",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/p9-2024-oort-selfgrav",
     "crates/p9-2024-panstarrs",
     "crates/p9-2025-clustering",
+    "crates/p9-2025-planet-y",
     "crates/p9-2025-iras-akari",
     "crates/p9-2025-perturbation",
     "crates/p9-review-article",

--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -126,6 +126,35 @@ the P9 orientation angles (ϖ₉, Ω₉) profiled out of the KDE likelihood over
 rather than sampled as MCMC dimensions. The cluster-scattering Fréchet prior is not
 implemented (uniform prior only; needs the Batygin & Brown 2021b scattering suite).
 
+### 10. p9-2025-planet-y — warp amplitude: sub-degree for most of the allowed box, "a few degrees" only at the Earth-mass/close corner
+
+The forced-inclination warp in the 50–80 AU band is computed from the linear Laplace-plane
+balance `tan(2 i_forced) = A_out sin(2 i_Y) / (A_in + A_out cos(2 i_Y))`, with `A_in` the
+giant-planet quadrupole (reusing `p9_core::forces::j2_secular::effective_j2` for JSUN) and
+`A_out` Planet Y's exterior ring torque (`¼ n (m_Y/M) α² b_{3/2}^{(1)}(α)`). Across the
+published parameter box the warp amplitude (tilt rise from 50→80 AU) is:
+
+| m_Y (M⊕) | a_Y (AU) | warp amplitude |
+|----------|----------|----------------|
+| 0.05     | 100      | 0.28°          |
+| 0.3      | 150      | 0.13°          |
+| 1.0      | 200      | 0.13°          |
+| 1.0      | 100      | 3.6°           |
+
+So the paper's "few-degree" warp is reached only at the **Earth-mass, 100 AU corner**; a
+Mercury-mass object, or an Earth-mass one out at 200 AU, warps the band by only a few tenths
+of a degree. This is the honest reason the data signal is *tentative*. It also means the
+torque crossover (`A_in = A_out`) sits at ≈ 95–180 AU — *exterior* to the 50–80 AU band — so
+within the band the warp is the small rising shoulder of the transition, not full alignment
+with Planet Y's plane. The forced tilt is strictly bounded by i_Y. No free parameter was
+tuned; the band, mass range, and a_Y range are the paper's labelled constants in
+`laplace_plane::published`.
+- Pinned: `crates/p9-2025-planet-y/src/laplace_plane.rs` —
+  `test_warp_feature_in_50_80_band` (0.01–1.0° for 0.3 M⊕ @ 150 AU),
+  `test_warp_amplitude_few_degrees_for_earth_mass` (2–6° for 1 M⊕ @ 100 AU),
+  `test_warp_amplitude_scales_with_mass` (∝ m_Y), `test_outer_dominates_near_planet_y`
+  (crossover near a_Y, not in-band), `test_no_perturber_plane_stays_flat`.
+
 ---
 
 ## Agreements within tolerance (for completeness)

--- a/crates/p9-2025-planet-y/Cargo.toml
+++ b/crates/p9-2025-planet-y/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "p9-2025-planet-y"
+version = "0.1.0"
+edition = "2021"
+description = "Reproduction of Siraj et al. (2025) 'Planet Y' (arXiv:2508.14156): a Mercury-to-Earth-mass perturber warping the Kuiper belt's mean plane"
+
+[dependencies]
+nalgebra.workspace = true
+p9-core = { path = "../p9-core" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/p9-2025-planet-y/src/laplace_plane.rs
+++ b/crates/p9-2025-planet-y/src/laplace_plane.rs
@@ -1,0 +1,451 @@
+//! Classical Laplace-plane / forced-inclination theory for a Kuiper-belt test
+//! particle under competing torques.
+//!
+//! A test particle at semi-major axis `a` precesses about a *forced* plane
+//! (the local Laplace plane) set by the competition between two nodal torques:
+//!
+//! 1. **Inner torque** from the giant planets' orbit-averaged quadrupole. The
+//!    averaged JSU(N) field is a J2-like flattening of the inner Solar System
+//!    (reuse `p9_core::forces::j2_secular::effective_j2`). Its nodal-precession
+//!    coefficient scales as
+//!
+//!    ```text
+//!    A_in(a) = (3/4) n(a) Σ_j (m_j/M_⊙)(a_j/a)²            (∝ a^{-7/2})
+//!    ```
+//!
+//!    and it holds the local mean plane near the inner planets' invariable
+//!    plane (≈ the ecliptic for our purposes — the giants' invariable plane is
+//!    only ≈ 1.58° from the ecliptic; see `p9-2025-clustering::orbital_poles`).
+//!
+//! 2. **Outer torque** from a distant *inclined* perturber — Planet Y at
+//!    a_Y ≈ 100–200 AU, mass m_Y ≈ 0.05–1 M_⊕, inclination i_Y. Treating Planet
+//!    Y as an exterior ring, its nodal-precession coefficient on an interior
+//!    particle is
+//!
+//!    ```text
+//!    A_out(a) = (3/4) n(a) (m_Y/M_⊙) (a/a_Y)³ b_{3/2}^{(1)}(a/a_Y)/3
+//!    ```
+//!
+//!    (Laplace–Lagrange; the leading b_{3/2}^{(1)} ≈ 3α gives the familiar
+//!    (a/a_Y)³ ring torque). It pulls the local mean plane toward Planet Y's
+//!    orbital plane.
+//!
+//! The classical Laplace surface lies at the inclination `i_forced` (measured
+//! from the inner reference plane toward Planet Y's plane) where the two
+//! torques balance. For a single inner axis (z, the invariable normal) and a
+//! single outer plane tilted by i_Y, the forced inclination satisfies the
+//! standard Laplace-plane relation
+//!
+//! ```text
+//! tan(2 i_forced) = A_out sin(2 i_Y) / (A_in + A_out cos(2 i_Y)).
+//! ```
+//!
+//! - When A_in ≫ A_out (small a): i_forced → 0, the plane hugs the invariable
+//!   plane.
+//! - When A_out ≫ A_in (large a): i_forced → i_Y, the plane aligns with Y.
+//! - The transition (A_out ≈ A_in) is the **warp**: the mean-plane tilt rises
+//!   over a localized band of semi-major axis. The ratio A_out/A_in ∝ a^{5}/a_Y³,
+//!   so the warp band's location is fixed by a_Y and m_Y.
+//!
+//! Reference: Murray & Dermott (1999) §7 (secular Laplace–Lagrange theory) and
+//! the Laplace-surface treatment of §5.3; Siraj, Loeb & Siegel (2025),
+//! arXiv:2508.14156.
+
+use p9_core::constants::{
+    DEG2RAD, EARTH_MASS_SOLAR, GM_SUN, MASS_JUPITER_SOLAR, MASS_NEPTUNE_SOLAR, MASS_SATURN_SOLAR,
+    MASS_URANUS_SOLAR,
+};
+use p9_core::forces::j2_secular::effective_j2;
+
+/// Published Planet Y reference numbers (Siraj et al. 2025), kept as labelled
+/// constants so the tests pin against them rather than against magic numbers.
+pub mod published {
+    /// Lower mass bound (≈ Mercury mass), in Earth masses.
+    pub const M_Y_LOW_EARTH: f64 = 0.05;
+    /// Upper mass bound (≈ Earth mass), in Earth masses.
+    pub const M_Y_HIGH_EARTH: f64 = 1.0;
+    /// Lower semi-major-axis bound (AU).
+    pub const A_Y_LOW_AU: f64 = 100.0;
+    /// Upper semi-major-axis bound (AU).
+    pub const A_Y_HIGH_AU: f64 = 200.0;
+    /// Inner edge of the warp band (AU).
+    pub const WARP_BAND_LOW_AU: f64 = 50.0;
+    /// Outer edge of the warp band (AU).
+    pub const WARP_BAND_HIGH_AU: f64 = 80.0;
+    /// Representative modest Planet Y inclination to the ecliptic (deg).
+    pub const I_Y_DEG: f64 = 10.0;
+}
+
+/// Semi-major axes (AU) of the four giant planets, used to build the inner
+/// quadrupole torque. The averaged JSU(N) ring is the same construction as
+/// `p9_core::forces::j2_secular::combined_j2_jsu`, extended to include Neptune
+/// because the warp band (50–80 AU) is exterior to Neptune.
+const GIANT_AU: [(f64, f64); 4] = [
+    (MASS_JUPITER_SOLAR, 5.2026),
+    (MASS_SATURN_SOLAR, 9.5549),
+    (MASS_URANUS_SOLAR, 19.2184),
+    (MASS_NEPTUNE_SOLAR, 30.07),
+];
+
+/// Specification of the distant perturber (Planet Y).
+#[derive(Debug, Clone, Copy)]
+pub struct PlanetY {
+    /// Mass in solar masses.
+    pub mass_solar: f64,
+    /// Semi-major axis (AU).
+    pub a_au: f64,
+    /// Inclination of Planet Y's orbital plane to the inner reference plane
+    /// (radians).
+    pub inclination: f64,
+}
+
+impl PlanetY {
+    /// Build from the paper's natural units: mass in Earth masses, a in AU,
+    /// inclination in degrees.
+    pub fn new(mass_earth: f64, a_au: f64, inclination_deg: f64) -> Self {
+        Self {
+            mass_solar: mass_earth * EARTH_MASS_SOLAR,
+            a_au,
+            inclination: inclination_deg * DEG2RAD,
+        }
+    }
+}
+
+/// Mean motion of a test particle (rad/day) about the Sun.
+fn mean_motion(a_au: f64) -> f64 {
+    (GM_SUN / (a_au * a_au * a_au)).sqrt()
+}
+
+/// Inner (giant-planet quadrupole) nodal-precession coefficient at semi-major
+/// axis `a` (rad/day, magnitude).
+///
+///   A_in = (3/4) n Σ_j (m_j/M_⊙) (a_j/a)²
+///
+/// Built from `effective_j2` for each giant so the inner field is exactly the
+/// p9-core orbit-averaged J2 ring (J2_eff,j = ½ (m_j/M)(a_j)², with R_ref = 1
+/// folded out below via the (R_ref/a)² lever arm = (1/a)²).
+pub fn inner_torque_coeff(a_au: f64) -> f64 {
+    let n = mean_motion(a_au);
+    // Σ_j (m_j/M)(a_j/a)² = (2/a²) Σ_j J2_eff,j with R_ref = 1 AU.
+    let j2_sum: f64 = GIANT_AU
+        .iter()
+        .map(|&(m, a_j)| effective_j2(m, a_j, 1.0))
+        .sum();
+    let quad_sum = 2.0 * j2_sum / (a_au * a_au);
+    0.75 * n * quad_sum
+}
+
+/// Leading Laplace coefficient b_{3/2}^{(1)}(α) for an exterior perturber,
+/// evaluated by direct quadrature of
+///
+///   b_{3/2}^{(s)}(α) = (1/π) ∫_0^{2π} cos(sψ) (1 − 2α cosψ + α²)^{-3/2} dψ.
+///
+/// For α → 0 this tends to 3α, recovering the bare (a/a_Y)³ ring torque; for
+/// the α ≈ 0.3–0.8 relevant to the warp band the exact coefficient matters.
+fn laplace_b_three_half_1(alpha: f64) -> f64 {
+    let n = 2048;
+    let dpsi = std::f64::consts::TAU / n as f64;
+    let mut sum = 0.0;
+    for k in 0..n {
+        let psi = (k as f64 + 0.5) * dpsi;
+        let denom = (1.0 - 2.0 * alpha * psi.cos() + alpha * alpha).powf(1.5);
+        sum += psi.cos() / denom;
+    }
+    sum * dpsi / std::f64::consts::PI
+}
+
+/// Outer (Planet Y) nodal-precession coefficient on an interior particle at
+/// semi-major axis `a` (rad/day, magnitude).
+///
+///   A_out = (3/4) n (m_Y/M_⊙) α b_{3/2}^{(1)}(α) / ... ,  α = a/a_Y < 1
+///
+/// In the secular Laplace–Lagrange framework the off-diagonal node coupling of
+/// an exterior body to an interior particle is
+///
+///   |A_out| = (1/4) n (m_Y/M_⊙) α² b_{3/2}^{(1)}(α),
+///
+/// which for α ≪ 1 reduces to (3/4) n (m_Y/M)(a/a_Y)³ (since b_{3/2}^{(1)}→3α).
+pub fn outer_torque_coeff(a_au: f64, planet_y: &PlanetY) -> f64 {
+    let alpha = a_au / planet_y.a_au;
+    let n = mean_motion(a_au);
+    let b1 = laplace_b_three_half_1(alpha);
+    0.25 * n * planet_y.mass_solar * alpha * alpha * b1
+}
+
+/// Forced inclination of the local Laplace plane (radians), measured from the
+/// inner invariable plane toward Planet Y's orbital plane.
+///
+///   tan(2 i_forced) = A_out sin(2 i_Y) / (A_in + A_out cos(2 i_Y))
+///
+/// The half-angle solution is taken in [0, i_Y]; `atan2` keeps the branch
+/// continuous across the A_in = A_out crossover.
+pub fn forced_inclination(a_au: f64, planet_y: &PlanetY) -> f64 {
+    let a_in = inner_torque_coeff(a_au);
+    let a_out = outer_torque_coeff(a_au, planet_y);
+    let two_iy = 2.0 * planet_y.inclination;
+    let num = a_out * two_iy.sin();
+    let den = a_in + a_out * two_iy.cos();
+    0.5 * num.atan2(den)
+}
+
+/// Convenience: forced inclination in degrees.
+pub fn forced_inclination_deg(a_au: f64, planet_y: &PlanetY) -> f64 {
+    forced_inclination(a_au, planet_y) / DEG2RAD
+}
+
+/// A sample of the forced-inclination profile.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ForcedProfilePoint {
+    pub a_au: f64,
+    pub i_forced_deg: f64,
+}
+
+/// Sample the forced-inclination profile i_forced(a) over a grid of
+/// semi-major axes (AU), inclusive of both endpoints.
+pub fn forced_profile(
+    a_min: f64,
+    a_max: f64,
+    n: usize,
+    planet_y: &PlanetY,
+) -> Vec<ForcedProfilePoint> {
+    assert!(n >= 2, "need at least two grid points");
+    (0..n)
+        .map(|k| {
+            let a = a_min + (a_max - a_min) * (k as f64) / ((n - 1) as f64);
+            ForcedProfilePoint {
+                a_au: a,
+                i_forced_deg: forced_inclination_deg(a, planet_y),
+            }
+        })
+        .collect()
+}
+
+/// Warp diagnostic over the published 50–80 AU band.
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub struct WarpFeature {
+    /// Semi-major axis (AU) of the peak forced tilt inside the band.
+    pub a_peak_au: f64,
+    /// Forced tilt at the peak (deg).
+    pub i_peak_deg: f64,
+    /// Forced tilt at the inner band edge (deg).
+    pub i_inner_deg: f64,
+    /// Forced tilt at the outer band edge (deg).
+    pub i_outer_deg: f64,
+    /// Warp amplitude (deg): rise across the band, i_outer − i_inner.
+    pub amplitude_deg: f64,
+}
+
+/// Measure the warp feature in the 50–80 AU band: the rise of the forced tilt
+/// across the band and the location of the in-band peak. The "warp amplitude"
+/// is the increase from the inner to the outer band edge — the localized
+/// feature the paper attributes to Planet Y.
+pub fn warp_feature(planet_y: &PlanetY) -> WarpFeature {
+    let lo = published::WARP_BAND_LOW_AU;
+    let hi = published::WARP_BAND_HIGH_AU;
+    let n = 121;
+    let profile = forced_profile(lo, hi, n, planet_y);
+
+    let inner = profile.first().unwrap().i_forced_deg;
+    let outer = profile.last().unwrap().i_forced_deg;
+
+    let peak = profile
+        .iter()
+        .max_by(|x, y| x.i_forced_deg.partial_cmp(&y.i_forced_deg).unwrap())
+        .unwrap();
+
+    WarpFeature {
+        a_peak_au: peak.a_au,
+        i_peak_deg: peak.i_forced_deg,
+        i_inner_deg: inner,
+        i_outer_deg: outer,
+        amplitude_deg: outer - inner,
+    }
+}
+
+/// Neptune's mass-ratio contribution, exposed so callers can confirm the inner
+/// field genuinely includes the planet that bounds the warp band on the inside.
+pub fn neptune_mass_solar() -> f64 {
+    MASS_NEPTUNE_SOLAR
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    fn nominal_planet_y() -> PlanetY {
+        // Mid-range published Planet Y: 0.3 M_⊕ at 150 AU, modestly inclined.
+        PlanetY::new(0.3, 150.0, published::I_Y_DEG)
+    }
+
+    #[test]
+    fn test_laplace_coeff_small_alpha_limit() {
+        // b_{3/2}^{(1)}(α) → 3α as α → 0.
+        let alpha = 1e-3;
+        let b1 = laplace_b_three_half_1(alpha);
+        assert_relative_eq!(b1, 3.0 * alpha, max_relative = 1e-3);
+    }
+
+    #[test]
+    fn test_outer_torque_reduces_to_ring_at_small_alpha() {
+        // |A_out| → (3/4) n (m_Y/M)(a/a_Y)³ for α ≪ 1.
+        let py = PlanetY::new(1.0, 1000.0, 10.0); // tiny α at a = 40
+        let a = 40.0;
+        let alpha = a / py.a_au;
+        let n = mean_motion(a);
+        let ring = 0.75 * n * py.mass_solar * alpha.powi(3);
+        let computed = outer_torque_coeff(a, &py);
+        assert_relative_eq!(computed, ring, max_relative = 2e-3);
+    }
+
+    #[test]
+    fn test_inner_dominates_at_small_a() {
+        // At 40 AU the giant-planet quadrupole should dominate Planet Y.
+        let py = nominal_planet_y();
+        let a_in = inner_torque_coeff(40.0);
+        let a_out = outer_torque_coeff(40.0, &py);
+        assert!(
+            a_in > a_out,
+            "expected inner torque to dominate at 40 AU: A_in={a_in:.3e} A_out={a_out:.3e}"
+        );
+        // Forced tilt nearly zero there.
+        assert!(forced_inclination_deg(40.0, &py) < 1.0);
+    }
+
+    #[test]
+    fn test_outer_dominates_near_planet_y() {
+        // The inner giant-planet quadrupole (∝ a^{-7/2}) dominates throughout
+        // the warp band and well beyond; the outer ring torque (∝ a³/a_Y³)
+        // only overtakes it as the particle approaches Planet Y. With the
+        // nominal 0.3 M_⊕ / 150 AU perturber the crossover is at ≈ 128 AU, so
+        // "outer wins" must be tested just interior to a_Y, not at 90 AU.
+        // (This is the honest reason the 50–80 AU warp is a small rising
+        // shoulder, not full alignment with Y's plane — see REPRODUCTION_NOTES.)
+        let py = nominal_planet_y();
+        let a = 0.95 * py.a_au; // 142.5 AU, interior to and near Planet Y
+        let a_in = inner_torque_coeff(a);
+        let a_out = outer_torque_coeff(a, &py);
+        assert!(
+            a_out > a_in,
+            "expected outer torque to win near a_Y ({a} AU): A_in={a_in:.3e} A_out={a_out:.3e}"
+        );
+    }
+
+    #[test]
+    fn test_warp_feature_in_50_80_band() {
+        // With Planet Y the forced tilt rises across the 50–80 AU band. For a
+        // sub-Earth-mass perturber at 150 AU the rise is a small fraction of a
+        // degree (the band is far interior to the torque crossover); the
+        // "few-degree" warp is reached only at the Earth-mass, close end (see
+        // `test_warp_amplitude_few_degrees_for_earth_mass`).
+        let py = nominal_planet_y();
+        let w = warp_feature(&py);
+        assert!(
+            w.i_outer_deg > w.i_inner_deg,
+            "tilt should rise across the band: {:?}",
+            w
+        );
+        // Monotone rise: the in-band peak sits at the outer edge.
+        assert!(w.a_peak_au >= published::WARP_BAND_LOW_AU);
+        assert!(w.a_peak_au <= published::WARP_BAND_HIGH_AU);
+        assert_relative_eq!(w.a_peak_au, published::WARP_BAND_HIGH_AU, epsilon = 0.5);
+        // A real, localized warp of order a tenth of a degree for this case.
+        assert!(
+            w.amplitude_deg > 0.01 && w.amplitude_deg < 1.0,
+            "warp amplitude = {:.3}° for 0.3 M_earth @ 150 AU",
+            w.amplitude_deg
+        );
+    }
+
+    #[test]
+    fn test_warp_amplitude_few_degrees_for_earth_mass() {
+        // The paper's headline "a few degrees" warp is realized at the upper,
+        // close end of the allowed box: an Earth-mass Planet Y at 100 AU
+        // produces a ≈ 3–4° rise across the 50–80 AU band.
+        let py = PlanetY::new(
+            published::M_Y_HIGH_EARTH,
+            published::A_Y_LOW_AU,
+            published::I_Y_DEG,
+        );
+        let w = warp_feature(&py);
+        assert!(
+            w.amplitude_deg > 2.0 && w.amplitude_deg < 6.0,
+            "Earth-mass @ 100 AU warp amplitude = {:.3}°, expected a few degrees",
+            w.amplitude_deg
+        );
+    }
+
+    #[test]
+    fn test_no_perturber_plane_stays_flat() {
+        // Zero Planet Y mass: the local mean plane stays on the inner
+        // invariable plane (i_forced = 0) at every a.
+        let none = PlanetY::new(0.0, 150.0, 10.0);
+        for a in [40.0, 60.0, 80.0, 90.0] {
+            assert!(
+                forced_inclination_deg(a, &none).abs() < 1e-9,
+                "no-perturber tilt at {a} AU should vanish"
+            );
+        }
+        let w = warp_feature(&none);
+        assert!(w.amplitude_deg.abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_warp_amplitude_scales_with_mass() {
+        // Heavier Planet Y → larger warp. Check the two published mass bounds
+        // (0.05 and 1 M_⊕) at fixed a_Y, i_Y.
+        let light = PlanetY::new(published::M_Y_LOW_EARTH, 150.0, published::I_Y_DEG);
+        let heavy = PlanetY::new(published::M_Y_HIGH_EARTH, 150.0, published::I_Y_DEG);
+        let w_light = warp_feature(&light);
+        let w_heavy = warp_feature(&heavy);
+        assert!(
+            w_heavy.amplitude_deg > w_light.amplitude_deg,
+            "heavier Planet Y must warp more: light={:.3}° heavy={:.3}°",
+            w_light.amplitude_deg,
+            w_heavy.amplitude_deg
+        );
+        // In the small-tilt regime the warp is ∝ A_out ∝ m_Y, so a 20× mass
+        // ratio gives roughly a 20× amplitude ratio (modest tilts keep it
+        // close to linear).
+        let ratio = w_heavy.amplitude_deg / w_light.amplitude_deg;
+        let mass_ratio = published::M_Y_HIGH_EARTH / published::M_Y_LOW_EARTH;
+        assert!(
+            ratio > 0.4 * mass_ratio && ratio < mass_ratio * 1.1,
+            "amplitude ratio {ratio:.1} vs mass ratio {mass_ratio:.1}"
+        );
+    }
+
+    #[test]
+    fn test_a_y_position_shifts_warp() {
+        // A closer Planet Y (100 AU) warps the band more than a distant one
+        // (200 AU) at fixed mass, since A_out/A_in ∝ a_Y^{-3}.
+        let close = PlanetY::new(0.3, published::A_Y_LOW_AU, published::I_Y_DEG);
+        let far = PlanetY::new(0.3, published::A_Y_HIGH_AU, published::I_Y_DEG);
+        assert!(
+            warp_feature(&close).amplitude_deg > warp_feature(&far).amplitude_deg,
+            "closer Planet Y should warp more"
+        );
+    }
+
+    #[test]
+    fn test_forced_tilt_bounded_by_i_y() {
+        // The Laplace plane never tilts past Planet Y's own inclination.
+        let py = nominal_planet_y();
+        for a in [40.0, 55.0, 70.0, 85.0, 100.0] {
+            let i_f = forced_inclination_deg(a, &py);
+            assert!(
+                i_f >= 0.0 && i_f <= published::I_Y_DEG + 1e-6,
+                "forced tilt {i_f:.3}° at {a} AU out of [0, i_Y]"
+            );
+        }
+    }
+
+    #[test]
+    fn test_inner_field_includes_neptune() {
+        // The warp band is exterior to Neptune; the inner torque must include
+        // Neptune's mass (it is the nearest interior planet to the band).
+        assert!(neptune_mass_solar() > 0.0);
+        let with_n = inner_torque_coeff(60.0);
+        assert!(with_n > 0.0);
+    }
+}

--- a/crates/p9-2025-planet-y/src/lib.rs
+++ b/crates/p9-2025-planet-y/src/lib.rs
@@ -1,0 +1,18 @@
+//! Reproduction of Siraj, Loeb & Siegel (2025), "Planet Y" (arXiv:2508.14156).
+//!
+//! Distinct from Planet Nine: a Mercury-to-Earth-mass object (≈ 0.05–1 M_⊕) at
+//! a ≈ 100–200 AU, modestly inclined, imposes a **warp** of the Kuiper belt's
+//! mean plane — the local Laplace plane / forced inclination tilts up over a
+//! localized band of semi-major axis, a ≈ 50–80 AU, where the distant
+//! perturber's nodal torque becomes comparable to the giant planets'.
+//!
+//! - [`laplace_plane`] computes the forced inclination i_forced(a) from the
+//!   competition between the giant-planet quadrupole (inner torque, reusing
+//!   `p9_core::forces::j2_secular`) and Planet Y's exterior ring torque
+//!   (∝ m_Y), and measures the warp amplitude.
+//! - [`mean_plane`] expresses the forced plane as an observable mean-plane pole
+//!   (reusing p9-core pole geometry) and applies a first-order debiasing of an
+//!   inclination-limited sample.
+
+pub mod laplace_plane;
+pub mod mean_plane;

--- a/crates/p9-2025-planet-y/src/mean_plane.rs
+++ b/crates/p9-2025-planet-y/src/mean_plane.rs
@@ -1,0 +1,125 @@
+//! Observable mean-plane warp and a simple debiasing of an inclination-limited
+//! sample.
+//!
+//! Siraj et al. (2025) infer the local Laplace plane from the *measured* mean
+//! plane of Kuiper-belt objects binned in semi-major axis. The forced
+//! inclination computed in [`crate::laplace_plane`] is the underlying signal;
+//! what a survey records is the mean pole of objects that pass an
+//! inclination-dependent detectability cut. A flat, isotropic-in-node belt
+//! whose particles librate about the forced plane has a mean pole *at* the
+//! forced plane — but detection efficiency that favours low ecliptic
+//! inclination biases the estimate toward the ecliptic. This module computes
+//! the forced mean-plane pole and applies a first-order debiasing correction.
+//!
+//! The "mean plane" here is expressed as a pole vector via p9-core's pole
+//! geometry conventions, reusing the same (sin i sin Ω, −sin i cos Ω, cos i)
+//! normal used in `p9-2025-clustering::orbital_poles`.
+
+use nalgebra::Vector3;
+use p9_core::constants::DEG2RAD;
+use p9_core::coords::sky::angular_distance;
+
+use crate::laplace_plane::{forced_inclination, PlanetY};
+
+/// Pole unit vector of the forced (local Laplace) plane at semi-major axis `a`.
+///
+/// The forced plane is tilted by `i_forced` toward Planet Y's plane. Taking
+/// Planet Y's node as the reference longitude (Ω = 0), the forced pole is
+/// n̂ = (sin i_f sin Ω, −sin i_f cos Ω, cos i_f) with Ω = 0, i.e.
+/// n̂ = (0, −sin i_f, cos i_f).
+pub fn forced_pole(a_au: f64, planet_y: &PlanetY) -> Vector3<f64> {
+    let i_f = forced_inclination(a_au, planet_y);
+    Vector3::new(0.0, -i_f.sin(), i_f.cos())
+}
+
+/// Reference (inner invariable) pole = ecliptic z-axis in this reduced frame.
+pub fn reference_pole() -> Vector3<f64> {
+    Vector3::new(0.0, 0.0, 1.0)
+}
+
+/// Tilt (deg) of the local mean plane from the reference plane at `a`,
+/// measured as the true spherical angle between poles (reusing p9-core's
+/// `angular_distance`, the same metric the clustering crate uses for poles).
+pub fn mean_plane_tilt_deg(a_au: f64, planet_y: &PlanetY) -> f64 {
+    angular_distance(&forced_pole(a_au, planet_y), &reference_pole()) / DEG2RAD
+}
+
+/// First-order debiasing of a measured mean-plane tilt.
+///
+/// An inclination-limited sample (detection efficiency ∝ a smooth, decreasing
+/// function of ecliptic inclination) under-weights high-inclination members,
+/// pulling the *measured* pole toward the ecliptic. To leading order the
+/// measured tilt is suppressed by a factor `efficiency_slope ∈ (0, 1]`
+/// relative to the true forced tilt; debiasing divides it back out.
+///
+/// `measured_tilt_deg`: the raw mean-plane tilt from the (biased) sample.
+/// `efficiency_slope`: the fractional suppression (1.0 = unbiased).
+pub fn debias_tilt_deg(measured_tilt_deg: f64, efficiency_slope: f64) -> f64 {
+    assert!(
+        efficiency_slope > 0.0 && efficiency_slope <= 1.0,
+        "efficiency_slope must be in (0, 1]"
+    );
+    measured_tilt_deg / efficiency_slope
+}
+
+/// Forward model of a *biased* measurement: apply the inclination suppression
+/// to the true forced tilt. Used to verify that debiasing inverts the bias.
+pub fn biased_tilt_deg(a_au: f64, planet_y: &PlanetY, efficiency_slope: f64) -> f64 {
+    mean_plane_tilt_deg(a_au, planet_y) * efficiency_slope
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::laplace_plane::published;
+    use approx::assert_relative_eq;
+
+    fn nominal() -> PlanetY {
+        PlanetY::new(0.3, 150.0, published::I_Y_DEG)
+    }
+
+    #[test]
+    fn test_forced_pole_is_unit() {
+        let p = forced_pole(70.0, &nominal());
+        assert_relative_eq!(p.norm(), 1.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn test_tilt_matches_forced_inclination() {
+        // With Ω = 0 the pole tilt equals i_forced exactly.
+        let py = nominal();
+        let tilt = mean_plane_tilt_deg(72.0, &py);
+        let i_f = forced_inclination(72.0, &py) / DEG2RAD;
+        assert_relative_eq!(tilt, i_f, max_relative = 1e-9);
+    }
+
+    #[test]
+    fn test_debias_inverts_bias() {
+        let py = nominal();
+        let slope = 0.7;
+        let true_tilt = mean_plane_tilt_deg(75.0, &py);
+        let measured = biased_tilt_deg(75.0, &py, slope);
+        let recovered = debias_tilt_deg(measured, slope);
+        assert_relative_eq!(recovered, true_tilt, max_relative = 1e-12);
+    }
+
+    #[test]
+    fn test_bias_pulls_toward_ecliptic() {
+        // A biased measurement is always closer to flat than the truth.
+        let py = nominal();
+        let true_tilt = mean_plane_tilt_deg(78.0, &py);
+        let measured = biased_tilt_deg(78.0, &py, 0.6);
+        assert!(measured < true_tilt && measured > 0.0);
+    }
+
+    #[test]
+    fn test_tilt_rises_across_band() {
+        let py = nominal();
+        let t50 = mean_plane_tilt_deg(50.0, &py);
+        let t80 = mean_plane_tilt_deg(80.0, &py);
+        assert!(
+            t80 > t50,
+            "mean-plane tilt should rise: {t50:.3} → {t80:.3}"
+        );
+    }
+}


### PR DESCRIPTION
Reproduces Siraj, Loeb & Siegel (2025), "Planet Y" (arXiv:2508.14156).

Planet Y is distinct from Planet Nine: a Mercury-to-Earth-mass object (≈ 0.05–1 M⊕) at a ≈ 100–200 AU, modestly inclined, that imposes a **warp** of the Kuiper belt's mean plane localized to a ≈ 50–80 AU.

## What it computes (real, no hard-coded answers)
- **`laplace_plane`**: the classical Laplace-plane / forced inclination `i_forced(a)` from the balance of two nodal torques —
  - inner giant-planet quadrupole `A_in ∝ a^-7/2`, built by reusing `p9_core::forces::j2_secular::effective_j2` for the orbit-averaged JSUN ring (Neptune included since the band is exterior to it);
  - outer Planet Y exterior-ring torque `A_out = ¼ n (m_Y/M) α² b_{3/2}^(1)(α)`, with the Laplace coefficient evaluated by quadrature;
  - `tan(2 i_forced) = A_out sin 2i_Y / (A_in + A_out cos 2i_Y)`, plus a `warp_feature` diagnostic over the 50–80 AU band.
- **`mean_plane`**: expresses the forced plane as an observable mean-plane pole (reusing p9-core `coords::sky::angular_distance`, same pole geometry as the clustering crate) and applies a first-order debiasing of an inclination-limited sample.

## Pinned results
- With Planet Y the forced mean-plane tilt rises across 50–80 AU; the warp scales with m_Y (checked at both 0.05 and 1 M⊕) and with a_Y.
- The "few-degree" warp is realized at the Earth-mass / 100 AU corner (≈ 3.6°); a Mercury-mass or distant object gives only a few tenths of a degree — documented honestly.
- Without the perturber the plane stays exactly on the invariable/ecliptic plane.
- Published reference numbers kept as labelled constants in `laplace_plane::published`.

Residuals documented in `REPRODUCTION_NOTES.md` (entry 10): the warp is sub-degree for most of the allowed parameter box, and the torque crossover sits exterior to the band, so the in-band signal is the small rising shoulder of the transition — the honest reason the observed warp is tentative.

`cargo build`, `cargo test` (16 tests), and `cargo fmt` all green.

Closes #66