### PR TITLE
Add JBT 0.5m + SPENCER preset to p9-survey detectability

### DIFF
--- a/crates/p9-survey/README.md
+++ b/crates/p9-survey/README.md
@@ -12,7 +12,11 @@ across this workspace and asks two questions numerically —
 2. **Can a survey catch it?** Each telescope (`telescope.rs`) has a footprint
    (declination band + galactic-plane cut + coverage fraction) and a limiting
    magnitude; detection probability = P(in footprint **and** brighter than the
-   depth), integrated over the same Monte Carlo.
+   depth), integrated over the same Monte Carlo. Presets: Rubin/LSST (ground),
+   Roman (space NIR, deep but tiny field), and **JBT 0.5 m + SPENCER** — the
+   0.485 m f/12.3 telescope with the 4×IMX455 imager, with optics, plate scale
+   (0.130″/px), field (~0.32 deg²) and photon-budget depth (V≈24–26 stacked)
+   derived from the `focalplane` simulator (see `telescope.rs` module docs).
 
 Surveyed solutions (all sourced from reproduction crates, not re-typed):
 

--- a/crates/p9-survey/p9_survey_sky.svg
+++ b/crates/p9-survey/p9_survey_sky.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-14T06:05:19.168792</dc:date>
+    <dc:date>2026-06-14T10:49:12.708539</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -43,12 +43,12 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m063e5127ec" d="M 0 0 
+       <path id="m9de694df24" d="M 0 0 
 L 0 3.5 
 " style="stroke: #565f89; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m063e5127ec" x="565.693075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="565.693075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -104,7 +104,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m063e5127ec" x="522.615475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="522.615475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -144,7 +144,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m063e5127ec" x="479.537875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="479.537875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -179,7 +179,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m063e5127ec" x="436.460275" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="436.460275" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -225,7 +225,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m063e5127ec" x="393.382675" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="393.382675" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -280,7 +280,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m063e5127ec" x="350.305075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="350.305075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -311,7 +311,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m063e5127ec" x="307.227475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="307.227475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -326,7 +326,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m063e5127ec" x="264.149875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="264.149875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -341,7 +341,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m063e5127ec" x="221.072275" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="221.072275" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -356,7 +356,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m063e5127ec" x="177.994675" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="177.994675" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -371,7 +371,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m063e5127ec" x="134.917075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="134.917075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -386,7 +386,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m063e5127ec" x="91.839475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="91.839475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -401,7 +401,7 @@ z
     <g id="xtick_13">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m063e5127ec" x="48.761875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="48.761875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -670,12 +670,12 @@ z
     <g id="ytick_1">
      <g id="line2d_14">
       <defs>
-       <path id="m0e240601d3" d="M 0 0 
+       <path id="me86f7f4261" d="M 0 0 
 L -3.5 0 
 " style="stroke: #565f89; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0e240601d3" x="48.761875" y="233.734168" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me86f7f4261" x="48.761875" y="233.734168" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -748,7 +748,7 @@ z
     <g id="ytick_2">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m0e240601d3" x="48.761875" y="203.81759" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me86f7f4261" x="48.761875" y="203.81759" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -798,7 +798,7 @@ z
     <g id="ytick_3">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m0e240601d3" x="48.761875" y="173.901013" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me86f7f4261" x="48.761875" y="173.901013" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -814,7 +814,7 @@ z
     <g id="ytick_4">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m0e240601d3" x="48.761875" y="143.984435" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me86f7f4261" x="48.761875" y="143.984435" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -846,7 +846,7 @@ z
     <g id="ytick_5">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m0e240601d3" x="48.761875" y="114.067858" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me86f7f4261" x="48.761875" y="114.067858" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -862,7 +862,7 @@ z
     <g id="ytick_6">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m0e240601d3" x="48.761875" y="84.15128" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me86f7f4261" x="48.761875" y="84.15128" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -878,7 +878,7 @@ z
     <g id="ytick_7">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m0e240601d3" x="48.761875" y="54.234703" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me86f7f4261" x="48.761875" y="54.234703" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
@@ -969,9 +969,9 @@ z
      </g>
     </g>
    </g>
