### PR TITLE
Add LEO vs annual parallax channel to p9-survey

### DIFF
--- a/crates/p9-survey/src/bin/survey.rs
+++ b/crates/p9-survey/src/bin/survey.rs
@@ -71,6 +71,29 @@ fn main() -> ExitCode {
         );
     }
 
+    // Parallax channel: LEO (per-orbit) vs Earth's annual baseline, per study.
+    use p9_survey::parallax::{annual_parallax_arcsec, leo_parallax_arcsec, LEO_ALTITUDE_KM};
+    use p9_survey::telescope::JBT_PLATE_SCALE_ARCSEC_PER_PX as PXSCALE;
+    eprintln!(
+        "\n  parallax of P9 at its median distance — LEO ({:.0} km, per-orbit) vs annual (Earth 2 AU):",
+        LEO_ALTITUDE_KM
+    );
+    for s in &dataset.studies {
+        let d = s.dist_median_au;
+        let leo = leo_parallax_arcsec(LEO_ALTITUDE_KM, d);
+        let ann = annual_parallax_arcsec(d);
+        eprintln!(
+            "  {:44}  d={:4.0}AU  LEO {:.3}″ ({:.2} px)  | annual {:5.0}″ ({:.1}′)  | annual/LEO {:.0}×",
+            s.solution.name,
+            d,
+            leo,
+            leo / PXSCALE,
+            ann,
+            ann / 60.0,
+            ann / leo,
+        );
+    }
+
     let json = match serde_json::to_string_pretty(&dataset) {
         Ok(j) => j,
         Err(e) => return fail(&format!("serialize: {e}")),

--- a/crates/p9-survey/src/lib.rs
+++ b/crates/p9-survey/src/lib.rs
@@ -15,6 +15,7 @@
 //! rendering of numerical outputs of the reproduced papers — nothing is drawn
 //! that the Rust side did not compute.
 
+pub mod parallax;
 pub mod schema;
 pub mod skymap;
 pub mod studies;

--- a/crates/p9-survey/src/parallax.rs
+++ b/crates/p9-survey/src/parallax.rs
@@ -1,0 +1,94 @@
+//! Observer-baseline parallax of a distant body.
+//!
+//! Parallax is just baseline / distance. For a body at hundreds of AU the only
+//! baseline that matters is Earth's *heliocentric* orbit (2 AU peak-to-peak),
+//! which gives Planet Nine a huge annual parallax (~arcminutes). A low-Earth
+//! orbit adds a second, far shorter baseline — the orbit *diameter*,
+//! ~14,000 km ≈ 9.4e-5 AU — so its per-orbit parallax is ~2e4× smaller than the
+//! annual one and lands well below an arcsecond (sub-pixel for the JBT/SPENCER
+//! 0.130″/px scale). Being in LEO helps by getting above the atmosphere
+//! (depth, continuous all-sky access), not by parallax.
+//!
+//! This module quantifies that so the comparison is explicit, not assumed.
+
+/// Astronomical unit in kilometers (IAU 2012).
+pub const AU_KM: f64 = 1.495_978_707e8;
+/// Mean Earth radius used elsewhere in the workspace.
+pub const EARTH_RADIUS_KM: f64 = p9_core::constants::EARTH_RADIUS_KM;
+/// Arcseconds per radian (= PC_AU, the parsec definition).
+pub const ARCSEC_PER_RAD: f64 = p9_core::constants::PC_AU;
+/// The LEO altitude requested for this comparison (km).
+pub const LEO_ALTITUDE_KM: f64 = 650.0;
+
+/// Full peak-to-peak parallax (arcsec) of a body at `distance_au` seen across a
+/// baseline of `baseline_km`.
+pub fn parallax_arcsec(baseline_km: f64, distance_au: f64) -> f64 {
+    (baseline_km / AU_KM) / distance_au * ARCSEC_PER_RAD
+}
+
+/// LEO orbit diameter (km) at the given altitude — the maximum instantaneous
+/// parallax baseline a single satellite sweeps each orbit.
+pub fn leo_baseline_km(altitude_km: f64) -> f64 {
+    2.0 * (EARTH_RADIUS_KM + altitude_km)
+}
+
+/// Per-orbit (peak-to-peak) parallax of a body at `distance_au`, observed from
+/// a circular LEO at `altitude_km`.
+pub fn leo_parallax_arcsec(altitude_km: f64, distance_au: f64) -> f64 {
+    parallax_arcsec(leo_baseline_km(altitude_km), distance_au)
+}
+
+/// Annual (peak-to-peak) parallax from Earth's 2-AU heliocentric baseline.
+pub fn annual_parallax_arcsec(distance_au: f64) -> f64 {
+    parallax_arcsec(2.0 * AU_KM, distance_au)
+}
+
+/// Distance (AU) at which the LEO per-orbit parallax equals `arcsec` — e.g.
+/// pass one detector pixel to find where the wobble becomes a 1-pixel effect.
+pub fn leo_parallax_crossover_au(altitude_km: f64, arcsec: f64) -> f64 {
+    (leo_baseline_km(altitude_km) / AU_KM) * ARCSEC_PER_RAD / arcsec
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn leo_baseline_is_orbit_diameter() {
+        // 650 km altitude -> radius 7028.1 km -> diameter 14056.2 km.
+        assert_relative_eq!(leo_baseline_km(650.0), 14_056.2, epsilon = 0.1);
+    }
+
+    #[test]
+    fn leo_parallax_is_tens_of_milliarcsec() {
+        // At a representative 460 AU the per-orbit swing is ~0.042".
+        let p = leo_parallax_arcsec(650.0, 460.0);
+        assert_relative_eq!(p, 0.0421, epsilon = 0.002);
+        // Sub-pixel for the JBT/SPENCER 0.130"/px scale.
+        assert!(p < 0.130);
+    }
+
+    #[test]
+    fn annual_parallax_dwarfs_leo() {
+        // Annual parallax at 460 AU is ~897" (15'); ratio ~ 2 AU / 14,056 km.
+        let ann = annual_parallax_arcsec(460.0);
+        let leo = leo_parallax_arcsec(650.0, 460.0);
+        assert_relative_eq!(ann, 897.0, epsilon = 5.0);
+        let ratio = ann / leo;
+        assert!(
+            ratio > 2.0e4,
+            "annual/LEO ratio = {ratio:.0}, expected ~2e4"
+        );
+    }
+
+    #[test]
+    fn crossover_is_far_inside_planet_nine() {
+        // LEO wobble reaches one JBT pixel (0.130") only inside ~149 AU —
+        // i.e. never for P9 at 300-800 AU, but yes for nearer scattered-disk
+        // objects.
+        let d = leo_parallax_crossover_au(650.0, 0.130);
+        assert_relative_eq!(d, 149.0, epsilon = 3.0);
+        assert!(d < 300.0);
+    }
+}


### PR DESCRIPTION
Adds `parallax.rs` quantifying the parallax of Planet 9 from a low-Earth orbit (default 650 km) vs Earth's annual heliocentric baseline, and prints a per-study comparison in the `survey` binary.

**Finding (the counterintuitive part):** a LEO baseline does **not** make P9 easier to spot via parallax. Parallax = baseline/distance; a 650 km orbit's baseline is its *diameter* (~14,056 km ≈ 9.4e-5 AU), so the per-orbit parallax of P9 is only **~0.02–0.06″** (sub-pixel at JBT/SPENCER's 0.130″/px) — about **21,000× smaller** than the annual parallax from Earth's 2-AU orbit (~8–22 arcmin), which is the baseline that actually localizes P9 over months.

The LEO/space advantage is real but elsewhere: above the atmosphere → fainter limiting magnitude and continuous all-sky access (already credited in the JBT preset), not parallax. The module also computes the crossover distance where the LEO wobble reaches one pixel (~149 AU) — so diurnal/topocentric parallax is useful for nearer scattered-disk objects, just not for P9 at 300–800 AU.

Pure functions + 4 unit tests (baseline, magnitude, annual/LEO ratio, crossover); no schema change. `cargo build/test/fmt` green.