-   <g clip-path="url(#p9f985b6241)">
+   <g clip-path="url(#pbca7bb30fa)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAs4AAAFNCAYAAAAQIOnHAAAZg0lEQVR4nO3dWXcc57kd4KqunoDGRIKTJlOjLctnSNbKXe6yVv5FfmuuspKTUbZlWTq2HEm2TFEUBxAgph6qcpuzuL/kwzm0RUnPc7lRrC4WgO6Nunjftmm6Bw0AAPD/NPquLwAAAL4PFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFcbf9QX89bWFtLviaUp/c1z1b5H+iscXDFc7z9AMha+UzlM6HgDgx8ETZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAV/goLUAoLR9pJIc+XNGqnOR/lvCvms8L5C687KlznC/qbY7jiApRh2BTyfJ7S+UvH9/065pv+Mh8/5OOHQt4Py3x8X8ibfB4AgL82T5wBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgArjtjTKuTDXuBvN84m67ZhPxoucd4V8tBXzWbubj28Lxzf5eqZDPn4y5HnN4xc06rovzFMu5SVDm49fN3m+86ZZ5bzN85FXTZ7XvGou8usO+fhi3p/FfLk5za9bzPN5+v756zQjGgB4ETxxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqjA92PohfKM1Tno/2Y77THsZ8tz/IxzeF8xfmR8+7LuazUe7+41Eb80nhT4Wuzcd3heOHIeebQt4X/kFfOL4QF4/fFM5fup5VX5gHXXiB1ZCPXw15fvSqMFf6fJTnO190eS7zs/YoHz8cx3zZP3s+2zyfNU3TLNcnMV+t8/GbwgzqYchzogGAl0XueW07K+S5j3riDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKDC+N90/z5+YT7Kg593xznfm+YOvjPJA6e382macT68uLiksOekMOb66otFygtHcr4uLhzJV3TVBSibvIekKcTF69z0+YYWz1P4Quk6V6VFKv0i5svNtZhf9Hdifjas8vHt88tITid5ccnp9Cjnw8P8muvHMb9c5fMUF6kUFrIMzTrmAMA/1bbTmI+7vZhvTfOivq3J9ZjP2t2Ye+IMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFQY/7s7ea7uvMtzeBeFfKvLg36no9Jk4Kw073g1FPIrHn+xya+7LBxfmst8WThPMS/MNS7PWc55aW7yujQQ+opKc7FHbWkydtYVDu8KX5gX8p0h/223GSaFfOu5bN3nmY5nm5sxPx3uxvx4nOcvP508ivlJ/yDmF5ujmJfmQS/XxzHvN3k+tXnQALy88ud91+W5ybNx3vOwM8t7Hq53+TP8Tv9qzA/Hz/eGpmmaxbiLuSfOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAECF8b89zLNpu9HV5gJvCvOUzzZ5Dt7Jehzziz53+ZN1Pv/JKufPCqNsT1f5/3W2zoOTLwuDli8Kg5bP+vzCy6GQN3nw86aQ901+3VI+KvxtVMonTf6+jAvHt4V5jKXjx23hdUeFvHD8tDD3eRIGUZdmRG+P87kPhnwPDtd51uPZJs+YPG1+EvNn49OYH0+e5OOHPA/6dPVtzC+W+TzL9VHMh+Ei5gDw/9O205hPxgcx35oexnx/8kbMbw9vxfy1Ln/2vr7Iex5e285d4OYs96dFYT+JJ84AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKoz355fxC+tN7tSnqzxY+uEyD8D+5iIvk3hwmc//7UVeOPJ0mQdRHy3zYpGnfV7q8KzNyyfO2uOYXzR5QcxqOM95fxbz9ZDv86bP+TDk/+9VtYUFIqM2fx+7Nn+/SseX8nE7i/m03c75kJeLbPd7OV/n8+yE152P8hKeWWHpyjgsUWmappmPS3m+BwdDztd9vvaLTR4KfzLkofCPJ09j/mR6L59nfT/m58uHMb9cHcW87/PvUNNcbWkSAC+f0Wgn5vNJ/ozanb8a81vtuzF/rbkT8ze25zlf5M/eN7bzorhX57n/3dzK+WK6jPnYAhQAAPjnU5wBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBh/PnxbvzCyTrPvn24zF37/nmes3fvLM/Zu3+RZ8F+2z6J+XH7bcxP+zyD9mJ9FPPl+iTmmz7P8dsU5kEPQ54fXc7zfWiaFzOvuSx/v9o2f3/Lx5fmO+e8dPy4y3Mau1Ge+zzpFjGfdYX5zu2157JFf5CP3eRZlYsmX+O8MLN6q8v3ct7le7k9zvneNJ9nf5Pv5eE6z74+Xl+P+ePR3Zxv5/nOz/oHMT9d5vxi+Sjm603+nWua0u8EAFeXP0PGXe55W7ObMd+f/iTmrw0/jfk70/yZ8/Zevp63F/m9/81F3oPxyk7ui3uL3M/mW7mHlaxW+TN5vczX74kzAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBh/B8fTOMXjpd5vvCjyzzv+H5/FPNvR3/K5+/vxfx8mecyr9bPYl6es3wZ86YZCvkPVZ6XWJ4rnQ2F23bVKdSrdZ733RbmT7aj/PM5GuVZy5Nu+7lsOs4zLKddnuM8G9XPiG6aptnb5Hx/nV93v8szqxeT/HfsdJTv2WSaj19M8r25tsmve2d9EPOnzZsxfzjPc5wfT/Pv+unqm5ifF+Y+b9bHMR+aq83mBPg+a5vCPoTxQcwX8zsxvz55K+av92/H/J15/ux6/yB/5nywm/vWT6/lPnfzdp7tv3UjN4p2mj8D+8tcTC4f5+t8+ijvPnhwkrvAk8tC/4gpAADwTyjOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAECF9oNr/yFuMzhtnsR/cLrOyw/OCssMLtf5PP3mLOaWHPAv8/yg9LbNiz+6whKVUj6d5KHw89Iw+u5mzA+GPKT+YMiLV/YL17MY56Uxs66wMKWwSKW0Euhyk7/ybJWX5zzenMf8UZvfGx43XxXOfz/mpYUpq9LClCEvRwL4LrRt4bOl8BmyO3815jfG78b8zeFuzN/aya/7fv7Iaf5mP7+X/+xmfg8+fC+/107eyK/bzvJil+F8FfPVn/OCladfTmL+xTd5KdnvC4tOPj/Nn6UPC3v0PHEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACq0k/HtOJi5H5bxH5i/zA9fnnfctnlmZNfl2ZDTrjD3eZpnTO50t2K+2+Z50Nf6w5yPtmK+N8mzM7fH+e/naeHP6j7HzbIw9/l0nfOjVX6Pedgc5bz9c8yP1/difnaZZ84v1/n8fZ9nl5YnXQM/DvkzoSu9x0/ye/Pu7LWY32l/GvO3R7dj/t5+/ix6fy/P2P/F/rOYv/Nansu8+7P8ntfdzYOf2938mdMscy/s7+XZ+2ef5MHJn39+PeYfPd6P+W+P82fdH47z9fxx9TTmj0bfxNwTZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgQts0XR52CvyLtE2eJTnqtmM+KcyDnk/zDMvFOM933m/vxLw09/mgzddzMM2zQncn+e/tWZdnnY5y3BTGPjcnyzwp+vFlnsH5sM8zSh+M8nzno82fYn62fBjzy3We8bnZ5NcdCjPwgZdD205jPu7ynOLtWWGW/vStmL/evxvzt+Z57vN7e13M/24/v5f8zY3HMX/l3TwfefazRcxHr+fPlmY3fyY0l/l6hnv5epaf5uu599v8Wffhg/wZ9eun+fv18ZNVzP+wyfOXvx4+ifnJRf6sWG5OYu6JMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQwRxneGkU5iCPtmI+Ls19nlyL+fYkzyLdG+W5zzf7nN8Y5de9Pstzqw9m+e/zeR5dWrgLTXO5yfnJKg+EflL4B4/W5zH/ts1znJ82eSboyfp+zC9WhZmm6zzTtN+cxXxo8txq+LEqzcbvCu+F0/F+zBezWzE/7PJc5rv9T2L+9m5+b34/j4NuPtjL7z2/eOXbmN/41/k9bPy3r+QXeDW/xw/zPAe5PbvI5/k6X8/6V/k978GH+fy/up+v58Ojecx/8yT/f3+3yu/BX/Ufxfz4Is/qvyy8Nw9D4T4UeOIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoIIFKPAD07Z5GH1pSUBpYcpiWlgSMHoz5rf62zG/PdmO+fXCBpS9SV6BUlqYMipsTCktTDkt7BV5uuxj/uQy/4MnfV5m8GiUF6kcDfcK15OXDVws87D+1eZZzC1S4WWW3pdGo7wIYzYuLHGaHsZ8b/xazG8XFpe8XliM8tZeXrDy8738ZvJ3B3mp0dt3H8V891/l9+bRL16P+fBOvv5hL19/e3qa8y+/inn/6y9i/vS/LGP+yy/yUqx/eJTf4z8uLDT5tLDQ5M/Dx/l6zr+M+eUqv9cOQ77+F8UTZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCggjnO8CPXNnl2aTfei/lWYZbq7vSVmB82d2N+Z8hzom9O82zXG1t5kPNBHo3azAqPBUpzn1d5jHNz8ReeB/2oz/OXH4/yfOfjIb9ln23y7NjL1dOcr3Pe9xeF/DLmTVO4Qbyk8i9A2+Tfr7Ywa3nc5dm90/FuzLcm15/Ldrs8F/hmn+cavz4+yPliEvO3d4aYv7uTf5bfP3wS81c/yLPTp3+f3wvb9wpzme/k97xhN9+zZp3fM9qv7+fjf/m7GJ/+p6OY/+Yf8+z9//o4X8//epTf2z6+zHOZv+o/inlpLvNynWfX/6XnMl+VJ84AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAVznIEruerc5+3pzZjvTl+N+Y3mJzG/M+Tz3JrPYn59lufS7l9x7vOsy7NgS1Z9npN7Xhh3fLLK+XFhHnQpP1rn2bRHTZ5B+3SU5z6fDjlf9vk8y03OV+s8n3q1OY15X5jV2veFGa5DnnE7NKXvV2FQd1HpPIVB4EX5B6ttC3OT2/z7Vcq7wpzlbpR/0CfdIuaz0tz20bWY7zd5BvDN4UbOJ1vPZa8u8v/pzcXV5i+/d+0o5q+8eRzzrZ8/fy1N0zSjn78W8+Gd/J40XM9znJsuf2+bZyf5db/6Op//t5/H/Ow/H8X8o0+uNpf5V4/zff74PM+Q/3L4ZcyPzvN1rlaFucxNYQj+94QnzgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqWIAC/EW1bV7EMO7ywoX5NC9c2J2+EvPD5m7MbxUWptyc5uUHh4UNKPvTvPCitEhlPspLBbor7s1YFfZvLAsLVs4KOwVOC/nxMr/As1VeFHK6zhtczvq8weVZc5GPb/PClLM2L4e4HPLx68L5131ektEP+Tr7wmKUYch5217teVPXTgp5XtwzbbdjPmt3Yr495OUWO4V8t80//9cn+Qf6xlZe5nE7711pXt/KPyd3F+fPZW/s5+/57bs5n3+Q783oZ3mZ0nC3sNDk1q2c7+R7VtI+zsuCRp/975j3H+b8+B/yz/KvP88LTf7b4/yz8KvH+d5/svwm5l/1H8W8tNBkucr/36YpbHf6gfLEGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACoYI4z8FJpm3HMuy7PLp1PD2O+mOZZrddGb8T8Rn8n5re6RT5+nq/z2izPWT4ozH1ejPM85e0u57PinOic91ecB31ZyC9K+aaU59e9ar4s/AeWm0JeOH6TxzIXpji/uKdK41G+P/PCYO+tcc4X+cet2c1jopuDSf6f3Zzlwd6353n+9Su7pzG/cSfP195+M19/9/bz89nb12/EY4dX8/zi4Ubh+L39mDej/F1sT/O1t9/kecftH76M+ebDP8X82/+eX/d/fpXfY/7HkzzT+zdP8uzxT/s/xvzr9ccxPz7Px6/XT2LeNIU3DZqm8cQZAACqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKhgjjPwPdfltDB/eTZ+fp5s0zTNdmEe9N74tZgf9q/G/FabZ8oezvIg52uz/Pzieh7t2lyb5hmr1wpzexfjPCB5Upj7PCrkeTpv+firKp2/dPZ+yP9iU8hLSvOvS3np/1sY19zMu3z/F5M8o3d7uszHb+V8azfn82v552FyKw9+Ht3ejnl7J/++NHfy78tw62bO9/fCxRSGm6/zrOnmNM+Ubh8+yvmf78e8/+RezE9+me/lZ1/k+dEfHe3m/Gl+T/rk6XnMf9/+LubfXn4a89PLr2O+2RzHnBfLE2cAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFSxAAWiaZjTKCyAmXVjc0DTNfJoXQ+xM7sT8oM0LUw77vFzhRpev53A+zsfP8waOw1le2LE7zvmiy4szdsalBSt5WcV2YfHKVuH4eSGfTXI+LlznuLTwZVLIt3I+Lty3tissQCns8ugW+fsy2i8sItkvbL7ZnefrWeS82SnkWzkfCnkzK1xPaeNLyfnFc1H78Em+lq8exnz92dOYP/l9vpdffJN/Rz853on5p8d5cclnx3lZzZebfJ33mn+M+dH5lzE/X34T82F4/p7x3fPEGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACoYI4zwD9D2+R5yl2XZ8ROx/sxL86D7m7F/FrzSswPh+s5H2/F/GCWZ9buTfJ83v3CnOKDaZ5rvF+Y+7xfmKe8W5jXvNXlfDHNs3VL+fbWZcznO/n4yfwFzXHezc+nRrv556dd5JnEbWF+d3Gecp+vs1nm+z9c5vvcPyvkJ/k8y8f5ZU8ePT8P+puj3XjsH58tYv75Wb43nz/L9+CPz5Yx/6p/FPOvm89i/vTyjzG/WObzrDcnMW+afM/4fvHEGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACoYI4zwHeobecx77rtmM8K86Bnk5xvd4cx32vznOjd/iDm19o8n3p/nGfr7k3znOidwpzoRWFM8VY+TbMzznOKdwvzo3cnhXyc5xTPuzxzt/S0qRvl65mO8nmm45xPRvk62zaff73JV3Sxzjf0tJCfrPL38WiVj3+yyq/7ZJm/v4/CGO0H5/kePFiexfz+6H7MH/d/ivmz5dcxv1g9iflmfRzzock/I/w4eeIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoIIFKAA/AG07jXk3yotUxoUFK5PxIubz8UHMZ6O9mG+313I+5OO3hq2cN/n/NW3zYo7tUc63xvk50bzLCzumhbz0tKnNhzejwhcKhzejwhc2ef9Js+nzFy4K/+B8nfOTdV7ycdKHzSVN0xy3z/Lx7eOYnw4Pn8vO1vnYi2XOV5v8mv0mL0yxuIS/BE+cAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAK5jgD8H8pzB1uJzEfjeYx7wr5eJTnNXddaQ71LL9uYY7zuM3HjwvnGTf5Okvn75p8H16Uoelj3jebnA95VvG6uYj5qj+/Ur5cneTzF47f9Pl1+5APwzIeCy8zT5wBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgArmOAPwEijMj266wuGl5z45bwvHt4V5ze1VnysVr6dgyPOaS3Och8LxZaXz5LnPw7AqnGe44uvCD5snzgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAq5MnvAPBXlRdtDE1e2HHVvRyDPR7AC+CJMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFT4P93k/D7/mvQDAAAAAElFTkSuQmCC" id="imagec5c9f061ea" transform="scale(1 -1) translate(0 -239.76)" x="48.761875" y="-23.890745" width="516.96" height="239.76"/>
+iVBORw0KGgoAAAANSUhEUgAAAs4AAAFNCAYAAAAQIOnHAAAZg0lEQVR4nO3dWXcc57kd4KqunoDGRIKTJlOjLctnSNbKXe6yVv5FfmuuspKTUbZlWTq2HEm2TFEUBxAgph6qcpuzuL/kwzm0RUnPc7lRrC4WgO6Nunjftmm6Bw0AAPD/NPquLwAAAL4PFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFcbf9QX89bWFtLviaUp/c1z1b5H+iscXDFc7z9AMha+UzlM6HgDgx8ETZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAV/goLUAoLR9pJIc+XNGqnOR/lvCvms8L5C687KlznC/qbY7jiApRh2BTyfJ7S+UvH9/065pv+Mh8/5OOHQt4Py3x8X8ibfB4AgL82T5wBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgArjtjTKuTDXuBvN84m67ZhPxoucd4V8tBXzWbubj28Lxzf5eqZDPn4y5HnN4xc06rovzFMu5SVDm49fN3m+86ZZ5bzN85FXTZ7XvGou8usO+fhi3p/FfLk5za9bzPN5+v756zQjGgB4ETxxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqjA92PohfKM1Tno/2Y77THsZ8tz/IxzeF8xfmR8+7LuazUe7+41Eb80nhT4Wuzcd3heOHIeebQt4X/kFfOL4QF4/fFM5fup5VX5gHXXiB1ZCPXw15fvSqMFf6fJTnO190eS7zs/YoHz8cx3zZP3s+2zyfNU3TLNcnMV+t8/GbwgzqYchzogGAl0XueW07K+S5j3riDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKDC+N90/z5+YT7Kg593xznfm+YOvjPJA6e382macT68uLiksOekMOb66otFygtHcr4uLhzJV3TVBSibvIekKcTF69z0+YYWz1P4Quk6V6VFKv0i5svNtZhf9Hdifjas8vHt88tITid5ccnp9Cjnw8P8muvHMb9c5fMUF6kUFrIMzTrmAMA/1bbTmI+7vZhvTfOivq3J9ZjP2t2Ye+IMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFQY/7s7ea7uvMtzeBeFfKvLg36no9Jk4Kw073g1FPIrHn+xya+7LBxfmst8WThPMS/MNS7PWc55aW7yujQQ+opKc7FHbWkydtYVDu8KX5gX8p0h/223GSaFfOu5bN3nmY5nm5sxPx3uxvx4nOcvP508ivlJ/yDmF5ujmJfmQS/XxzHvN3k+tXnQALy88ud91+W5ybNx3vOwM8t7Hq53+TP8Tv9qzA/Hz/eGpmmaxbiLuSfOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAECF8b89zLNpu9HV5gJvCvOUzzZ5Dt7Jehzziz53+ZN1Pv/JKufPCqNsT1f5/3W2zoOTLwuDli8Kg5bP+vzCy6GQN3nw86aQ901+3VI+KvxtVMonTf6+jAvHt4V5jKXjx23hdUeFvHD8tDD3eRIGUZdmRG+P87kPhnwPDtd51uPZJs+YPG1+EvNn49OYH0+e5OOHPA/6dPVtzC+W+TzL9VHMh+Ei5gDw/9O205hPxgcx35oexnx/8kbMbw9vxfy1Ln/2vr7Iex5e285d4OYs96dFYT+JJ84AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKoz355fxC+tN7tSnqzxY+uEyD8D+5iIvk3hwmc//7UVeOPJ0mQdRHy3zYpGnfV7q8KzNyyfO2uOYXzR5QcxqOM95fxbz9ZDv86bP+TDk/+9VtYUFIqM2fx+7Nn+/SseX8nE7i/m03c75kJeLbPd7OV/n8+yE152P8hKeWWHpyjgsUWmappmPS3m+BwdDztd9vvaLTR4KfzLkofCPJ09j/mR6L59nfT/m58uHMb9cHcW87/PvUNNcbWkSAC+f0Wgn5vNJ/ozanb8a81vtuzF/rbkT8ze25zlf5M/eN7bzorhX57n/3dzK+WK6jPnYAhQAAPjnU5wBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBh/PnxbvzCyTrPvn24zF37/nmes3fvLM/Zu3+RZ8F+2z6J+XH7bcxP+zyD9mJ9FPPl+iTmmz7P8dsU5kEPQ54fXc7zfWiaFzOvuSx/v9o2f3/Lx5fmO+e8dPy4y3Mau1Ge+zzpFjGfdYX5zu2157JFf5CP3eRZlYsmX+O8MLN6q8v3ct7le7k9zvneNJ9nf5Pv5eE6z74+Xl+P+ePR3Zxv5/nOz/oHMT9d5vxi+Sjm603+nWua0u8EAFeXP0PGXe55W7ObMd+f/iTmrw0/jfk70/yZ8/Zevp63F/m9/81F3oPxyk7ui3uL3M/mW7mHlaxW+TN5vczX74kzAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBh/B8fTOMXjpd5vvCjyzzv+H5/FPNvR3/K5+/vxfx8mecyr9bPYl6es3wZ86YZCvkPVZ6XWJ4rnQ2F23bVKdSrdZ733RbmT7aj/PM5GuVZy5Nu+7lsOs4zLKddnuM8G9XPiG6aptnb5Hx/nV93v8szqxeT/HfsdJTv2WSaj19M8r25tsmve2d9EPOnzZsxfzjPc5wfT/Pv+unqm5ifF+Y+b9bHMR+aq83mBPg+a5vCPoTxQcwX8zsxvz55K+av92/H/J15/ux6/yB/5nywm/vWT6/lPnfzdp7tv3UjN4p2mj8D+8tcTC4f5+t8+ijvPnhwkrvAk8tC/4gpAADwTyjOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAECF9oNr/yFuMzhtnsR/cLrOyw/OCssMLtf5PP3mLOaWHPAv8/yg9LbNiz+6whKVUj6d5KHw89Iw+u5mzA+GPKT+YMiLV/YL17MY56Uxs66wMKWwSKW0Euhyk7/ybJWX5zzenMf8UZvfGx43XxXOfz/mpYUpq9LClCEvRwL4LrRt4bOl8BmyO3815jfG78b8zeFuzN/aya/7fv7Iaf5mP7+X/+xmfg8+fC+/107eyK/bzvJil+F8FfPVn/OCladfTmL+xTd5KdnvC4tOPj/Nn6UPC3v0PHEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACq0k/HtOJi5H5bxH5i/zA9fnnfctnlmZNfl2ZDTrjD3eZpnTO50t2K+2+Z50Nf6w5yPtmK+N8mzM7fH+e/naeHP6j7HzbIw9/l0nfOjVX6Pedgc5bz9c8yP1/difnaZZ84v1/n8fZ9nl5YnXQM/DvkzoSu9x0/ye/Pu7LWY32l/GvO3R7dj/t5+/ix6fy/P2P/F/rOYv/Nansu8+7P8ntfdzYOf2938mdMscy/s7+XZ+2ef5MHJn39+PeYfPd6P+W+P82fdH47z9fxx9TTmj0bfxNwTZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgQts0XR52CvyLtE2eJTnqtmM+KcyDnk/zDMvFOM933m/vxLw09/mgzddzMM2zQncn+e/tWZdnnY5y3BTGPjcnyzwp+vFlnsH5sM8zSh+M8nzno82fYn62fBjzy3We8bnZ5NcdCjPwgZdD205jPu7ynOLtWWGW/vStmL/evxvzt+Z57vN7e13M/24/v5f8zY3HMX/l3TwfefazRcxHr+fPlmY3fyY0l/l6hnv5epaf5uu599v8Wffhg/wZ9eun+fv18ZNVzP+wyfOXvx4+ifnJRf6sWG5OYu6JMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQwRxneGkU5iCPtmI+Ls19nlyL+fYkzyLdG+W5zzf7nN8Y5de9Pstzqw9m+e/zeR5dWrgLTXO5yfnJKg+EflL4B4/W5zH/ts1znJ82eSboyfp+zC9WhZmm6zzTtN+cxXxo8txq+LEqzcbvCu+F0/F+zBezWzE/7PJc5rv9T2L+9m5+b34/j4NuPtjL7z2/eOXbmN/41/k9bPy3r+QXeDW/xw/zPAe5PbvI5/k6X8/6V/k978GH+fy/up+v58Ojecx/8yT/f3+3yu/BX/Ufxfz4Is/qvyy8Nw9D4T4UeOIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoIIFKPAD07Z5GH1pSUBpYcpiWlgSMHoz5rf62zG/PdmO+fXCBpS9SV6BUlqYMipsTCktTDkt7BV5uuxj/uQy/4MnfV5m8GiUF6kcDfcK15OXDVws87D+1eZZzC1S4WWW3pdGo7wIYzYuLHGaHsZ8b/xazG8XFpe8XliM8tZeXrDy8738ZvJ3B3mp0dt3H8V891/l9+bRL16P+fBOvv5hL19/e3qa8y+/inn/6y9i/vS/LGP+yy/yUqx/eJTf4z8uLDT5tLDQ5M/Dx/l6zr+M+eUqv9cOQ77+F8UTZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCggjnO8CPXNnl2aTfei/lWYZbq7vSVmB82d2N+Z8hzom9O82zXG1t5kPNBHo3azAqPBUpzn1d5jHNz8ReeB/2oz/OXH4/yfOfjIb9ln23y7NjL1dOcr3Pe9xeF/DLmTVO4Qbyk8i9A2+Tfr7Ywa3nc5dm90/FuzLcm15/Ldrs8F/hmn+cavz4+yPliEvO3d4aYv7uTf5bfP3wS81c/yLPTp3+f3wvb9wpzme/k97xhN9+zZp3fM9qv7+fjf/m7GJ/+p6OY/+Yf8+z9//o4X8//epTf2z6+zHOZv+o/inlpLvNynWfX/6XnMl+VJ84AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAVznIEruerc5+3pzZjvTl+N+Y3mJzG/M+Tz3JrPYn59lufS7l9x7vOsy7NgS1Z9npN7Xhh3fLLK+XFhHnQpP1rn2bRHTZ5B+3SU5z6fDjlf9vk8y03OV+s8n3q1OY15X5jV2veFGa5DnnE7NKXvV2FQd1HpPIVB4EX5B6ttC3OT2/z7Vcq7wpzlbpR/0CfdIuaz0tz20bWY7zd5BvDN4UbOJ1vPZa8u8v/pzcXV5i+/d+0o5q+8eRzzrZ8/fy1N0zSjn78W8+Gd/J40XM9znJsuf2+bZyf5db/6Op//t5/H/Ow/H8X8o0+uNpf5V4/zff74PM+Q/3L4ZcyPzvN1rlaFucxNYQj+94QnzgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqWIAC/EW1bV7EMO7ywoX5NC9c2J2+EvPD5m7MbxUWptyc5uUHh4UNKPvTvPCitEhlPspLBbor7s1YFfZvLAsLVs4KOwVOC/nxMr/As1VeFHK6zhtczvq8weVZc5GPb/PClLM2L4e4HPLx68L5131ektEP+Tr7wmKUYch5217teVPXTgp5XtwzbbdjPmt3Yr495OUWO4V8t80//9cn+Qf6xlZe5nE7711pXt/KPyd3F+fPZW/s5+/57bs5n3+Q783oZ3mZ0nC3sNDk1q2c7+R7VtI+zsuCRp/975j3H+b8+B/yz/KvP88LTf7b4/yz8KvH+d5/svwm5l/1H8W8tNBkucr/36YpbHf6gfLEGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACoYI4z8FJpm3HMuy7PLp1PD2O+mOZZrddGb8T8Rn8n5re6RT5+nq/z2izPWT4ozH1ejPM85e0u57PinOic91ecB31ZyC9K+aaU59e9ar4s/AeWm0JeOH6TxzIXpji/uKdK41G+P/PCYO+tcc4X+cet2c1jopuDSf6f3Zzlwd6353n+9Su7pzG/cSfP195+M19/9/bz89nb12/EY4dX8/zi4Ubh+L39mDej/F1sT/O1t9/kecftH76M+ebDP8X82/+eX/d/fpXfY/7HkzzT+zdP8uzxT/s/xvzr9ccxPz7Px6/XT2LeNIU3DZqm8cQZAACqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKhgjjPwPdfltDB/eTZ+fp5s0zTNdmEe9N74tZgf9q/G/FabZ8oezvIg52uz/Pzieh7t2lyb5hmr1wpzexfjPCB5Upj7PCrkeTpv+firKp2/dPZ+yP9iU8hLSvOvS3np/1sY19zMu3z/F5M8o3d7uszHb+V8azfn82v552FyKw9+Ht3ejnl7J/++NHfy78tw62bO9/fCxRSGm6/zrOnmNM+Ubh8+yvmf78e8/+RezE9+me/lZ1/k+dEfHe3m/Gl+T/rk6XnMf9/+LubfXn4a89PLr2O+2RzHnBfLE2cAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFSxAAWiaZjTKCyAmXVjc0DTNfJoXQ+xM7sT8oM0LUw77vFzhRpev53A+zsfP8waOw1le2LE7zvmiy4szdsalBSt5WcV2YfHKVuH4eSGfTXI+LlznuLTwZVLIt3I+Lty3tissQCns8ugW+fsy2i8sItkvbL7ZnefrWeS82SnkWzkfCnkzK1xPaeNLyfnFc1H78Em+lq8exnz92dOYP/l9vpdffJN/Rz853on5p8d5cclnx3lZzZebfJ33mn+M+dH5lzE/X34T82F4/p7x3fPEGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACoYI4zwD9D2+R5yl2XZ8ROx/sxL86D7m7F/FrzSswPh+s5H2/F/GCWZ9buTfJ83v3CnOKDaZ5rvF+Y+7xfmKe8W5jXvNXlfDHNs3VL+fbWZcznO/n4yfwFzXHezc+nRrv556dd5JnEbWF+d3Gecp+vs1nm+z9c5vvcPyvkJ/k8y8f5ZU8ePT8P+puj3XjsH58tYv75Wb43nz/L9+CPz5Yx/6p/FPOvm89i/vTyjzG/WObzrDcnMW+afM/4fvHEGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACoYI4zwHeobecx77rtmM8K86Bnk5xvd4cx32vznOjd/iDm19o8n3p/nGfr7k3znOidwpzoRWFM8VY+TbMzznOKdwvzo3cnhXyc5xTPuzxzt/S0qRvl65mO8nmm45xPRvk62zaff73JV3Sxzjf0tJCfrPL38WiVj3+yyq/7ZJm/v4/CGO0H5/kePFiexfz+6H7MH/d/ivmz5dcxv1g9iflmfRzzock/I/w4eeIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoIIFKAA/AG07jXk3yotUxoUFK5PxIubz8UHMZ6O9mG+313I+5OO3hq2cN/n/NW3zYo7tUc63xvk50bzLCzumhbz0tKnNhzejwhcKhzejwhc2ef9Js+nzFy4K/+B8nfOTdV7ycdKHzSVN0xy3z/Lx7eOYnw4Pn8vO1vnYi2XOV5v8mv0mL0yxuIS/BE+cAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAK5jgD8H8pzB1uJzEfjeYx7wr5eJTnNXddaQ71LL9uYY7zuM3HjwvnGTf5Okvn75p8H16Uoelj3jebnA95VvG6uYj5qj+/Ur5cneTzF47f9Pl1+5APwzIeCy8zT5wBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgArmOAPwEijMj266wuGl5z45bwvHt4V5ze1VnysVr6dgyPOaS3Och8LxZaXz5LnPw7AqnGe44uvCD5snzgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAq5MnvAPBXlRdtDE1e2HHVvRyDPR7AC+CJMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFT4P93k/D7/mvQDAAAAAElFTkSuQmCC" id="imagee0274cb87d" transform="scale(1 -1) translate(0 -239.76)" x="48.761875" y="-23.890745" width="516.96" height="239.76"/>
    </g>
    <g id="line2d_21"/>
    <g id="line2d_22"/>
@@ -1121,7 +1121,7 @@ L 60.461429 21.843268
 L 54.694307 20.687041 
 L 51.734129 20.198908 
 L 51.734129 20.198908 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke-dasharray: 7.4,3.2; stroke-dashoffset: 0; stroke: #565f89; stroke-opacity: 0.9; stroke-width: 2"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke-dasharray: 7.4,3.2; stroke-dashoffset: 0; stroke: #565f89; stroke-opacity: 0.9; stroke-width: 2"/>
    </g>
    <g id="line2d_27">
     <path d="M 565.693075 143.984435 
@@ -1196,7 +1196,7 @@ L 73.936535 158.824866
 L 63.281677 152.666036 
 L 50.079327 144.777743 
 L 50.079327 144.777743 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke-dasharray: 0.9,1.485; stroke-dashoffset: 0; stroke: #c0caf5; stroke-opacity: 0.5; stroke-width: 0.9"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke-dasharray: 0.9,1.485; stroke-dashoffset: 0; stroke: #c0caf5; stroke-opacity: 0.5; stroke-width: 0.9"/>
    </g>
    <g id="text_23">
     <!-- Where is Planet 9? Dwell-time position probability across orbit solutions -->
@@ -1631,7 +1631,7 @@ L 59.531275 250.631838
 L 55.223515 249.909227 
 L 50.915755 249.398641 
 L 50.915755 249.398641 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 0.9"/>
     <path d="M 50.915755 154.196731 
 L 55.223515 155.549905 
 L 63.839035 160.282466 
@@ -1740,7 +1740,7 @@ L 554.923675 141.796709
 L 559.231435 145.082156 
 L 563.539195 147.288055 
 L 563.539195 147.288055 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 0.9"/>
    </g>
    <g id="PathCollection_2">
     <path d="M 563.539195 222.714652 
@@ -1826,7 +1826,7 @@ L 554.923675 162.912262
 L 559.231435 166.206966 
 L 563.539195 168.157047 
 L 563.539195 168.157047 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 50.915755 177.808694 
 L 55.223515 179.813444 
 L 59.531275 182.857932 
@@ -1850,7 +1850,7 @@ L 63.839035 222.26085
 L 59.531275 222.617585 
 L 55.223515 222.892123 
 L 50.915755 223.098217 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 1.6"/>
    </g>
    <g id="PathCollection_3">
     <path d="M 563.539195 245.681528 
@@ -1959,7 +1959,7 @@ L 55.223515 249.402432
 L 52.405851 248.692457 
 L 50.915755 248.44913 
 L 50.915755 248.44913 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 0.9"/>
     <path d="M 50.915755 153.832846 
 L 55.223515 154.982652 
 L 59.531275 156.960668 
@@ -2069,7 +2069,7 @@ L 554.923675 141.704086
 L 559.231435 144.618047 
 L 563.539195 146.606684 
 L 563.539195 146.606684 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 0.9"/>
    </g>
    <g id="PathCollection_4">
     <path d="M 563.539195 224.314488 
@@ -2179,7 +2179,7 @@ L 554.923675 160.999647
 L 559.231435 164.040514 
 L 563.539195 165.926713 
 L 563.539195 165.926713 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 50.915755 175.141404 
 L 55.223515 176.583079 
 L 55.81124 176.89267 
@@ -2213,7 +2213,7 @@ L 63.839035 226.750485
 L 59.531275 226.589266 
 L 55.223515 226.52877 
 L 50.915755 226.530946 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 1.6"/>
    </g>
    <g id="PathCollection_5">
     <path d="M 563.539195 218.026617 
@@ -2323,7 +2323,7 @@ L 72.454555 226.337958
 L 55.223515 222.131186 
 L 50.915755 221.329095 
 L 50.915755 221.329095 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 0.9"/>
     <path d="M 50.915755 147.692658 
 L 55.223515 148.7023 
 L 59.531275 150.452571 
@@ -2430,7 +2430,7 @@ L 559.231435 140.566899
 L 560.242304 140.992777 
 L 563.539195 141.962789 
 L 563.539195 141.962789 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 0.9"/>
    </g>
    <g id="PathCollection_6">
     <path d="M 563.539195 200.505249 
@@ -2516,7 +2516,7 @@ L 59.531275 204.654445
 L 55.223515 203.669833 
 L 50.915755 202.973512 
 L 50.915755 202.973512 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 50.915755 164.313798 
 L 55.223515 165.5314 
 L 59.531275 167.522079 
@@ -2608,7 +2608,7 @@ L 554.923675 154.867094
 L 559.231435 157.418593 
 L 563.539195 158.930987 
 L 563.539195 158.930987 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 1.6"/>
    </g>
    <g id="PathCollection_7">
     <path d="M 563.539195 174.954186 
@@ -2717,7 +2717,7 @@ L 58.719645 182.875986
 L 55.223515 181.736025 
 L 50.915755 180.667786 
 L 50.915755 180.667786 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 0.9"/>
     <path d="M 50.915755 140.218997 
 L 53.07907 140.992777 
 L 55.223515 141.359204 
@@ -2834,7 +2834,7 @@ L 553.970855 129.026146
 L 559.231435 131.608798 
 L 563.539195 133.585469 
 L 563.539195 133.585469 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 0.9"/>
    </g>
    <g id="PathCollection_8">
     <path d="M 563.539195 166.819028 
@@ -2961,7 +2961,7 @@ L 559.231435 140.191952
 L 561.092287 140.992777 
 L 563.539195 141.825846 
 L 563.539195 141.825846 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 50.915755 148.350771 
 L 55.223515 149.526465 
 L 59.531275 151.660751 
@@ -3022,14 +3022,14 @@ L 63.839035 176.622347
 L 59.531275 174.79249 
 L 55.223515 173.193179 
 L 50.915755 172.104921 
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 223.226155 176.91667 
 L 222.467581 176.89267 
 L 223.226155 176.845451 
 L 223.41229 176.89267 
 L 223.226155 176.91667 
 z
-" clip-path="url(#p9f985b6241)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
    </g>
    <g id="legend_1">
     <g id="patch_7">
@@ -3720,7 +3720,7 @@ z
    </g>
    <g id="line2d_35">
     <defs>
-     <path id="m7621945c43" d="M 0 -7 
+     <path id="mbfc0c0eb3e" d="M 0 -7 
 L -1.571598 -2.163119 
 L -6.657396 -2.163119 
 L -2.542899 0.826238 
@@ -3733,13 +3733,13 @@ L 1.571598 -2.163119
 z
 " style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p9f985b6241)">
-     <use xlink:href="#m7621945c43" x="468.768475" y="129.026146" style="fill: #7dcfff; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pbca7bb30fa)">
+     <use xlink:href="#mbfc0c0eb3e" x="468.768475" y="129.026146" style="fill: #7dcfff; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_36">
     <defs>
-     <path id="m6237565a34" d="M 0 -7 
+     <path id="m39b7a359d0" d="M 0 -7 
 L -1.571598 -2.163119 
 L -6.657396 -2.163119 
 L -2.542899 0.826238 
@@ -3752,13 +3752,13 @@ L 1.571598 -2.163119
 z
 " style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p9f985b6241)">
-     <use xlink:href="#m6237565a34" x="485.999515" y="146.976093" style="fill: #7aa2f7; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pbca7bb30fa)">
+     <use xlink:href="#m39b7a359d0" x="485.999515" y="146.976093" style="fill: #7aa2f7; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_37">
     <defs>
-     <path id="m990e34d97d" d="M 0 -7 
+     <path id="m1744b9958f" d="M 0 -7 
 L -1.571598 -2.163119 
 L -6.657396 -2.163119 
 L -2.542899 0.826238 
@@ -3771,13 +3771,13 @@ L 1.571598 -2.163119
 z
 " style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p9f985b6241)">
-     <use xlink:href="#m990e34d97d" x="429.998635" y="99.109569" style="fill: #9ece6a; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pbca7bb30fa)">
+     <use xlink:href="#m1744b9958f" x="429.998635" y="99.109569" style="fill: #9ece6a; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_38">
     <defs>
-     <path id="m8736b1a000" d="M 0 -7 
+     <path id="m76a192b159" d="M 0 -7 
 L -1.571598 -2.163119 
 L -6.657396 -2.163119 
 L -2.542899 0.826238 
@@ -3790,13 +3790,13 @@ L 1.571598 -2.163119
 z
 " style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p9f985b6241)">
-     <use xlink:href="#m8736b1a000" x="473.076235" y="117.059515" style="fill: #f7768e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pbca7bb30fa)">
+     <use xlink:href="#m76a192b159" x="473.076235" y="117.059515" style="fill: #f7768e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_39">
     <defs>
-     <path id="m0a1ab8f8b9" d="M 0 -7 
+     <path id="m01f4ea7b94" d="M 0 -7 
 L -1.571598 -2.163119 
 L -6.657396 -2.163119 
 L -2.542899 0.826238 
@@ -3809,8 +3809,8 @@ L 1.571598 -2.163119
 z
 " style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p9f985b6241)">
-     <use xlink:href="#m0a1ab8f8b9" x="494.615035" y="117.059515" style="fill: #e0af68; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pbca7bb30fa)">
+     <use xlink:href="#m01f4ea7b94" x="494.615035" y="117.059515" style="fill: #e0af68; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </g>
    </g>
   </g>
@@ -3825,21 +3825,21 @@ z
 " style="fill: none"/>
    </g>
    <g id="patch_9">
-    <path clip-path="url(#pef42561d1e)" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.01; stroke-linejoin: miter"/>
+    <path clip-path="url(#p8e4e78cf92)" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.01; stroke-linejoin: miter"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFNCAYAAADmVoTCAAAB9UlEQVR4nO2cwQ3EMAgEwef+G70ikn/iHxNphHABKzzsYie6S0bsfxTXqgpEROyMrItEEiLAjlRM6sUgTHYClTBgI351EWI7Oz1mG588l6fFUCUesAwTSYoZJquVT3YCM7Zfii1MRGbT+ARiQgwlohJiO9S01zDRBBBqMQB2XR6fWJg0CyAy2QifiJ53GCbEE3pqAuhhwoAVmU3DBHhFpmICVEK8Z4OYEC8wIZ+UNZhKqGdAQIRxLFAJxUQTQA0TUXYIEdNks4gAGiYmmhSrBjUgokkxNdkAkWZMiFHgGdQD9iMRislVF5kT8CBS15jJdhLRdEd1tQBSbHreIUQsQ2mvrHdnAvheVACJE5CoxDSoLbcCKMWWAGq2IzIbdFOSpJjyCXGgayrxmE2THdVQGiaPBQVQc7cXXUE1TIgjw3QrYFJsYaI50AfsQUQzHiEmy8NEImKa9kR3mjFBHDtMTpUQIgAVarIRIr2YBOMToBITE0AEMhsgQmxHFEBNd1RmQ/6HXq+kHRPGsZbf+EEBRMD2YoJ810LDRNNiKsUD9gsRiAmRnfHJZyLEV0eagWWmveW/b73M1o4J8tkfUQAl22lnNotPVGCHyWN5Di8TE0uLIRHNX8gvD5Mx21tE82k1TYs93YECyNwKJCL9zKZh0upW4AF7AzPBMzutgp3rAAAAAElFTkSuQmCC" id="image83da9d1e95" transform="scale(1 -1) translate(0 -239.76)" x="570.96" y="-23.76" width="12.24" height="239.76"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFNCAYAAADmVoTCAAAB9UlEQVR4nO2cwQ3EMAgEwef+G70ikn/iHxNphHABKzzsYie6S0bsfxTXqgpEROyMrItEEiLAjlRM6sUgTHYClTBgI351EWI7Oz1mG588l6fFUCUesAwTSYoZJquVT3YCM7Zfii1MRGbT+ARiQgwlohJiO9S01zDRBBBqMQB2XR6fWJg0CyAy2QifiJ53GCbEE3pqAuhhwoAVmU3DBHhFpmICVEK8Z4OYEC8wIZ+UNZhKqGdAQIRxLFAJxUQTQA0TUXYIEdNks4gAGiYmmhSrBjUgokkxNdkAkWZMiFHgGdQD9iMRislVF5kT8CBS15jJdhLRdEd1tQBSbHreIUQsQ2mvrHdnAvheVACJE5CoxDSoLbcCKMWWAGq2IzIbdFOSpJjyCXGgayrxmE2THdVQGiaPBQVQc7cXXUE1TIgjw3QrYFJsYaI50AfsQUQzHiEmy8NEImKa9kR3mjFBHDtMTpUQIgAVarIRIr2YBOMToBITE0AEMhsgQmxHFEBNd1RmQ/6HXq+kHRPGsZbf+EEBRMD2YoJ810LDRNNiKsUD9gsRiAmRnfHJZyLEV0eagWWmveW/b73M1o4J8tkfUQAl22lnNotPVGCHyWN5Di8TE0uLIRHNX8gvD5Mx21tE82k1TYs93YECyNwKJCL9zKZh0upW4AF7AzPBMzutgp3rAAAAAElFTkSuQmCC" id="imagef6fa31ad39" transform="scale(1 -1) translate(0 -239.76)" x="570.96" y="-23.76" width="12.24" height="239.76"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_8">
      <g id="line2d_40">
       <defs>
-       <path id="m3247124af8" d="M 0 0 
+       <path id="mc685351852" d="M 0 0 
 L 3.5 0 
 " style="stroke: #565f89; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m3247124af8" x="583.016506" y="223.761975" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mc685351852" x="583.016506" y="223.761975" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_31">
@@ -3854,7 +3854,7 @@ L 3.5 0
     <g id="ytick_9">
      <g id="line2d_41">
       <g>
-       <use xlink:href="#m3247124af8" x="583.016506" y="173.901013" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mc685351852" x="583.016506" y="173.901013" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_32">
@@ -3869,7 +3869,7 @@ L 3.5 0
     <g id="ytick_10">
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m3247124af8" x="583.016506" y="124.04005" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mc685351852" x="583.016506" y="124.04005" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_33">
@@ -3884,7 +3884,7 @@ L 3.5 0
     <g id="ytick_11">
      <g id="line2d_43">
       <g>
-       <use xlink:href="#m3247124af8" x="583.016506" y="74.179088" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mc685351852" x="583.016506" y="74.179088" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_34">
@@ -3899,7 +3899,7 @@ L 3.5 0
     <g id="ytick_12">
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m3247124af8" x="583.016506" y="24.318125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mc685351852" x="583.016506" y="24.318125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_35">
@@ -4015,7 +4015,7 @@ L 99.599517 434.574125
 L 99.599517 391.798721 
 L 73.110966 391.798721 
 z
-" clip-path="url(#p856b09e913)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#p976f6006f4)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
    <g id="patch_13">
     <path d="M 174.990007 434.574125 
@@ -4023,7 +4023,7 @@ L 201.478558 434.574125
 L 201.478558 387.866818 
 L 174.990007 387.866818 
 z
-" clip-path="url(#p856b09e913)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#p976f6006f4)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
    <g id="patch_14">
     <path d="M 276.869049 434.574125 
@@ -4031,7 +4031,7 @@ L 303.3576 434.574125
 L 303.3576 386.89458 
 L 276.869049 386.89458 
 z
-" clip-path="url(#p856b09e913)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#p976f6006f4)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
    <g id="patch_15">
     <path d="M 378.74809 434.574125 
@@ -4039,7 +4039,7 @@ L 405.236641 434.574125
 L 405.236641 388.01572 
 L 378.74809 388.01572 
 z
-" clip-path="url(#p856b09e913)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#p976f6006f4)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
    <g id="patch_16">
     <path d="M 480.627132 434.574125 
@@ -4047,7 +4047,7 @@ L 507.115683 434.574125
 L 507.115683 389.581304 
 L 480.627132 389.581304 
 z
-" clip-path="url(#p856b09e913)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#p976f6006f4)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
    <g id="patch_17">
     <path d="M 99.599517 434.574125 
@@ -4055,7 +4055,7 @@ L 126.088067 434.574125
 L 126.088067 432.58188 
 L 99.599517 432.58188 
 z
-" clip-path="url(#p856b09e913)" style="fill: #bb9af7; opacity: 0.9"/>
+" clip-path="url(#p976f6006f4)" style="fill: #bb9af7; opacity: 0.9"/>
    </g>
    <g id="patch_18">
     <path d="M 201.478558 434.574125 
@@ -4063,7 +4063,7 @@ L 227.967109 434.574125
 L 227.967109 432.5797 
 L 201.478558 432.5797 
 z
-" clip-path="url(#p856b09e913)" style="fill: #bb9af7; opacity: 0.9"/>
+" clip-path="url(#p976f6006f4)" style="fill: #bb9af7; opacity: 0.9"/>
    </g>
    <g id="patch_19">
     <path d="M 303.3576 434.574125 
@@ -4071,7 +4071,7 @@ L 329.84615 434.574125
 L 329.84615 432.579686 
 L 303.3576 432.579686 
 z
-" clip-path="url(#p856b09e913)" style="fill: #bb9af7; opacity: 0.9"/>
+" clip-path="url(#p976f6006f4)" style="fill: #bb9af7; opacity: 0.9"/>
    </g>
    <g id="patch_20">
     <path d="M 405.236641 434.574125 
@@ -4079,7 +4079,7 @@ L 431.725192 434.574125
 L 431.725192 432.579686 
 L 405.236641 432.579686 
 z
-" clip-path="url(#p856b09e913)" style="fill: #bb9af7; opacity: 0.9"/>
+" clip-path="url(#p976f6006f4)" style="fill: #bb9af7; opacity: 0.9"/>
    </g>
    <g id="patch_21">
     <path d="M 507.115683 434.574125 
@@ -4087,53 +4087,53 @@ L 533.604233 434.574125
 L 533.604233 432.579686 
 L 507.115683 432.579686 
 z
-" clip-path="url(#p856b09e913)" style="fill: #bb9af7; opacity: 0.9"/>
+" clip-path="url(#p976f6006f4)" style="fill: #bb9af7; opacity: 0.9"/>
    </g>
    <g id="patch_22">
     <path d="M 126.088067 434.574125 
 L 152.576618 434.574125 
-L 152.576618 350.833436 
-L 126.088067 350.833436 
+L 152.576618 379.409751 
+L 126.088067 379.409751 
 z
-" clip-path="url(#p856b09e913)" style="fill: #9ece6a; opacity: 0.9"/>
+" clip-path="url(#p976f6006f4)" style="fill: #c0caf5; opacity: 0.9"/>
    </g>
    <g id="patch_23">
     <path d="M 227.967109 434.574125 
 L 254.45566 434.574125 
-L 254.45566 350.463069 
-L 227.967109 350.463069 
+L 254.45566 374.307213 
+L 227.967109 374.307213 
 z
-" clip-path="url(#p856b09e913)" style="fill: #9ece6a; opacity: 0.9"/>
+" clip-path="url(#p976f6006f4)" style="fill: #c0caf5; opacity: 0.9"/>
    </g>
    <g id="patch_24">
     <path d="M 329.84615 434.574125 
 L 356.334701 434.574125 
-L 356.334701 350.183947 
-L 329.84615 350.183947 
+L 356.334701 373.067702 
+L 329.84615 373.067702 
 z
-" clip-path="url(#p856b09e913)" style="fill: #9ece6a; opacity: 0.9"/>
+" clip-path="url(#p976f6006f4)" style="fill: #c0caf5; opacity: 0.9"/>
    </g>
    <g id="patch_25">
     <path d="M 431.725192 434.574125 
 L 458.213743 434.574125 
-L 458.213743 350.43046 
-L 431.725192 350.43046 
+L 458.213743 373.434879 
+L 431.725192 373.434879 
 z
-" clip-path="url(#p856b09e913)" style="fill: #9ece6a; opacity: 0.9"/>
+" clip-path="url(#p976f6006f4)" style="fill: #c0caf5; opacity: 0.9"/>
    </g>
    <g id="patch_26">
     <path d="M 533.604233 434.574125 
 L 560.092784 434.574125 
-L 560.092784 350.627311 
-L 533.604233 350.627311 
+L 560.092784 373.801124 
+L 533.604233 373.801124 
 z
-" clip-path="url(#p856b09e913)" style="fill: #9ece6a; opacity: 0.9"/>
+" clip-path="url(#p976f6006f4)" style="fill: #c0caf5; opacity: 0.9"/>
    </g>
    <g id="matplotlib.axis_5">
     <g id="xtick_14">
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m063e5127ec" x="112.843792" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="112.843792" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_37">
@@ -4153,7 +4153,7 @@ z
     <g id="xtick_15">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m063e5127ec" x="214.722834" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="214.722834" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_38">
@@ -4173,7 +4173,7 @@ z
     <g id="xtick_16">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m063e5127ec" x="316.601875" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="316.601875" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_39">
@@ -4198,7 +4198,7 @@ z
     <g id="xtick_17">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m063e5127ec" x="418.480916" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="418.480916" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_40">
@@ -4230,7 +4230,7 @@ z
     <g id="xtick_18">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m063e5127ec" x="520.359958" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m9de694df24" x="520.359958" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_41">
@@ -4256,11 +4256,11 @@ z
      <g id="line2d_50">
       <path d="M 48.761875 434.574125 
 L 584.441875 434.574125 
-" clip-path="url(#p856b09e913)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p976f6006f4)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m0e240601d3" x="48.761875" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me86f7f4261" x="48.761875" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_42">
@@ -4274,11 +4274,11 @@ L 584.441875 434.574125
      <g id="line2d_52">
       <path d="M 48.761875 409.643644 
 L 584.441875 409.643644 
-" clip-path="url(#p856b09e913)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p976f6006f4)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m0e240601d3" x="48.761875" y="409.643644" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me86f7f4261" x="48.761875" y="409.643644" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_43">
@@ -4293,11 +4293,11 @@ L 584.441875 409.643644
      <g id="line2d_54">
       <path d="M 48.761875 384.713162 
 L 584.441875 384.713162 
-" clip-path="url(#p856b09e913)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p976f6006f4)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_55">
       <g>
-       <use xlink:href="#m0e240601d3" x="48.761875" y="384.713162" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me86f7f4261" x="48.761875" y="384.713162" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_44">
@@ -4312,11 +4312,11 @@ L 584.441875 384.713162
      <g id="line2d_56">
       <path d="M 48.761875 359.782681 
 L 584.441875 359.782681 
-" clip-path="url(#p856b09e913)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p976f6006f4)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_57">
       <g>
-       <use xlink:href="#m0e240601d3" x="48.761875" y="359.782681" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me86f7f4261" x="48.761875" y="359.782681" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_45">
@@ -4331,11 +4331,11 @@ L 584.441875 359.782681
      <g id="line2d_58">
       <path d="M 48.761875 334.8522 
 L 584.441875 334.8522 
-" clip-path="url(#p856b09e913)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p976f6006f4)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_59">
       <g>
-       <use xlink:href="#m0e240601d3" x="48.761875" y="334.8522" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me86f7f4261" x="48.761875" y="334.8522" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_46">
@@ -4599,30 +4599,30 @@ z
    </g>
    <g id="legend_2">
     <g id="patch_31">
-     <path d="M 411.085 372.31695 
+     <path d="M 440.837875 372.31695 
 L 579.401875 372.31695 
 Q 580.841875 372.31695 580.841875 370.87695 
 L 580.841875 339.8922 
 Q 580.841875 338.4522 579.401875 338.4522 
-L 411.085 338.4522 
-Q 409.645 338.4522 409.645 339.8922 
-L 409.645 370.87695 
-Q 409.645 372.31695 411.085 372.31695 
-L 411.085 372.31695 
+L 440.837875 338.4522 
+Q 439.397875 338.4522 439.397875 339.8922 
+L 439.397875 370.87695 
+Q 439.397875 372.31695 440.837875 372.31695 
+L 440.837875 372.31695 
 z
 " style="fill: none; opacity: 0"/>
     </g>
     <g id="patch_32">
-     <path d="M 412.525 346.803075 
-L 426.925 346.803075 
-L 426.925 341.763075 
-L 412.525 341.763075 
+     <path d="M 442.277875 346.803075 
+L 456.677875 346.803075 
+L 456.677875 341.763075 
+L 442.277875 341.763075 
 z
 " style="fill: #7dcfff; opacity: 0.9"/>
     </g>
     <g id="text_49">
      <!-- Rubin / LSST (m&lt;24.5) -->
-     <g style="fill: #c0caf5" transform="translate(432.685 346.803075) scale(0.072 -0.072)">
+     <g style="fill: #c0caf5" transform="translate(462.437875 346.803075) scale(0.072 -0.072)">
       <defs>
        <path id="DejaVuSans-2f" d="M 1625 4666 
 L 2156 4666 
@@ -4675,16 +4675,16 @@ z
      </g>
     </g>
     <g id="patch_33">
-     <path d="M 412.525 357.371325 
-L 426.925 357.371325 
-L 426.925 352.331325 
-L 412.525 352.331325 
+     <path d="M 442.277875 357.371325 
+L 456.677875 357.371325 
+L 456.677875 352.331325 
+L 442.277875 352.331325 
 z
 " style="fill: #bb9af7; opacity: 0.9"/>
     </g>
     <g id="text_50">
      <!-- Roman (m&lt;26.0) -->
-     <g style="fill: #c0caf5" transform="translate(432.685 357.371325) scale(0.072 -0.072)">
+     <g style="fill: #c0caf5" transform="translate(462.437875 357.371325) scale(0.072 -0.072)">
       <use xlink:href="#DejaVuSans-52"/>
       <use xlink:href="#DejaVuSans-6f" x="64.982422"/>
       <use xlink:href="#DejaVuSans-6d" x="126.164062"/>
@@ -4702,83 +4702,72 @@ z
      </g>
     </g>
     <g id="patch_34">
-     <path d="M 412.525 367.939575 
-L 426.925 367.939575 
-L 426.925 362.899575 
-L 412.525 362.899575 
+     <path d="M 442.277875 367.939575 
+L 456.677875 367.939575 
+L 456.677875 362.899575 
+L 442.277875 362.899575 
 z
-" style="fill: #9ece6a; opacity: 0.9"/>
+" style="fill: #c0caf5; opacity: 0.9"/>
     </g>
     <g id="text_51">
-     <!-- Proposed all-sky space survey (m&lt;26.0) -->
-     <g style="fill: #c0caf5" transform="translate(432.685 367.939575) scale(0.072 -0.072)">
+     <!-- JBT 0.5 m + SPENCER (m&lt;24.5) -->
+     <g style="fill: #c0caf5" transform="translate(462.437875 367.939575) scale(0.072 -0.072)">
       <defs>
-       <path id="DejaVuSans-6b" d="M 581 4863 
-L 1159 4863 
-L 1159 1991 
-L 2875 3500 
-L 3609 3500 
-L 1753 1863 
-L 3688 0 
-L 2938 0 
-L 1159 1709 
-L 1159 0 
-L 581 0 
-L 581 4863 
+       <path id="DejaVuSans-4a" d="M 628 4666 
+L 1259 4666 
+L 1259 325 
+Q 1259 -519 939 -900 
+Q 619 -1281 -91 -1281 
+L -331 -1281 
+L -331 -750 
+L -134 -750 
+Q 284 -750 456 -515 
+Q 628 -281 628 325 
+L 628 4666 
 z
 " transform="scale(0.015625)"/>
       </defs>
-      <use xlink:href="#DejaVuSans-50"/>
-      <use xlink:href="#DejaVuSans-72" x="58.552734"/>
-      <use xlink:href="#DejaVuSans-6f" x="97.416016"/>
-      <use xlink:href="#DejaVuSans-70" x="158.597656"/>
-      <use xlink:href="#DejaVuSans-6f" x="222.074219"/>
-      <use xlink:href="#DejaVuSans-73" x="283.255859"/>
-      <use xlink:href="#DejaVuSans-65" x="335.355469"/>
-      <use xlink:href="#DejaVuSans-64" x="396.878906"/>
-      <use xlink:href="#DejaVuSans-20" x="460.355469"/>
-      <use xlink:href="#DejaVuSans-61" x="492.142578"/>
-      <use xlink:href="#DejaVuSans-6c" x="553.421875"/>
-      <use xlink:href="#DejaVuSans-6c" x="581.205078"/>
-      <use xlink:href="#DejaVuSans-2d" x="608.988281"/>
-      <use xlink:href="#DejaVuSans-73" x="645.072266"/>
-      <use xlink:href="#DejaVuSans-6b" x="697.171875"/>
-      <use xlink:href="#DejaVuSans-79" x="751.457031"/>
-      <use xlink:href="#DejaVuSans-20" x="810.636719"/>
-      <use xlink:href="#DejaVuSans-73" x="842.423828"/>
-      <use xlink:href="#DejaVuSans-70" x="894.523438"/>
-      <use xlink:href="#DejaVuSans-61" x="958"/>
-      <use xlink:href="#DejaVuSans-63" x="1019.279297"/>
-      <use xlink:href="#DejaVuSans-65" x="1074.259766"/>
-      <use xlink:href="#DejaVuSans-20" x="1135.783203"/>
-      <use xlink:href="#DejaVuSans-73" x="1167.570312"/>
-      <use xlink:href="#DejaVuSans-75" x="1219.669922"/>
-      <use xlink:href="#DejaVuSans-72" x="1283.048828"/>
-      <use xlink:href="#DejaVuSans-76" x="1324.162109"/>
-      <use xlink:href="#DejaVuSans-65" x="1383.341797"/>
-      <use xlink:href="#DejaVuSans-79" x="1444.865234"/>
-      <use xlink:href="#DejaVuSans-20" x="1504.044922"/>
-      <use xlink:href="#DejaVuSans-28" x="1535.832031"/>
-      <use xlink:href="#DejaVuSans-6d" x="1574.845703"/>
-      <use xlink:href="#DejaVuSans-3c" x="1672.257812"/>
-      <use xlink:href="#DejaVuSans-32" x="1756.046875"/>
-      <use xlink:href="#DejaVuSans-36" x="1819.669922"/>
-      <use xlink:href="#DejaVuSans-2e" x="1883.292969"/>
-      <use xlink:href="#DejaVuSans-30" x="1915.080078"/>
-      <use xlink:href="#DejaVuSans-29" x="1978.703125"/>
+      <use xlink:href="#DejaVuSans-4a"/>
+      <use xlink:href="#DejaVuSans-42" x="29.492188"/>
+      <use xlink:href="#DejaVuSans-54" x="98.095703"/>
+      <use xlink:href="#DejaVuSans-20" x="159.179688"/>
+      <use xlink:href="#DejaVuSans-30" x="190.966797"/>
+      <use xlink:href="#DejaVuSans-2e" x="254.589844"/>
+      <use xlink:href="#DejaVuSans-35" x="286.376953"/>
+      <use xlink:href="#DejaVuSans-20" x="350"/>
+      <use xlink:href="#DejaVuSans-6d" x="381.787109"/>
+      <use xlink:href="#DejaVuSans-20" x="479.199219"/>
+      <use xlink:href="#DejaVuSans-2b" x="510.986328"/>
+      <use xlink:href="#DejaVuSans-20" x="594.775391"/>
+      <use xlink:href="#DejaVuSans-53" x="626.5625"/>
+      <use xlink:href="#DejaVuSans-50" x="690.039062"/>
+      <use xlink:href="#DejaVuSans-45" x="750.341797"/>
+      <use xlink:href="#DejaVuSans-4e" x="813.525391"/>
+      <use xlink:href="#DejaVuSans-43" x="888.330078"/>
+      <use xlink:href="#DejaVuSans-45" x="958.154297"/>
+      <use xlink:href="#DejaVuSans-52" x="1021.337891"/>
+      <use xlink:href="#DejaVuSans-20" x="1090.820312"/>
+      <use xlink:href="#DejaVuSans-28" x="1122.607422"/>
+      <use xlink:href="#DejaVuSans-6d" x="1161.621094"/>
+      <use xlink:href="#DejaVuSans-3c" x="1259.033203"/>
+      <use xlink:href="#DejaVuSans-32" x="1342.822266"/>
+      <use xlink:href="#DejaVuSans-34" x="1406.445312"/>
+      <use xlink:href="#DejaVuSans-2e" x="1470.068359"/>
+      <use xlink:href="#DejaVuSans-35" x="1501.855469"/>
+      <use xlink:href="#DejaVuSans-29" x="1565.478516"/>
      </g>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p9f985b6241">
+  <clipPath id="pbca7bb30fa">
    <rect x="48.761875" y="24.318125" width="516.9312" height="239.33262"/>
   </clipPath>
-  <clipPath id="pef42561d1e">
+  <clipPath id="p8e4e78cf92">
    <rect x="571.049875" y="24.318125" width="11.966631" height="239.33262"/>
   </clipPath>
-  <clipPath id="p856b09e913">
+  <clipPath id="p976f6006f4">
    <rect x="48.761875" y="334.8522" width="535.68" height="99.721925"/>
   </clipPath>
  </defs>

--- a/crates/p9-survey/src/skymap.rs
+++ b/crates/p9-survey/src/skymap.rs
@@ -299,7 +299,7 @@ mod tests {
         let space = det
             .iter()
             .zip(&tel)
-            .find(|(_, t)| t.name.contains("Proposed"))
+            .find(|(_, t)| t.name.contains("JBT"))
             .unwrap()
             .0;
         // All detection probabilities are valid.

--- a/crates/p9-survey/src/telescope.rs
+++ b/crates/p9-survey/src/telescope.rs
@@ -8,8 +8,26 @@
 //! caveat). Thermal-IR detectability of a *cold* Planet Nine is separately
 //! shown to be negligible in `p9-2018-wise-search`, so this survey stays in
 //! the reflected-light regime.
+//!
+//! JBT 0.5 m + SPENCER parameters are derived from the `focalplane` simulator
+//! (CosmicFrontierLabs): the default "Cosmic Frontier JBT .5m" telescope
+//! (0.485 m aperture, f/12.3 → 5.97 m focal length) with the SPENCER imager
+//! (4× Sony IMX455, 9568×6380 px at 3.76 µm, read noise 1.58 e⁻, dark
+//! 0.0046 e⁻/s/px). That gives a 0.130″/px plate scale, ~0.080 deg² per chip
+//! → ~0.32 deg² instantaneous field. A photon-budget SNR=5 calculation against
+//! the space/zodiacal sky (V≈22.5/arcsec²) yields V≈23.8 in a single 300 s
+//! visit, ~25 for an ~1 h per-field stack, and ~26 for a deep multi-epoch
+//! shift-stack. So the limiter is not depth (P9 is V≈19–23) but the small
+//! field: tiling the multi-thousand-deg² P9 prior is the constraint.
 
 use crate::schema::{Footprint, Telescope};
+
+/// JBT 0.5 m + SPENCER derived optics (see module docs / `focalplane`).
+pub const JBT_APERTURE_M: f64 = 0.485;
+pub const JBT_F_NUMBER: f64 = 12.3;
+pub const JBT_PLATE_SCALE_ARCSEC_PER_PX: f64 = 0.130;
+/// Instantaneous field of the 4-chip SPENCER array (deg²).
+pub const SPENCER_FIELD_DEG2: f64 = 0.32;
 
 /// The surveyed instruments: one ground baseline, two space assets.
 pub fn catalog() -> Vec<Telescope> {
@@ -45,19 +63,28 @@ pub fn catalog() -> Vec<Telescope> {
                 .to_string(),
         },
         Telescope {
-            name: "Proposed all-sky space survey".to_string(),
-            band: "optical/NIR (proxy)".to_string(),
-            limiting_mag: 26.0,
+            name: "JBT 0.5 m + SPENCER (space)".to_string(),
+            band: "broadband visible (V proxy)".to_string(),
+            // Operational per-field depth (a few stacked 300 s visits). Single
+            // 300 s visit ≈ 23.8; deep multi-epoch shift-stack ≈ 26.
+            limiting_mag: 24.5,
             footprint: Footprint {
                 dec_min_deg: -90.0,
                 dec_max_deg: 90.0,
-                galactic_lat_min_deg: 5.0,
-                coverage_fraction: 0.90,
+                galactic_lat_min_deg: 10.0,
+                // The 0.32 deg² field must tile the multi-thousand-deg² P9
+                // prior. Feasible (~months at ~0.3 deg²/visit) for a dedicated
+                // campaign over the high-probability region; this fraction is
+                // the dominant assumption — the limiter is sky coverage, not
+                // depth. Galactic-plane crowding excluded (|b| > 10°).
+                coverage_fraction: 0.70,
             },
             space_based: true,
-            note: "PLACEHOLDER specs for the upcoming mission — deep, near-all-\
-                   sky from space (only the galactic plane still hurts). Tune \
-                   limiting_mag / coverage / footprint to the real design."
+            note: "Cosmic Frontier JBT 0.5 m (0.485 m, f/12.3) + SPENCER imager \
+                   (4× Sony IMX455, 0.130″/px, ~0.32 deg² field), from the \
+                   focalplane simulator. Depth is ample (V≈24–26 stacked vs P9 \
+                   V≈19–23); detection is gated by how much of the prior region \
+                   the small field can tile (coverage_fraction)."
                 .to_string(),
         },
     ]
@@ -76,13 +103,16 @@ mod tests {
     }
 
     #[test]
-    fn space_survey_is_all_sky() {
+    fn jbt_is_space_all_sky() {
         let t = catalog()
             .into_iter()
-            .find(|t| t.name.contains("Proposed"))
+            .find(|t| t.name.contains("JBT"))
             .unwrap();
         assert!(t.space_based);
         assert!(t.footprint.accepts(80.0, 30.0)); // northern, allowed from space
-        assert!(t.footprint.coverage_fraction > 0.5);
+        assert!(!t.footprint.accepts(80.0, 5.0)); // galactic plane excluded
+                                                  // Deep enough that every surveyed P9 solution (V ≈ 19–23) is bright
+                                                  // enough; coverage of the small field is the limiter.
+        assert!(t.limiting_mag > 23.0);
     }
 }


### PR DESCRIPTION
Replaces the placeholder "proposed all-sky space survey" in `p9-survey` with the real **Cosmic Frontier JBT 0.5 m + SPENCER** instrument, with parameters derived from the `focalplane` simulator (CosmicFrontierLabs):

- **Optics**: 0.485 m aperture, f/12.3 → 5.97 m focal length.
- **SPENCER imager**: 4× Sony IMX455 (9568×6380 px, 3.76 µm, read noise 1.58 e⁻, dark 0.0046 e⁻/s/px).
- **Derived**: 0.130″/px plate scale, ~0.080 deg²/chip → **~0.32 deg² instantaneous field**.
- **Depth** (photon-budget SNR=5 vs space/zodiacal sky): V≈23.8 single 300 s visit, ~25 per-field ~1 h stack, ~26 deep shift-stack. `limiting_mag = 24.5` (operational).

**Result**: depth is *ample* — every surveyed P9 solution is V≈19–23, well brighter than 24.5 — so detection is gated entirely by **sky coverage** of the small field, not brightness. Best detection probability across solutions ≈ **62%** (vs Rubin 48%, Roman 2%); it beats Rubin because it has all-sky access from space, but the 0.32 deg² field caps it via `coverage_fraction = 0.70` (a dedicated campaign tiling the prior region; the dominant, documented assumption). Galactic plane excluded (|b|>10°).

Derived optics exposed as `pub const`s; module docs carry the full derivation. 11 tests pass; `cargo build/test/fmt` green. Figure regenerated.