### PR TITLE
Fold ephemeris nu-prior and real survey footprints into p9-survey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,6 +1703,7 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "nalgebra",
+ "p9-2016-cassini-ranging",
  "p9-2024-siraj-orbit",
  "p9-core",
  "rand 0.8.5",

--- a/crates/p9-survey/Cargo.toml
+++ b/crates/p9-survey/Cargo.toml
@@ -8,6 +8,7 @@ description = "Cross-paper survey of Planet Nine sky-position predictions, brigh
 p9-core = { path = "../p9-core" }
 nalgebra = { workspace = true }
 p9-2024-siraj-orbit = { path = "../p9-2024-siraj-orbit" }
+p9-2016-cassini-ranging = { path = "../p9-2016-cassini-ranging" }
 rand = { workspace = true }
 rand_distr = { workspace = true }
 serde = { workspace = true }

--- a/crates/p9-survey/README.md
+++ b/crates/p9-survey/README.md
@@ -49,3 +49,18 @@ in.
 The brightness here is reflected-light optical/NIR; thermal-IR detectability of
 a *cold* Planet Nine is treated (and shown negligible at WISE W1) in
 `p9-2018-wise-search`.
+
+## Planning binaries
+
+- `cargo run -p p9-survey --bin plan` — convert a time budget into coverable
+  area + stacked depth and report the captured probability (≈ detection chance)
+  per orbit solution; shows wide-shallow beats deep-narrow for this instrument.
+- `cargo run -p p9-survey --bin refine` — narrow JBT's target by (1) ceding
+  Rubin's southern sky (Dec ≤ +12°), (2) surviving the prior optical surveys
+  (`refine.rs`: real ZTF/PS1/DES footprints incl. the galactic plane, with a
+  crowding/extinction depth degradation rather than a hard hole), and (3) the
+  Cassini/Iorio ephemeris favored-ν phase prior (`ephemeris.rs`, sourced from
+  `p9-2016-cassini-ranging`). The favored-ν arc and the Rubin line are emitted
+  in the dataset `constraints` block and drawn on the figure. Note the model
+  surfaces a real tension: the Cassini favored-ν zone lands *south* of +12°, in
+  Rubin's sky — so it argues against, not for, JBT's northern niche.

--- a/crates/p9-survey/p9_survey_sky.svg
+++ b/crates/p9-survey/p9_survey_sky.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-14T10:49:12.708539</dc:date>
+    <dc:date>2026-06-15T10:37:26.521837</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -39,16 +39,24 @@ L 48.761875 263.650745
 z
 " style="fill: none"/>
    </g>
+   <g id="patch_3">
+    <path d="M 48.761875 263.650745 
+L 48.761875 120.051173 
+L 565.693075 120.051173 
+L 565.693075 263.650745 
+z
+" clip-path="url(#p05be3ac94f)" style="fill: #565f89; opacity: 0.1; stroke: #565f89; stroke-linejoin: miter"/>
+   </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m9de694df24" d="M 0 0 
+       <path id="m0bdc7879fd" d="M 0 0 
 L 0 3.5 
 " style="stroke: #565f89; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m9de694df24" x="565.693075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="565.693075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -104,7 +112,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m9de694df24" x="522.615475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="522.615475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -144,7 +152,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m9de694df24" x="479.537875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="479.537875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -179,7 +187,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m9de694df24" x="436.460275" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="436.460275" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -225,7 +233,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m9de694df24" x="393.382675" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="393.382675" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -280,7 +288,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m9de694df24" x="350.305075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="350.305075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -311,7 +319,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m9de694df24" x="307.227475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="307.227475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -326,7 +334,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m9de694df24" x="264.149875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="264.149875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -341,7 +349,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m9de694df24" x="221.072275" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="221.072275" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -356,7 +364,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m9de694df24" x="177.994675" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="177.994675" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -371,7 +379,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m9de694df24" x="134.917075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="134.917075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -386,7 +394,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m9de694df24" x="91.839475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="91.839475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -401,7 +409,7 @@ z
     <g id="xtick_13">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m9de694df24" x="48.761875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="48.761875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -670,12 +678,12 @@ z
     <g id="ytick_1">
      <g id="line2d_14">
       <defs>
-       <path id="me86f7f4261" d="M 0 0 
+       <path id="m397f7840c7" d="M 0 0 
 L -3.5 0 
 " style="stroke: #565f89; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me86f7f4261" x="48.761875" y="233.734168" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m397f7840c7" x="48.761875" y="233.734168" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -748,7 +756,7 @@ z
     <g id="ytick_2">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#me86f7f4261" x="48.761875" y="203.81759" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m397f7840c7" x="48.761875" y="203.81759" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -798,7 +806,7 @@ z
     <g id="ytick_3">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#me86f7f4261" x="48.761875" y="173.901013" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m397f7840c7" x="48.761875" y="173.901013" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -814,7 +822,7 @@ z
     <g id="ytick_4">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#me86f7f4261" x="48.761875" y="143.984435" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m397f7840c7" x="48.761875" y="143.984435" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -846,7 +854,7 @@ z
     <g id="ytick_5">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#me86f7f4261" x="48.761875" y="114.067858" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m397f7840c7" x="48.761875" y="114.067858" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -862,7 +870,7 @@ z
     <g id="ytick_6">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#me86f7f4261" x="48.761875" y="84.15128" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m397f7840c7" x="48.761875" y="84.15128" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -878,7 +886,7 @@ z
     <g id="ytick_7">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#me86f7f4261" x="48.761875" y="54.234703" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m397f7840c7" x="48.761875" y="54.234703" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
@@ -969,31 +977,31 @@ z
      </g>
     </g>
    </g>
-   <g clip-path="url(#pbca7bb30fa)">
+   <g clip-path="url(#p05be3ac94f)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAs4AAAFNCAYAAAAQIOnHAAAZg0lEQVR4nO3dWXcc57kd4KqunoDGRIKTJlOjLctnSNbKXe6yVv5FfmuuspKTUbZlWTq2HEm2TFEUBxAgph6qcpuzuL/kwzm0RUnPc7lRrC4WgO6Nunjftmm6Bw0AAPD/NPquLwAAAL4PFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFcbf9QX89bWFtLviaUp/c1z1b5H+iscXDFc7z9AMha+UzlM6HgDgx8ETZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAV/goLUAoLR9pJIc+XNGqnOR/lvCvms8L5C687KlznC/qbY7jiApRh2BTyfJ7S+UvH9/065pv+Mh8/5OOHQt4Py3x8X8ibfB4AgL82T5wBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgArjtjTKuTDXuBvN84m67ZhPxoucd4V8tBXzWbubj28Lxzf5eqZDPn4y5HnN4xc06rovzFMu5SVDm49fN3m+86ZZ5bzN85FXTZ7XvGou8usO+fhi3p/FfLk5za9bzPN5+v756zQjGgB4ETxxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqjA92PohfKM1Tno/2Y77THsZ8tz/IxzeF8xfmR8+7LuazUe7+41Eb80nhT4Wuzcd3heOHIeebQt4X/kFfOL4QF4/fFM5fup5VX5gHXXiB1ZCPXw15fvSqMFf6fJTnO190eS7zs/YoHz8cx3zZP3s+2zyfNU3TLNcnMV+t8/GbwgzqYchzogGAl0XueW07K+S5j3riDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKDC+N90/z5+YT7Kg593xznfm+YOvjPJA6e382macT68uLiksOekMOb66otFygtHcr4uLhzJV3TVBSibvIekKcTF69z0+YYWz1P4Quk6V6VFKv0i5svNtZhf9Hdifjas8vHt88tITid5ccnp9Cjnw8P8muvHMb9c5fMUF6kUFrIMzTrmAMA/1bbTmI+7vZhvTfOivq3J9ZjP2t2Ye+IMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFQY/7s7ea7uvMtzeBeFfKvLg36no9Jk4Kw073g1FPIrHn+xya+7LBxfmst8WThPMS/MNS7PWc55aW7yujQQ+opKc7FHbWkydtYVDu8KX5gX8p0h/223GSaFfOu5bN3nmY5nm5sxPx3uxvx4nOcvP508ivlJ/yDmF5ujmJfmQS/XxzHvN3k+tXnQALy88ud91+W5ybNx3vOwM8t7Hq53+TP8Tv9qzA/Hz/eGpmmaxbiLuSfOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAECF8b89zLNpu9HV5gJvCvOUzzZ5Dt7Jehzziz53+ZN1Pv/JKufPCqNsT1f5/3W2zoOTLwuDli8Kg5bP+vzCy6GQN3nw86aQ901+3VI+KvxtVMonTf6+jAvHt4V5jKXjx23hdUeFvHD8tDD3eRIGUZdmRG+P87kPhnwPDtd51uPZJs+YPG1+EvNn49OYH0+e5OOHPA/6dPVtzC+W+TzL9VHMh+Ei5gDw/9O205hPxgcx35oexnx/8kbMbw9vxfy1Ln/2vr7Iex5e285d4OYs96dFYT+JJ84AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKoz355fxC+tN7tSnqzxY+uEyD8D+5iIvk3hwmc//7UVeOPJ0mQdRHy3zYpGnfV7q8KzNyyfO2uOYXzR5QcxqOM95fxbz9ZDv86bP+TDk/+9VtYUFIqM2fx+7Nn+/SseX8nE7i/m03c75kJeLbPd7OV/n8+yE152P8hKeWWHpyjgsUWmappmPS3m+BwdDztd9vvaLTR4KfzLkofCPJ09j/mR6L59nfT/m58uHMb9cHcW87/PvUNNcbWkSAC+f0Wgn5vNJ/ozanb8a81vtuzF/rbkT8ze25zlf5M/eN7bzorhX57n/3dzK+WK6jPnYAhQAAPjnU5wBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBh/PnxbvzCyTrPvn24zF37/nmes3fvLM/Zu3+RZ8F+2z6J+XH7bcxP+zyD9mJ9FPPl+iTmmz7P8dsU5kEPQ54fXc7zfWiaFzOvuSx/v9o2f3/Lx5fmO+e8dPy4y3Mau1Ge+zzpFjGfdYX5zu2157JFf5CP3eRZlYsmX+O8MLN6q8v3ct7le7k9zvneNJ9nf5Pv5eE6z74+Xl+P+ePR3Zxv5/nOz/oHMT9d5vxi+Sjm603+nWua0u8EAFeXP0PGXe55W7ObMd+f/iTmrw0/jfk70/yZ8/Zevp63F/m9/81F3oPxyk7ui3uL3M/mW7mHlaxW+TN5vczX74kzAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBh/B8fTOMXjpd5vvCjyzzv+H5/FPNvR3/K5+/vxfx8mecyr9bPYl6es3wZ86YZCvkPVZ6XWJ4rnQ2F23bVKdSrdZ733RbmT7aj/PM5GuVZy5Nu+7lsOs4zLKddnuM8G9XPiG6aptnb5Hx/nV93v8szqxeT/HfsdJTv2WSaj19M8r25tsmve2d9EPOnzZsxfzjPc5wfT/Pv+unqm5ifF+Y+b9bHMR+aq83mBPg+a5vCPoTxQcwX8zsxvz55K+av92/H/J15/ux6/yB/5nywm/vWT6/lPnfzdp7tv3UjN4p2mj8D+8tcTC4f5+t8+ijvPnhwkrvAk8tC/4gpAADwTyjOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAECF9oNr/yFuMzhtnsR/cLrOyw/OCssMLtf5PP3mLOaWHPAv8/yg9LbNiz+6whKVUj6d5KHw89Iw+u5mzA+GPKT+YMiLV/YL17MY56Uxs66wMKWwSKW0Euhyk7/ybJWX5zzenMf8UZvfGx43XxXOfz/mpYUpq9LClCEvRwL4LrRt4bOl8BmyO3815jfG78b8zeFuzN/aya/7fv7Iaf5mP7+X/+xmfg8+fC+/107eyK/bzvJil+F8FfPVn/OCladfTmL+xTd5KdnvC4tOPj/Nn6UPC3v0PHEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACq0k/HtOJi5H5bxH5i/zA9fnnfctnlmZNfl2ZDTrjD3eZpnTO50t2K+2+Z50Nf6w5yPtmK+N8mzM7fH+e/naeHP6j7HzbIw9/l0nfOjVX6Pedgc5bz9c8yP1/difnaZZ84v1/n8fZ9nl5YnXQM/DvkzoSu9x0/ye/Pu7LWY32l/GvO3R7dj/t5+/ix6fy/P2P/F/rOYv/Nansu8+7P8ntfdzYOf2938mdMscy/s7+XZ+2ef5MHJn39+PeYfPd6P+W+P82fdH47z9fxx9TTmj0bfxNwTZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgQts0XR52CvyLtE2eJTnqtmM+KcyDnk/zDMvFOM933m/vxLw09/mgzddzMM2zQncn+e/tWZdnnY5y3BTGPjcnyzwp+vFlnsH5sM8zSh+M8nzno82fYn62fBjzy3We8bnZ5NcdCjPwgZdD205jPu7ynOLtWWGW/vStmL/evxvzt+Z57vN7e13M/24/v5f8zY3HMX/l3TwfefazRcxHr+fPlmY3fyY0l/l6hnv5epaf5uu599v8Wffhg/wZ9eun+fv18ZNVzP+wyfOXvx4+ifnJRf6sWG5OYu6JMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQwRxneGkU5iCPtmI+Ls19nlyL+fYkzyLdG+W5zzf7nN8Y5de9Pstzqw9m+e/zeR5dWrgLTXO5yfnJKg+EflL4B4/W5zH/ts1znJ82eSboyfp+zC9WhZmm6zzTtN+cxXxo8txq+LEqzcbvCu+F0/F+zBezWzE/7PJc5rv9T2L+9m5+b34/j4NuPtjL7z2/eOXbmN/41/k9bPy3r+QXeDW/xw/zPAe5PbvI5/k6X8/6V/k978GH+fy/up+v58Ojecx/8yT/f3+3yu/BX/Ufxfz4Is/qvyy8Nw9D4T4UeOIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoIIFKPAD07Z5GH1pSUBpYcpiWlgSMHoz5rf62zG/PdmO+fXCBpS9SV6BUlqYMipsTCktTDkt7BV5uuxj/uQy/4MnfV5m8GiUF6kcDfcK15OXDVws87D+1eZZzC1S4WWW3pdGo7wIYzYuLHGaHsZ8b/xazG8XFpe8XliM8tZeXrDy8738ZvJ3B3mp0dt3H8V891/l9+bRL16P+fBOvv5hL19/e3qa8y+/inn/6y9i/vS/LGP+yy/yUqx/eJTf4z8uLDT5tLDQ5M/Dx/l6zr+M+eUqv9cOQ77+F8UTZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCggjnO8CPXNnl2aTfei/lWYZbq7vSVmB82d2N+Z8hzom9O82zXG1t5kPNBHo3azAqPBUpzn1d5jHNz8ReeB/2oz/OXH4/yfOfjIb9ln23y7NjL1dOcr3Pe9xeF/DLmTVO4Qbyk8i9A2+Tfr7Ywa3nc5dm90/FuzLcm15/Ldrs8F/hmn+cavz4+yPliEvO3d4aYv7uTf5bfP3wS81c/yLPTp3+f3wvb9wpzme/k97xhN9+zZp3fM9qv7+fjf/m7GJ/+p6OY/+Yf8+z9//o4X8//epTf2z6+zHOZv+o/inlpLvNynWfX/6XnMl+VJ84AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAVznIEruerc5+3pzZjvTl+N+Y3mJzG/M+Tz3JrPYn59lufS7l9x7vOsy7NgS1Z9npN7Xhh3fLLK+XFhHnQpP1rn2bRHTZ5B+3SU5z6fDjlf9vk8y03OV+s8n3q1OY15X5jV2veFGa5DnnE7NKXvV2FQd1HpPIVB4EX5B6ttC3OT2/z7Vcq7wpzlbpR/0CfdIuaz0tz20bWY7zd5BvDN4UbOJ1vPZa8u8v/pzcXV5i+/d+0o5q+8eRzzrZ8/fy1N0zSjn78W8+Gd/J40XM9znJsuf2+bZyf5db/6Op//t5/H/Ow/H8X8o0+uNpf5V4/zff74PM+Q/3L4ZcyPzvN1rlaFucxNYQj+94QnzgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqWIAC/EW1bV7EMO7ywoX5NC9c2J2+EvPD5m7MbxUWptyc5uUHh4UNKPvTvPCitEhlPspLBbor7s1YFfZvLAsLVs4KOwVOC/nxMr/As1VeFHK6zhtczvq8weVZc5GPb/PClLM2L4e4HPLx68L5131ektEP+Tr7wmKUYch5217teVPXTgp5XtwzbbdjPmt3Yr495OUWO4V8t80//9cn+Qf6xlZe5nE7711pXt/KPyd3F+fPZW/s5+/57bs5n3+Q783oZ3mZ0nC3sNDk1q2c7+R7VtI+zsuCRp/975j3H+b8+B/yz/KvP88LTf7b4/yz8KvH+d5/svwm5l/1H8W8tNBkucr/36YpbHf6gfLEGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACoYI4z8FJpm3HMuy7PLp1PD2O+mOZZrddGb8T8Rn8n5re6RT5+nq/z2izPWT4ozH1ejPM85e0u57PinOic91ecB31ZyC9K+aaU59e9ar4s/AeWm0JeOH6TxzIXpji/uKdK41G+P/PCYO+tcc4X+cet2c1jopuDSf6f3Zzlwd6353n+9Su7pzG/cSfP195+M19/9/bz89nb12/EY4dX8/zi4Ubh+L39mDej/F1sT/O1t9/kecftH76M+ebDP8X82/+eX/d/fpXfY/7HkzzT+zdP8uzxT/s/xvzr9ccxPz7Px6/XT2LeNIU3DZqm8cQZAACqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKhgjjPwPdfltDB/eTZ+fp5s0zTNdmEe9N74tZgf9q/G/FabZ8oezvIg52uz/Pzieh7t2lyb5hmr1wpzexfjPCB5Upj7PCrkeTpv+firKp2/dPZ+yP9iU8hLSvOvS3np/1sY19zMu3z/F5M8o3d7uszHb+V8azfn82v552FyKw9+Ht3ejnl7J/++NHfy78tw62bO9/fCxRSGm6/zrOnmNM+Ubh8+yvmf78e8/+RezE9+me/lZ1/k+dEfHe3m/Gl+T/rk6XnMf9/+LubfXn4a89PLr2O+2RzHnBfLE2cAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFSxAAWiaZjTKCyAmXVjc0DTNfJoXQ+xM7sT8oM0LUw77vFzhRpev53A+zsfP8waOw1le2LE7zvmiy4szdsalBSt5WcV2YfHKVuH4eSGfTXI+LlznuLTwZVLIt3I+Lty3tissQCns8ugW+fsy2i8sItkvbL7ZnefrWeS82SnkWzkfCnkzK1xPaeNLyfnFc1H78Em+lq8exnz92dOYP/l9vpdffJN/Rz853on5p8d5cclnx3lZzZebfJ33mn+M+dH5lzE/X34T82F4/p7x3fPEGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACoYI4zwD9D2+R5yl2XZ8ROx/sxL86D7m7F/FrzSswPh+s5H2/F/GCWZ9buTfJ83v3CnOKDaZ5rvF+Y+7xfmKe8W5jXvNXlfDHNs3VL+fbWZcznO/n4yfwFzXHezc+nRrv556dd5JnEbWF+d3Gecp+vs1nm+z9c5vvcPyvkJ/k8y8f5ZU8ePT8P+puj3XjsH58tYv75Wb43nz/L9+CPz5Yx/6p/FPOvm89i/vTyjzG/WObzrDcnMW+afM/4fvHEGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACoYI4zwHeobecx77rtmM8K86Bnk5xvd4cx32vznOjd/iDm19o8n3p/nGfr7k3znOidwpzoRWFM8VY+TbMzznOKdwvzo3cnhXyc5xTPuzxzt/S0qRvl65mO8nmm45xPRvk62zaff73JV3Sxzjf0tJCfrPL38WiVj3+yyq/7ZJm/v4/CGO0H5/kePFiexfz+6H7MH/d/ivmz5dcxv1g9iflmfRzzock/I/w4eeIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoIIFKAA/AG07jXk3yotUxoUFK5PxIubz8UHMZ6O9mG+313I+5OO3hq2cN/n/NW3zYo7tUc63xvk50bzLCzumhbz0tKnNhzejwhcKhzejwhc2ef9Js+nzFy4K/+B8nfOTdV7ycdKHzSVN0xy3z/Lx7eOYnw4Pn8vO1vnYi2XOV5v8mv0mL0yxuIS/BE+cAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAK5jgD8H8pzB1uJzEfjeYx7wr5eJTnNXddaQ71LL9uYY7zuM3HjwvnGTf5Okvn75p8H16Uoelj3jebnA95VvG6uYj5qj+/Ur5cneTzF47f9Pl1+5APwzIeCy8zT5wBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgArmOAPwEijMj266wuGl5z45bwvHt4V5ze1VnysVr6dgyPOaS3Och8LxZaXz5LnPw7AqnGe44uvCD5snzgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAq5MnvAPBXlRdtDE1e2HHVvRyDPR7AC+CJMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFT4P93k/D7/mvQDAAAAAElFTkSuQmCC" id="imagee0274cb87d" transform="scale(1 -1) translate(0 -239.76)" x="48.761875" y="-23.890745" width="516.96" height="239.76"/>
+iVBORw0KGgoAAAANSUhEUgAAAs4AAAFNCAYAAAAQIOnHAAAZg0lEQVR4nO3dWXcc57kd4KqunoDGRIKTJlOjLctnSNbKXe6yVv5FfmuuspKTUbZlWTq2HEm2TFEUBxAgph6qcpuzuL/kwzm0RUnPc7lRrC4WgO6Nunjftmm6Bw0AAPD/NPquLwAAAL4PFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFcbf9QX89bWFtLviaUp/c1z1b5H+iscXDFc7z9AMha+UzlM6HgDgx8ETZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAV/goLUAoLR9pJIc+XNGqnOR/lvCvms8L5C687KlznC/qbY7jiApRh2BTyfJ7S+UvH9/065pv+Mh8/5OOHQt4Py3x8X8ibfB4AgL82T5wBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgArjtjTKuTDXuBvN84m67ZhPxoucd4V8tBXzWbubj28Lxzf5eqZDPn4y5HnN4xc06rovzFMu5SVDm49fN3m+86ZZ5bzN85FXTZ7XvGou8usO+fhi3p/FfLk5za9bzPN5+v756zQjGgB4ETxxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqjA92PohfKM1Tno/2Y77THsZ8tz/IxzeF8xfmR8+7LuazUe7+41Eb80nhT4Wuzcd3heOHIeebQt4X/kFfOL4QF4/fFM5fup5VX5gHXXiB1ZCPXw15fvSqMFf6fJTnO190eS7zs/YoHz8cx3zZP3s+2zyfNU3TLNcnMV+t8/GbwgzqYchzogGAl0XueW07K+S5j3riDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKDC+N90/z5+YT7Kg593xznfm+YOvjPJA6e382macT68uLiksOekMOb66otFygtHcr4uLhzJV3TVBSibvIekKcTF69z0+YYWz1P4Quk6V6VFKv0i5svNtZhf9Hdifjas8vHt88tITid5ccnp9Cjnw8P8muvHMb9c5fMUF6kUFrIMzTrmAMA/1bbTmI+7vZhvTfOivq3J9ZjP2t2Ye+IMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFQY/7s7ea7uvMtzeBeFfKvLg36no9Jk4Kw073g1FPIrHn+xya+7LBxfmst8WThPMS/MNS7PWc55aW7yujQQ+opKc7FHbWkydtYVDu8KX5gX8p0h/223GSaFfOu5bN3nmY5nm5sxPx3uxvx4nOcvP508ivlJ/yDmF5ujmJfmQS/XxzHvN3k+tXnQALy88ud91+W5ybNx3vOwM8t7Hq53+TP8Tv9qzA/Hz/eGpmmaxbiLuSfOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAECF8b89zLNpu9HV5gJvCvOUzzZ5Dt7Jehzziz53+ZN1Pv/JKufPCqNsT1f5/3W2zoOTLwuDli8Kg5bP+vzCy6GQN3nw86aQ901+3VI+KvxtVMonTf6+jAvHt4V5jKXjx23hdUeFvHD8tDD3eRIGUZdmRG+P87kPhnwPDtd51uPZJs+YPG1+EvNn49OYH0+e5OOHPA/6dPVtzC+W+TzL9VHMh+Ei5gDw/9O205hPxgcx35oexnx/8kbMbw9vxfy1Ln/2vr7Iex5e285d4OYs96dFYT+JJ84AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKoz355fxC+tN7tSnqzxY+uEyD8D+5iIvk3hwmc//7UVeOPJ0mQdRHy3zYpGnfV7q8KzNyyfO2uOYXzR5QcxqOM95fxbz9ZDv86bP+TDk/+9VtYUFIqM2fx+7Nn+/SseX8nE7i/m03c75kJeLbPd7OV/n8+yE152P8hKeWWHpyjgsUWmappmPS3m+BwdDztd9vvaLTR4KfzLkofCPJ09j/mR6L59nfT/m58uHMb9cHcW87/PvUNNcbWkSAC+f0Wgn5vNJ/ozanb8a81vtuzF/rbkT8ze25zlf5M/eN7bzorhX57n/3dzK+WK6jPnYAhQAAPjnU5wBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBh/PnxbvzCyTrPvn24zF37/nmes3fvLM/Zu3+RZ8F+2z6J+XH7bcxP+zyD9mJ9FPPl+iTmmz7P8dsU5kEPQ54fXc7zfWiaFzOvuSx/v9o2f3/Lx5fmO+e8dPy4y3Mau1Ge+zzpFjGfdYX5zu2157JFf5CP3eRZlYsmX+O8MLN6q8v3ct7le7k9zvneNJ9nf5Pv5eE6z74+Xl+P+ePR3Zxv5/nOz/oHMT9d5vxi+Sjm603+nWua0u8EAFeXP0PGXe55W7ObMd+f/iTmrw0/jfk70/yZ8/Zevp63F/m9/81F3oPxyk7ui3uL3M/mW7mHlaxW+TN5vczX74kzAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBh/B8fTOMXjpd5vvCjyzzv+H5/FPNvR3/K5+/vxfx8mecyr9bPYl6es3wZ86YZCvkPVZ6XWJ4rnQ2F23bVKdSrdZ733RbmT7aj/PM5GuVZy5Nu+7lsOs4zLKddnuM8G9XPiG6aptnb5Hx/nV93v8szqxeT/HfsdJTv2WSaj19M8r25tsmve2d9EPOnzZsxfzjPc5wfT/Pv+unqm5ifF+Y+b9bHMR+aq83mBPg+a5vCPoTxQcwX8zsxvz55K+av92/H/J15/ux6/yB/5nywm/vWT6/lPnfzdp7tv3UjN4p2mj8D+8tcTC4f5+t8+ijvPnhwkrvAk8tC/4gpAADwTyjOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAECF9oNr/yFuMzhtnsR/cLrOyw/OCssMLtf5PP3mLOaWHPAv8/yg9LbNiz+6whKVUj6d5KHw89Iw+u5mzA+GPKT+YMiLV/YL17MY56Uxs66wMKWwSKW0Euhyk7/ybJWX5zzenMf8UZvfGx43XxXOfz/mpYUpq9LClCEvRwL4LrRt4bOl8BmyO3815jfG78b8zeFuzN/aya/7fv7Iaf5mP7+X/+xmfg8+fC+/107eyK/bzvJil+F8FfPVn/OCladfTmL+xTd5KdnvC4tOPj/Nn6UPC3v0PHEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACq0k/HtOJi5H5bxH5i/zA9fnnfctnlmZNfl2ZDTrjD3eZpnTO50t2K+2+Z50Nf6w5yPtmK+N8mzM7fH+e/naeHP6j7HzbIw9/l0nfOjVX6Pedgc5bz9c8yP1/difnaZZ84v1/n8fZ9nl5YnXQM/DvkzoSu9x0/ye/Pu7LWY32l/GvO3R7dj/t5+/ix6fy/P2P/F/rOYv/Nansu8+7P8ntfdzYOf2938mdMscy/s7+XZ+2ef5MHJn39+PeYfPd6P+W+P82fdH47z9fxx9TTmj0bfxNwTZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgQts0XR52CvyLtE2eJTnqtmM+KcyDnk/zDMvFOM933m/vxLw09/mgzddzMM2zQncn+e/tWZdnnY5y3BTGPjcnyzwp+vFlnsH5sM8zSh+M8nzno82fYn62fBjzy3We8bnZ5NcdCjPwgZdD205jPu7ynOLtWWGW/vStmL/evxvzt+Z57vN7e13M/24/v5f8zY3HMX/l3TwfefazRcxHr+fPlmY3fyY0l/l6hnv5epaf5uu599v8Wffhg/wZ9eun+fv18ZNVzP+wyfOXvx4+ifnJRf6sWG5OYu6JMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQwRxneGkU5iCPtmI+Ls19nlyL+fYkzyLdG+W5zzf7nN8Y5de9Pstzqw9m+e/zeR5dWrgLTXO5yfnJKg+EflL4B4/W5zH/ts1znJ82eSboyfp+zC9WhZmm6zzTtN+cxXxo8txq+LEqzcbvCu+F0/F+zBezWzE/7PJc5rv9T2L+9m5+b34/j4NuPtjL7z2/eOXbmN/41/k9bPy3r+QXeDW/xw/zPAe5PbvI5/k6X8/6V/k978GH+fy/up+v58Ojecx/8yT/f3+3yu/BX/Ufxfz4Is/qvyy8Nw9D4T4UeOIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoIIFKPAD07Z5GH1pSUBpYcpiWlgSMHoz5rf62zG/PdmO+fXCBpS9SV6BUlqYMipsTCktTDkt7BV5uuxj/uQy/4MnfV5m8GiUF6kcDfcK15OXDVws87D+1eZZzC1S4WWW3pdGo7wIYzYuLHGaHsZ8b/xazG8XFpe8XliM8tZeXrDy8738ZvJ3B3mp0dt3H8V891/l9+bRL16P+fBOvv5hL19/e3qa8y+/inn/6y9i/vS/LGP+yy/yUqx/eJTf4z8uLDT5tLDQ5M/Dx/l6zr+M+eUqv9cOQ77+F8UTZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCggjnO8CPXNnl2aTfei/lWYZbq7vSVmB82d2N+Z8hzom9O82zXG1t5kPNBHo3azAqPBUpzn1d5jHNz8ReeB/2oz/OXH4/yfOfjIb9ln23y7NjL1dOcr3Pe9xeF/DLmTVO4Qbyk8i9A2+Tfr7Ywa3nc5dm90/FuzLcm15/Ldrs8F/hmn+cavz4+yPliEvO3d4aYv7uTf5bfP3wS81c/yLPTp3+f3wvb9wpzme/k97xhN9+zZp3fM9qv7+fjf/m7GJ/+p6OY/+Yf8+z9//o4X8//epTf2z6+zHOZv+o/inlpLvNynWfX/6XnMl+VJ84AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAVznIEruerc5+3pzZjvTl+N+Y3mJzG/M+Tz3JrPYn59lufS7l9x7vOsy7NgS1Z9npN7Xhh3fLLK+XFhHnQpP1rn2bRHTZ5B+3SU5z6fDjlf9vk8y03OV+s8n3q1OY15X5jV2veFGa5DnnE7NKXvV2FQd1HpPIVB4EX5B6ttC3OT2/z7Vcq7wpzlbpR/0CfdIuaz0tz20bWY7zd5BvDN4UbOJ1vPZa8u8v/pzcXV5i+/d+0o5q+8eRzzrZ8/fy1N0zSjn78W8+Gd/J40XM9znJsuf2+bZyf5db/6Op//t5/H/Ow/H8X8o0+uNpf5V4/zff74PM+Q/3L4ZcyPzvN1rlaFucxNYQj+94QnzgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqWIAC/EW1bV7EMO7ywoX5NC9c2J2+EvPD5m7MbxUWptyc5uUHh4UNKPvTvPCitEhlPspLBbor7s1YFfZvLAsLVs4KOwVOC/nxMr/As1VeFHK6zhtczvq8weVZc5GPb/PClLM2L4e4HPLx68L5131ektEP+Tr7wmKUYch5217teVPXTgp5XtwzbbdjPmt3Yr495OUWO4V8t80//9cn+Qf6xlZe5nE7711pXt/KPyd3F+fPZW/s5+/57bs5n3+Q783oZ3mZ0nC3sNDk1q2c7+R7VtI+zsuCRp/975j3H+b8+B/yz/KvP88LTf7b4/yz8KvH+d5/svwm5l/1H8W8tNBkucr/36YpbHf6gfLEGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACoYI4z8FJpm3HMuy7PLp1PD2O+mOZZrddGb8T8Rn8n5re6RT5+nq/z2izPWT4ozH1ejPM85e0u57PinOic91ecB31ZyC9K+aaU59e9ar4s/AeWm0JeOH6TxzIXpji/uKdK41G+P/PCYO+tcc4X+cet2c1jopuDSf6f3Zzlwd6353n+9Su7pzG/cSfP195+M19/9/bz89nb12/EY4dX8/zi4Ubh+L39mDej/F1sT/O1t9/kecftH76M+ebDP8X82/+eX/d/fpXfY/7HkzzT+zdP8uzxT/s/xvzr9ccxPz7Px6/XT2LeNIU3DZqm8cQZAACqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKhgjjPwPdfltDB/eTZ+fp5s0zTNdmEe9N74tZgf9q/G/FabZ8oezvIg52uz/Pzieh7t2lyb5hmr1wpzexfjPCB5Upj7PCrkeTpv+firKp2/dPZ+yP9iU8hLSvOvS3np/1sY19zMu3z/F5M8o3d7uszHb+V8azfn82v552FyKw9+Ht3ejnl7J/++NHfy78tw62bO9/fCxRSGm6/zrOnmNM+Ubh8+yvmf78e8/+RezE9+me/lZ1/k+dEfHe3m/Gl+T/rk6XnMf9/+LubfXn4a89PLr2O+2RzHnBfLE2cAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFSxAAWiaZjTKCyAmXVjc0DTNfJoXQ+xM7sT8oM0LUw77vFzhRpev53A+zsfP8waOw1le2LE7zvmiy4szdsalBSt5WcV2YfHKVuH4eSGfTXI+LlznuLTwZVLIt3I+Lty3tissQCns8ugW+fsy2i8sItkvbL7ZnefrWeS82SnkWzkfCnkzK1xPaeNLyfnFc1H78Em+lq8exnz92dOYP/l9vpdffJN/Rz853on5p8d5cclnx3lZzZebfJ33mn+M+dH5lzE/X34T82F4/p7x3fPEGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACoYI4zwD9D2+R5yl2XZ8ROx/sxL86D7m7F/FrzSswPh+s5H2/F/GCWZ9buTfJ83v3CnOKDaZ5rvF+Y+7xfmKe8W5jXvNXlfDHNs3VL+fbWZcznO/n4yfwFzXHezc+nRrv556dd5JnEbWF+d3Gecp+vs1nm+z9c5vvcPyvkJ/k8y8f5ZU8ePT8P+puj3XjsH58tYv75Wb43nz/L9+CPz5Yx/6p/FPOvm89i/vTyjzG/WObzrDcnMW+afM/4fvHEGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACoYI4zwHeobecx77rtmM8K86Bnk5xvd4cx32vznOjd/iDm19o8n3p/nGfr7k3znOidwpzoRWFM8VY+TbMzznOKdwvzo3cnhXyc5xTPuzxzt/S0qRvl65mO8nmm45xPRvk62zaff73JV3Sxzjf0tJCfrPL38WiVj3+yyq/7ZJm/v4/CGO0H5/kePFiexfz+6H7MH/d/ivmz5dcxv1g9iflmfRzzock/I/w4eeIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoIIFKAA/AG07jXk3yotUxoUFK5PxIubz8UHMZ6O9mG+313I+5OO3hq2cN/n/NW3zYo7tUc63xvk50bzLCzumhbz0tKnNhzejwhcKhzejwhc2ef9Js+nzFy4K/+B8nfOTdV7ycdKHzSVN0xy3z/Lx7eOYnw4Pn8vO1vnYi2XOV5v8mv0mL0yxuIS/BE+cAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAK5jgD8H8pzB1uJzEfjeYx7wr5eJTnNXddaQ71LL9uYY7zuM3HjwvnGTf5Okvn75p8H16Uoelj3jebnA95VvG6uYj5qj+/Ur5cneTzF47f9Pl1+5APwzIeCy8zT5wBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgArmOAPwEijMj266wuGl5z45bwvHt4V5ze1VnysVr6dgyPOaS3Och8LxZaXz5LnPw7AqnGe44uvCD5snzgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAq5MnvAPBXlRdtDE1e2HHVvRyDPR7AC+CJMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFT4P93k/D7/mvQDAAAAAElFTkSuQmCC" id="image413211f04e" transform="scale(1 -1) translate(0 -239.76)" x="48.761875" y="-23.890745" width="516.96" height="239.76"/>
    </g>
    <g id="line2d_21"/>
    <g id="line2d_22"/>
    <g id="line2d_23"/>
    <g id="line2d_24"/>
    <g id="line2d_25"/>
-   <g id="patch_3">
+   <g id="patch_4">
     <path d="M 48.761875 263.650745 
 L 48.761875 24.318125 
 " style="fill: none; stroke: #565f89; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_4">
+   <g id="patch_5">
     <path d="M 565.693075 263.650745 
 L 565.693075 24.318125 
 " style="fill: none; stroke: #565f89; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_5">
+   <g id="patch_6">
     <path d="M 48.761875 263.650745 
 L 565.693075 263.650745 
 " style="fill: none; stroke: #565f89; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_6">
+   <g id="patch_7">
     <path d="M 48.761875 24.318125 
 L 565.693075 24.318125 
 " style="fill: none; stroke: #565f89; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
@@ -1121,7 +1129,7 @@ L 60.461429 21.843268
 L 54.694307 20.687041 
 L 51.734129 20.198908 
 L 51.734129 20.198908 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke-dasharray: 7.4,3.2; stroke-dashoffset: 0; stroke: #565f89; stroke-opacity: 0.9; stroke-width: 2"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke-dasharray: 7.4,3.2; stroke-dashoffset: 0; stroke: #565f89; stroke-opacity: 0.9; stroke-width: 2"/>
    </g>
    <g id="line2d_27">
     <path d="M 565.693075 143.984435 
@@ -1196,7 +1204,12 @@ L 73.936535 158.824866
 L 63.281677 152.666036 
 L 50.079327 144.777743 
 L 50.079327 144.777743 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke-dasharray: 0.9,1.485; stroke-dashoffset: 0; stroke: #c0caf5; stroke-opacity: 0.5; stroke-width: 0.9"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke-dasharray: 0.9,1.485; stroke-dashoffset: 0; stroke: #c0caf5; stroke-opacity: 0.5; stroke-width: 0.9"/>
+   </g>
+   <g id="line2d_28">
+    <path d="M 48.761875 120.051173 
+L 565.693075 120.051173 
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke-dasharray: 7.68,1.92,1.2,1.92; stroke-dashoffset: 0; stroke: #f7768e; stroke-opacity: 0.85; stroke-width: 1.2"/>
    </g>
    <g id="text_23">
     <!-- Where is Planet 9? Dwell-time position probability across orbit solutions -->
@@ -1631,7 +1644,7 @@ L 59.531275 250.631838
 L 55.223515 249.909227 
 L 50.915755 249.398641 
 L 50.915755 249.398641 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 0.9"/>
     <path d="M 50.915755 154.196731 
 L 55.223515 155.549905 
 L 63.839035 160.282466 
@@ -1740,7 +1753,7 @@ L 554.923675 141.796709
 L 559.231435 145.082156 
 L 563.539195 147.288055 
 L 563.539195 147.288055 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 0.9"/>
    </g>
    <g id="PathCollection_2">
     <path d="M 563.539195 222.714652 
@@ -1826,7 +1839,7 @@ L 554.923675 162.912262
 L 559.231435 166.206966 
 L 563.539195 168.157047 
 L 563.539195 168.157047 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 50.915755 177.808694 
 L 55.223515 179.813444 
 L 59.531275 182.857932 
@@ -1850,7 +1863,7 @@ L 63.839035 222.26085
 L 59.531275 222.617585 
 L 55.223515 222.892123 
 L 50.915755 223.098217 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 1.6"/>
    </g>
    <g id="PathCollection_3">
     <path d="M 563.539195 245.681528 
@@ -1959,7 +1972,7 @@ L 55.223515 249.402432
 L 52.405851 248.692457 
 L 50.915755 248.44913 
 L 50.915755 248.44913 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 0.9"/>
     <path d="M 50.915755 153.832846 
 L 55.223515 154.982652 
 L 59.531275 156.960668 
@@ -2069,7 +2082,7 @@ L 554.923675 141.704086
 L 559.231435 144.618047 
 L 563.539195 146.606684 
 L 563.539195 146.606684 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 0.9"/>
    </g>
    <g id="PathCollection_4">
     <path d="M 563.539195 224.314488 
@@ -2179,7 +2192,7 @@ L 554.923675 160.999647
 L 559.231435 164.040514 
 L 563.539195 165.926713 
 L 563.539195 165.926713 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 50.915755 175.141404 
 L 55.223515 176.583079 
 L 55.81124 176.89267 
@@ -2213,7 +2226,7 @@ L 63.839035 226.750485
 L 59.531275 226.589266 
 L 55.223515 226.52877 
 L 50.915755 226.530946 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 1.6"/>
    </g>
    <g id="PathCollection_5">
     <path d="M 563.539195 218.026617 
@@ -2323,7 +2336,7 @@ L 72.454555 226.337958
 L 55.223515 222.131186 
 L 50.915755 221.329095 
 L 50.915755 221.329095 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 0.9"/>
     <path d="M 50.915755 147.692658 
 L 55.223515 148.7023 
 L 59.531275 150.452571 
@@ -2430,7 +2443,7 @@ L 559.231435 140.566899
 L 560.242304 140.992777 
 L 563.539195 141.962789 
 L 563.539195 141.962789 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 0.9"/>
    </g>
    <g id="PathCollection_6">
     <path d="M 563.539195 200.505249 
@@ -2516,7 +2529,7 @@ L 59.531275 204.654445
 L 55.223515 203.669833 
 L 50.915755 202.973512 
 L 50.915755 202.973512 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 50.915755 164.313798 
 L 55.223515 165.5314 
 L 59.531275 167.522079 
@@ -2608,7 +2621,7 @@ L 554.923675 154.867094
 L 559.231435 157.418593 
 L 563.539195 158.930987 
 L 563.539195 158.930987 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 1.6"/>
    </g>
    <g id="PathCollection_7">
     <path d="M 563.539195 174.954186 
@@ -2717,7 +2730,7 @@ L 58.719645 182.875986
 L 55.223515 181.736025 
 L 50.915755 180.667786 
 L 50.915755 180.667786 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 0.9"/>
     <path d="M 50.915755 140.218997 
 L 53.07907 140.992777 
 L 55.223515 141.359204 
@@ -2834,7 +2847,7 @@ L 553.970855 129.026146
 L 559.231435 131.608798 
 L 563.539195 133.585469 
 L 563.539195 133.585469 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 0.9"/>
    </g>
    <g id="PathCollection_8">
     <path d="M 563.539195 166.819028 
@@ -2961,7 +2974,7 @@ L 559.231435 140.191952
 L 561.092287 140.992777 
 L 563.539195 141.825846 
 L 563.539195 141.825846 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 50.915755 148.350771 
 L 55.223515 149.526465 
 L 59.531275 151.660751 
@@ -3022,39 +3035,39 @@ L 63.839035 176.622347
 L 59.531275 174.79249 
 L 55.223515 173.193179 
 L 50.915755 172.104921 
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 223.226155 176.91667 
 L 222.467581 176.89267 
 L 223.226155 176.845451 
 L 223.41229 176.89267 
 L 223.226155 176.91667 
 z
-" clip-path="url(#pbca7bb30fa)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
    </g>
    <g id="legend_1">
-    <g id="patch_7">
+    <g id="patch_8">
      <path d="M 53.801875 260.050745 
-L 438.64975 260.050745 
-Q 440.08975 260.050745 440.08975 258.610745 
-L 440.08975 217.057745 
-Q 440.08975 215.617745 438.64975 215.617745 
-L 53.801875 215.617745 
-Q 52.361875 215.617745 52.361875 217.057745 
+L 428.267125 260.050745 
+Q 429.707125 260.050745 429.707125 258.610745 
+L 429.707125 206.489495 
+Q 429.707125 205.049495 428.267125 205.049495 
+L 53.801875 205.049495 
+Q 52.361875 205.049495 52.361875 206.489495 
 L 52.361875 258.610745 
 Q 52.361875 260.050745 53.801875 260.050745 
 L 53.801875 260.050745 
 z
 " style="fill: none; opacity: 0"/>
     </g>
-    <g id="line2d_28">
-     <path d="M 55.241875 221.44862 
-L 62.441875 221.44862 
-L 69.641875 221.44862 
+    <g id="line2d_29">
+     <path d="M 55.241875 210.88037 
+L 62.441875 210.88037 
+L 69.641875 210.88037 
 " style="fill: none; stroke: #7dcfff; stroke-width: 2.2; stroke-linecap: square"/>
     </g>
     <g id="text_24">
      <!-- 2016 Batygin &amp; Brown — V≈22.7, 835 AU -->
-     <g style="fill: #c0caf5" transform="translate(75.401875 223.96862) scale(0.072 -0.072)">
+     <g style="fill: #c0caf5" transform="translate(75.401875 213.40037) scale(0.072 -0.072)">
       <defs>
        <path id="DejaVuSans-42" d="M 1259 2228 
 L 1259 519 
@@ -3269,15 +3282,15 @@ z
       <use xlink:href="#DejaVuSans-55" x="2017.623047"/>
      </g>
     </g>
-    <g id="line2d_29">
-     <path d="M 55.241875 232.01687 
-L 62.441875 232.01687 
-L 69.641875 232.01687 
+    <g id="line2d_30">
+     <path d="M 55.241875 221.44862 
+L 62.441875 221.44862 
+L 69.641875 221.44862 
 " style="fill: none; stroke: #7aa2f7; stroke-width: 2.2; stroke-linecap: square"/>
     </g>
     <g id="text_25">
      <!-- 2016 Batygin &amp; Brown — V≈21.7, 671 AU -->
-     <g style="fill: #c0caf5" transform="translate(75.401875 234.53687) scale(0.072 -0.072)">
+     <g style="fill: #c0caf5" transform="translate(75.401875 223.96862) scale(0.072 -0.072)">
       <use xlink:href="#DejaVuSans-32"/>
       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
       <use xlink:href="#DejaVuSans-31" x="127.246094"/>
@@ -3317,15 +3330,15 @@ L 69.641875 232.01687
       <use xlink:href="#DejaVuSans-55" x="2017.623047"/>
      </g>
     </g>
-    <g id="line2d_30">
-     <path d="M 55.241875 242.58512 
-L 62.441875 242.58512 
-L 69.641875 242.58512 
+    <g id="line2d_31">
+     <path d="M 55.241875 232.01687 
+L 62.441875 232.01687 
+L 69.641875 232.01687 
 " style="fill: none; stroke: #9ece6a; stroke-width: 2.2; stroke-linecap: square"/>
     </g>
     <g id="text_26">
      <!-- 2019 Batygin et al. — V≈20.9, 506 AU -->
-     <g style="fill: #c0caf5" transform="translate(75.401875 245.10512) scale(0.072 -0.072)">
+     <g style="fill: #c0caf5" transform="translate(75.401875 234.53687) scale(0.072 -0.072)">
       <use xlink:href="#DejaVuSans-32"/>
       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
       <use xlink:href="#DejaVuSans-31" x="127.246094"/>
@@ -3364,15 +3377,15 @@ L 69.641875 242.58512
       <use xlink:href="#DejaVuSans-55" x="1847.412109"/>
      </g>
     </g>
-    <g id="line2d_31">
-     <path d="M 55.241875 253.15337 
-L 62.441875 253.15337 
-L 69.641875 253.15337 
+    <g id="line2d_32">
+     <path d="M 55.241875 242.58512 
+L 62.441875 242.58512 
+L 69.641875 242.58512 
 " style="fill: none; stroke: #f7768e; stroke-width: 2.2; stroke-linecap: square"/>
     </g>
     <g id="text_27">
      <!-- 2021 Brown &amp; Batygin — V≈19.6, 390 AU -->
-     <g style="fill: #c0caf5" transform="translate(75.401875 255.67337) scale(0.072 -0.072)">
+     <g style="fill: #c0caf5" transform="translate(75.401875 245.10512) scale(0.072 -0.072)">
       <use xlink:href="#DejaVuSans-32"/>
       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
       <use xlink:href="#DejaVuSans-32" x="127.246094"/>
@@ -3412,15 +3425,15 @@ L 69.641875 253.15337
       <use xlink:href="#DejaVuSans-55" x="2017.623047"/>
      </g>
     </g>
-    <g id="line2d_32">
-     <path d="M 240.33925 221.44862 
-L 247.53925 221.44862 
-L 254.73925 221.44862 
+    <g id="line2d_33">
+     <path d="M 55.241875 253.15337 
+L 62.441875 253.15337 
+L 69.641875 253.15337 
 " style="fill: none; stroke: #e0af68; stroke-width: 2.2; stroke-linecap: square"/>
     </g>
     <g id="text_28">
      <!-- 2024 Siraj, Chyba &amp; Tremaine — V≈18.8, 305 AU -->
-     <g style="fill: #c0caf5" transform="translate(260.49925 223.96862) scale(0.072 -0.072)">
+     <g style="fill: #c0caf5" transform="translate(75.401875 255.67337) scale(0.072 -0.072)">
       <defs>
        <path id="DejaVuSans-53" d="M 3425 4513 
 L 3425 3897 
@@ -3552,15 +3565,15 @@ z
       <use xlink:href="#DejaVuSans-55" x="2381.144531"/>
      </g>
     </g>
-    <g id="line2d_33">
-     <path d="M 240.33925 232.01687 
-L 247.53925 232.01687 
-L 254.73925 232.01687 
+    <g id="line2d_34">
+     <path d="M 266.512375 210.88037 
+L 273.712375 210.88037 
+L 280.912375 210.88037 
 " style="fill: none; stroke-dasharray: 7.4,3.2; stroke-dashoffset: 0; stroke: #565f89; stroke-opacity: 0.9; stroke-width: 2"/>
     </g>
     <g id="text_29">
      <!-- Galactic plane (hard zone) -->
-     <g style="fill: #c0caf5" transform="translate(260.49925 234.53687) scale(0.072 -0.072)">
+     <g style="fill: #c0caf5" transform="translate(286.672375 213.40037) scale(0.072 -0.072)">
       <defs>
        <path id="DejaVuSans-47" d="M 3809 666 
 L 3809 1919 
@@ -3681,15 +3694,15 @@ z
       <use xlink:href="#DejaVuSans-29" x="1282.673828"/>
      </g>
     </g>
-    <g id="line2d_34">
-     <path d="M 240.33925 242.58512 
-L 247.53925 242.58512 
-L 254.73925 242.58512 
+    <g id="line2d_35">
+     <path d="M 266.512375 221.44862 
+L 273.712375 221.44862 
+L 280.912375 221.44862 
 " style="fill: none; stroke-dasharray: 0.9,1.485; stroke-dashoffset: 0; stroke: #c0caf5; stroke-opacity: 0.5; stroke-width: 0.9"/>
     </g>
     <g id="text_30">
      <!-- Ecliptic -->
-     <g style="fill: #c0caf5" transform="translate(260.49925 245.10512) scale(0.072 -0.072)">
+     <g style="fill: #c0caf5" transform="translate(286.672375 223.96862) scale(0.072 -0.072)">
       <defs>
        <path id="DejaVuSans-45" d="M 628 4666 
 L 3578 4666 
@@ -3717,204 +3730,117 @@ z
       <use xlink:href="#DejaVuSans-63" x="304.199219"/>
      </g>
     </g>
-   </g>
-   <g id="line2d_35">
-    <defs>
-     <path id="mbfc0c0eb3e" d="M 0 -7 
-L -1.571598 -2.163119 
-L -6.657396 -2.163119 
-L -2.542899 0.826238 
-L -4.114497 5.663119 
-L -0 2.673762 
-L 4.114497 5.663119 
-L 2.542899 0.826238 
-L 6.657396 -2.163119 
-L 1.571598 -2.163119 
-z
-" style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
-    </defs>
-    <g clip-path="url(#pbca7bb30fa)">
-     <use xlink:href="#mbfc0c0eb3e" x="468.768475" y="129.026146" style="fill: #7dcfff; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    <g id="line2d_36">
+     <path d="M 266.512375 232.01687 
+L 273.712375 232.01687 
+L 280.912375 232.01687 
+" style="fill: none; stroke-dasharray: 7.68,1.92,1.2,1.92; stroke-dashoffset: 0; stroke: #f7768e; stroke-opacity: 0.85; stroke-width: 1.2"/>
     </g>
-   </g>
-   <g id="line2d_36">
-    <defs>
-     <path id="m39b7a359d0" d="M 0 -7 
-L -1.571598 -2.163119 
-L -6.657396 -2.163119 
-L -2.542899 0.826238 
-L -4.114497 5.663119 
-L -0 2.673762 
-L 4.114497 5.663119 
-L 2.542899 0.826238 
-L 6.657396 -2.163119 
-L 1.571598 -2.163119 
-z
-" style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
-    </defs>
-    <g clip-path="url(#pbca7bb30fa)">
-     <use xlink:href="#m39b7a359d0" x="485.999515" y="146.976093" style="fill: #7aa2f7; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
-    </g>
-   </g>
-   <g id="line2d_37">
-    <defs>
-     <path id="m1744b9958f" d="M 0 -7 
-L -1.571598 -2.163119 
-L -6.657396 -2.163119 
-L -2.542899 0.826238 
-L -4.114497 5.663119 
-L -0 2.673762 
-L 4.114497 5.663119 
-L 2.542899 0.826238 
-L 6.657396 -2.163119 
-L 1.571598 -2.163119 
-z
-" style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
-    </defs>
-    <g clip-path="url(#pbca7bb30fa)">
-     <use xlink:href="#m1744b9958f" x="429.998635" y="99.109569" style="fill: #9ece6a; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
-    </g>
-   </g>
-   <g id="line2d_38">
-    <defs>
-     <path id="m76a192b159" d="M 0 -7 
-L -1.571598 -2.163119 
-L -6.657396 -2.163119 
-L -2.542899 0.826238 
-L -4.114497 5.663119 
-L -0 2.673762 
-L 4.114497 5.663119 
-L 2.542899 0.826238 
-L 6.657396 -2.163119 
-L 1.571598 -2.163119 
-z
-" style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
-    </defs>
-    <g clip-path="url(#pbca7bb30fa)">
-     <use xlink:href="#m76a192b159" x="473.076235" y="117.059515" style="fill: #f7768e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
-    </g>
-   </g>
-   <g id="line2d_39">
-    <defs>
-     <path id="m01f4ea7b94" d="M 0 -7 
-L -1.571598 -2.163119 
-L -6.657396 -2.163119 
-L -2.542899 0.826238 
-L -4.114497 5.663119 
-L -0 2.673762 
-L 4.114497 5.663119 
-L 2.542899 0.826238 
-L 6.657396 -2.163119 
-L 1.571598 -2.163119 
-z
-" style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
-    </defs>
-    <g clip-path="url(#pbca7bb30fa)">
-     <use xlink:href="#m01f4ea7b94" x="494.615035" y="117.059515" style="fill: #e0af68; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
-    </g>
-   </g>
-  </g>
-  <g id="axes_2">
-   <g id="patch_8">
-    <path d="M 571.049875 263.650745 
-L 583.016506 263.650745 
-L 583.016506 24.318125 
-L 571.049875 24.318125 
-L 571.049875 263.650745 
-z
-" style="fill: none"/>
-   </g>
-   <g id="patch_9">
-    <path clip-path="url(#p8e4e78cf92)" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.01; stroke-linejoin: miter"/>
-   </g>
-   <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFNCAYAAADmVoTCAAAB9UlEQVR4nO2cwQ3EMAgEwef+G70ikn/iHxNphHABKzzsYie6S0bsfxTXqgpEROyMrItEEiLAjlRM6sUgTHYClTBgI351EWI7Oz1mG588l6fFUCUesAwTSYoZJquVT3YCM7Zfii1MRGbT+ARiQgwlohJiO9S01zDRBBBqMQB2XR6fWJg0CyAy2QifiJ53GCbEE3pqAuhhwoAVmU3DBHhFpmICVEK8Z4OYEC8wIZ+UNZhKqGdAQIRxLFAJxUQTQA0TUXYIEdNks4gAGiYmmhSrBjUgokkxNdkAkWZMiFHgGdQD9iMRislVF5kT8CBS15jJdhLRdEd1tQBSbHreIUQsQ2mvrHdnAvheVACJE5CoxDSoLbcCKMWWAGq2IzIbdFOSpJjyCXGgayrxmE2THdVQGiaPBQVQc7cXXUE1TIgjw3QrYFJsYaI50AfsQUQzHiEmy8NEImKa9kR3mjFBHDtMTpUQIgAVarIRIr2YBOMToBITE0AEMhsgQmxHFEBNd1RmQ/6HXq+kHRPGsZbf+EEBRMD2YoJ810LDRNNiKsUD9gsRiAmRnfHJZyLEV0eagWWmveW/b73M1o4J8tkfUQAl22lnNotPVGCHyWN5Di8TE0uLIRHNX8gvD5Mx21tE82k1TYs93YECyNwKJCL9zKZh0upW4AF7AzPBMzutgp3rAAAAAElFTkSuQmCC" id="imagef6fa31ad39" transform="scale(1 -1) translate(0 -239.76)" x="570.96" y="-23.76" width="12.24" height="239.76"/>
-   <g id="matplotlib.axis_3"/>
-   <g id="matplotlib.axis_4">
-    <g id="ytick_8">
-     <g id="line2d_40">
+    <g id="text_31">
+     <!-- Rubin limit Dec +12° (JBT keeps north) -->
+     <g style="fill: #c0caf5" transform="translate(286.672375 234.53687) scale(0.072 -0.072)">
       <defs>
-       <path id="mc685351852" d="M 0 0 
-L 3.5 0 
-" style="stroke: #565f89; stroke-width: 0.8"/>
+       <path id="DejaVuSans-4a" d="M 628 4666 
+L 1259 4666 
+L 1259 325 
+Q 1259 -519 939 -900 
+Q 619 -1281 -91 -1281 
+L -331 -1281 
+L -331 -750 
+L -134 -750 
+Q 284 -750 456 -515 
+Q 628 -281 628 325 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6b" d="M 581 4863 
+L 1159 4863 
+L 1159 1991 
+L 2875 3500 
+L 3609 3500 
+L 1753 1863 
+L 3688 0 
+L 2938 0 
+L 1159 1709 
+L 1159 0 
+L 581 0 
+L 581 4863 
+z
+" transform="scale(0.015625)"/>
       </defs>
-      <g>
-       <use xlink:href="#mc685351852" x="583.016506" y="223.761975" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_31">
-      <!-- 0.2 -->
-      <g style="fill: #c0caf5" transform="translate(590.016506 226.421428) scale(0.07 -0.07)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-32" x="95.410156"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_9">
-     <g id="line2d_41">
-      <g>
-       <use xlink:href="#mc685351852" x="583.016506" y="173.901013" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_32">
-      <!-- 0.4 -->
-      <g style="fill: #c0caf5" transform="translate(590.016506 176.560466) scale(0.07 -0.07)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-34" x="95.410156"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_10">
-     <g id="line2d_42">
-      <g>
-       <use xlink:href="#mc685351852" x="583.016506" y="124.04005" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_33">
-      <!-- 0.6 -->
-      <g style="fill: #c0caf5" transform="translate(590.016506 126.699503) scale(0.07 -0.07)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-36" x="95.410156"/>
-      </g>
+      <use xlink:href="#DejaVuSans-52"/>
+      <use xlink:href="#DejaVuSans-75" x="64.982422"/>
+      <use xlink:href="#DejaVuSans-62" x="128.361328"/>
+      <use xlink:href="#DejaVuSans-69" x="191.837891"/>
+      <use xlink:href="#DejaVuSans-6e" x="219.621094"/>
+      <use xlink:href="#DejaVuSans-20" x="283"/>
+      <use xlink:href="#DejaVuSans-6c" x="314.787109"/>
+      <use xlink:href="#DejaVuSans-69" x="342.570312"/>
+      <use xlink:href="#DejaVuSans-6d" x="370.353516"/>
+      <use xlink:href="#DejaVuSans-69" x="467.765625"/>
+      <use xlink:href="#DejaVuSans-74" x="495.548828"/>
+      <use xlink:href="#DejaVuSans-20" x="534.757812"/>
+      <use xlink:href="#DejaVuSans-44" x="566.544922"/>
+      <use xlink:href="#DejaVuSans-65" x="643.546875"/>
+      <use xlink:href="#DejaVuSans-63" x="705.070312"/>
+      <use xlink:href="#DejaVuSans-20" x="760.050781"/>
+      <use xlink:href="#DejaVuSans-2b" x="791.837891"/>
+      <use xlink:href="#DejaVuSans-31" x="875.626953"/>
+      <use xlink:href="#DejaVuSans-32" x="939.25"/>
+      <use xlink:href="#DejaVuSans-b0" x="1002.873047"/>
+      <use xlink:href="#DejaVuSans-20" x="1052.873047"/>
+      <use xlink:href="#DejaVuSans-28" x="1084.660156"/>
+      <use xlink:href="#DejaVuSans-4a" x="1123.673828"/>
+      <use xlink:href="#DejaVuSans-42" x="1153.166016"/>
+      <use xlink:href="#DejaVuSans-54" x="1221.769531"/>
+      <use xlink:href="#DejaVuSans-20" x="1282.853516"/>
+      <use xlink:href="#DejaVuSans-6b" x="1314.640625"/>
+      <use xlink:href="#DejaVuSans-65" x="1368.925781"/>
+      <use xlink:href="#DejaVuSans-65" x="1430.449219"/>
+      <use xlink:href="#DejaVuSans-70" x="1491.972656"/>
+      <use xlink:href="#DejaVuSans-73" x="1555.449219"/>
+      <use xlink:href="#DejaVuSans-20" x="1607.548828"/>
+      <use xlink:href="#DejaVuSans-6e" x="1639.335938"/>
+      <use xlink:href="#DejaVuSans-6f" x="1702.714844"/>
+      <use xlink:href="#DejaVuSans-72" x="1763.896484"/>
+      <use xlink:href="#DejaVuSans-74" x="1805.009766"/>
+      <use xlink:href="#DejaVuSans-68" x="1844.21875"/>
+      <use xlink:href="#DejaVuSans-29" x="1907.597656"/>
      </g>
     </g>
-    <g id="ytick_11">
-     <g id="line2d_43">
-      <g>
-       <use xlink:href="#mc685351852" x="583.016506" y="74.179088" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_34">
-      <!-- 0.8 -->
-      <g style="fill: #c0caf5" transform="translate(590.016506 76.838541) scale(0.07 -0.07)">
-       <use xlink:href="#DejaVuSans-30"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-38" x="95.410156"/>
-      </g>
-     </g>
+    <g id="PathCollection_9">
+     <path d="M 273.712375 245.451188 
+L 275.948443 243.21512 
+L 273.712375 240.979052 
+L 271.476307 243.21512 
+z
+" style="fill: #e0af68"/>
     </g>
-    <g id="ytick_12">
-     <g id="line2d_44">
-      <g>
-       <use xlink:href="#mc685351852" x="583.016506" y="24.318125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_35">
-      <!-- 1.0 -->
-      <g style="fill: #c0caf5" transform="translate(590.016506 26.977578) scale(0.07 -0.07)">
-       <use xlink:href="#DejaVuSans-31"/>
-       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
-       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
-      </g>
-     </g>
-    </g>
-    <g id="text_36">
-     <!-- relative position probability (2021 MCMC) -->
-     <g style="fill: #c0caf5" transform="translate(611.227444 227.13006) rotate(-90) scale(0.08 -0.08)">
+    <g id="text_32">
+     <!-- Cassini favored-ν arc (ν 108–129°) -->
+     <g style="fill: #c0caf5" transform="translate(286.672375 245.10512) scale(0.072 -0.072)">
       <defs>
+       <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
        <path id="DejaVuSans-76" d="M 191 3500 
 L 800 3500 
 L 1894 563 
@@ -3925,6 +3851,467 @@ L 1503 0
 L 191 3500 
 z
 " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-3bd" d="M 1300 0 
+L 231 3500 
+L 850 3500 
+L 1753 563 
+Q 2128 950 2441 1488 
+Q 2678 1891 2691 2241 
+Q 2697 2406 2622 2719 
+Q 2534 3091 2203 3500 
+L 2784 3500 
+L 2784 3500 
+Q 3000 3222 3144 2834 
+Q 3275 2478 3275 2234 
+Q 3275 1622 2850 1075 
+Q 2297 363 1913 0 
+L 1300 0 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2013" d="M 313 1978 
+L 2888 1978 
+L 2888 1528 
+L 313 1528 
+L 313 1978 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-43"/>
+      <use xlink:href="#DejaVuSans-61" x="69.824219"/>
+      <use xlink:href="#DejaVuSans-73" x="131.103516"/>
+      <use xlink:href="#DejaVuSans-73" x="183.203125"/>
+      <use xlink:href="#DejaVuSans-69" x="235.302734"/>
+      <use xlink:href="#DejaVuSans-6e" x="263.085938"/>
+      <use xlink:href="#DejaVuSans-69" x="326.464844"/>
+      <use xlink:href="#DejaVuSans-20" x="354.248047"/>
+      <use xlink:href="#DejaVuSans-66" x="386.035156"/>
+      <use xlink:href="#DejaVuSans-61" x="421.240234"/>
+      <use xlink:href="#DejaVuSans-76" x="482.519531"/>
+      <use xlink:href="#DejaVuSans-6f" x="541.699219"/>
+      <use xlink:href="#DejaVuSans-72" x="602.880859"/>
+      <use xlink:href="#DejaVuSans-65" x="641.744141"/>
+      <use xlink:href="#DejaVuSans-64" x="703.267578"/>
+      <use xlink:href="#DejaVuSans-2d" x="766.744141"/>
+      <use xlink:href="#DejaVuSans-3bd" x="802.828125"/>
+      <use xlink:href="#DejaVuSans-20" x="858.6875"/>
+      <use xlink:href="#DejaVuSans-61" x="890.474609"/>
+      <use xlink:href="#DejaVuSans-72" x="951.753906"/>
+      <use xlink:href="#DejaVuSans-63" x="990.617188"/>
+      <use xlink:href="#DejaVuSans-20" x="1045.597656"/>
+      <use xlink:href="#DejaVuSans-28" x="1077.384766"/>
+      <use xlink:href="#DejaVuSans-3bd" x="1116.398438"/>
+      <use xlink:href="#DejaVuSans-20" x="1172.257812"/>
+      <use xlink:href="#DejaVuSans-31" x="1204.044922"/>
+      <use xlink:href="#DejaVuSans-30" x="1267.667969"/>
+      <use xlink:href="#DejaVuSans-38" x="1331.291016"/>
+      <use xlink:href="#DejaVuSans-2013" x="1394.914062"/>
+      <use xlink:href="#DejaVuSans-31" x="1444.914062"/>
+      <use xlink:href="#DejaVuSans-32" x="1508.537109"/>
+      <use xlink:href="#DejaVuSans-39" x="1572.160156"/>
+      <use xlink:href="#DejaVuSans-b0" x="1635.783203"/>
+      <use xlink:href="#DejaVuSans-29" x="1685.783203"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_37">
+    <defs>
+     <path id="m16d15a823b" d="M 0 -7 
+L -1.571598 -2.163119 
+L -6.657396 -2.163119 
+L -2.542899 0.826238 
+L -4.114497 5.663119 
+L -0 2.673762 
+L 4.114497 5.663119 
+L 2.542899 0.826238 
+L 6.657396 -2.163119 
+L 1.571598 -2.163119 
+z
+" style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    </defs>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#m16d15a823b" x="468.768475" y="129.026146" style="fill: #7dcfff; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    </g>
+   </g>
+   <g id="line2d_38">
+    <defs>
+     <path id="m85dec3bd2a" d="M 0 -7 
+L -1.571598 -2.163119 
+L -6.657396 -2.163119 
+L -2.542899 0.826238 
+L -4.114497 5.663119 
+L -0 2.673762 
+L 4.114497 5.663119 
+L 2.542899 0.826238 
+L 6.657396 -2.163119 
+L 1.571598 -2.163119 
+z
+" style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    </defs>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#m85dec3bd2a" x="485.999515" y="146.976093" style="fill: #7aa2f7; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    </g>
+   </g>
+   <g id="line2d_39">
+    <defs>
+     <path id="m1cd9f341a1" d="M 0 -7 
+L -1.571598 -2.163119 
+L -6.657396 -2.163119 
+L -2.542899 0.826238 
+L -4.114497 5.663119 
+L -0 2.673762 
+L 4.114497 5.663119 
+L 2.542899 0.826238 
+L 6.657396 -2.163119 
+L 1.571598 -2.163119 
+z
+" style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    </defs>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#m1cd9f341a1" x="429.998635" y="99.109569" style="fill: #9ece6a; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    </g>
+   </g>
+   <g id="line2d_40">
+    <defs>
+     <path id="m6b1646db10" d="M 0 -7 
+L -1.571598 -2.163119 
+L -6.657396 -2.163119 
+L -2.542899 0.826238 
+L -4.114497 5.663119 
+L -0 2.673762 
+L 4.114497 5.663119 
+L 2.542899 0.826238 
+L 6.657396 -2.163119 
+L 1.571598 -2.163119 
+z
+" style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    </defs>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#m6b1646db10" x="473.076235" y="117.059515" style="fill: #f7768e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    </g>
+   </g>
+   <g id="line2d_41">
+    <defs>
+     <path id="m684bd3a6f1" d="M 0 -7 
+L -1.571598 -2.163119 
+L -6.657396 -2.163119 
+L -2.542899 0.826238 
+L -4.114497 5.663119 
+L -0 2.673762 
+L 4.114497 5.663119 
+L 2.542899 0.826238 
+L 6.657396 -2.163119 
+L 1.571598 -2.163119 
+z
+" style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    </defs>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#m684bd3a6f1" x="494.615035" y="117.059515" style="fill: #e0af68; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    </g>
+   </g>
+   <g id="PathCollection_10">
+    <defs>
+     <path id="C0_0_9579c22793" d="M -0 2.236068 
+L 2.236068 -0 
+L 0 -2.236068 
+L -2.236068 -0 
+z
+"/>
+    </defs>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="64.279475" y="184.115478" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="63.093319" y="183.657066" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="61.91063" y="183.191077" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="60.731408" y="182.717629" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="59.555653" y="182.236841" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="58.38336" y="181.748832" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="57.214522" y="181.253723" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="56.049128" y="180.751635" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="54.887166" y="180.242688" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="53.728621" y="179.727004" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="52.573473" y="179.204706" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="51.421704" y="178.675915" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="50.273288" y="178.140753" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="49.128202" y="177.599344" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="564.917616" y="177.05181" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="563.779101" y="176.498275" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="562.643824" y="175.93886" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="561.511752" y="175.373689" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="560.382846" y="174.802885" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="559.257068" y="174.226572" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="558.134377" y="173.644871" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="557.014732" y="173.057906" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="555.898086" y="172.4658" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="554.784395" y="171.868675" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="553.673609" y="171.266654" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="552.565679" y="170.659859" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="551.460555" y="170.048412" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="550.358182" y="169.432435" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="549.258506" y="168.81205" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="548.161473" y="168.187378" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="547.067024" y="167.558539" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="545.9751" y="166.925656" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="544.885643" y="166.288848" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="543.798591" y="165.648236" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="542.713882" y="165.00394" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="541.631452" y="164.35608" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="540.551237" y="163.704775" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="539.473172" y="163.050144" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="538.39719" y="162.392306" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="537.323224" y="161.731379" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="536.251206" y="161.067482" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="535.181066" y="160.400733" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="534.112734" y="159.731249" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="533.046141" y="159.059147" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="531.981214" y="158.384545" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="530.917882" y="157.70756" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="529.856071" y="157.028307" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="528.795709" y="156.346903" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="527.736721" y="155.663465" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="526.679033" y="154.978107" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="525.622571" y="154.290946" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="524.567259" y="153.602096" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="523.51302" y="152.911673" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="522.45978" y="152.219792" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="521.40746" y="151.526566" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="520.355985" y="150.832112" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="519.305277" y="150.136542" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="518.255259" y="149.439972" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="517.205852" y="148.742514" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="516.156979" y="148.044284" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="515.108562" y="147.345395" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="514.060522" y="146.645961" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="513.012781" y="145.946095" style="fill: #e0af68"/>
+    </g>
+    <g clip-path="url(#p05be3ac94f)">
+     <use xlink:href="#C0_0_9579c22793" x="511.965261" y="145.245911" style="fill: #e0af68"/>
+    </g>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_9">
+    <path d="M 571.049875 263.650745 
+L 583.016506 263.650745 
+L 583.016506 24.318125 
+L 571.049875 24.318125 
+L 571.049875 263.650745 
+z
+" style="fill: none"/>
+   </g>
+   <g id="patch_10">
+    <path clip-path="url(#pdfedda7f79)" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.01; stroke-linejoin: miter"/>
+   </g>
+   <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFNCAYAAADmVoTCAAAB9UlEQVR4nO2cwQ3EMAgEwef+G70ikn/iHxNphHABKzzsYie6S0bsfxTXqgpEROyMrItEEiLAjlRM6sUgTHYClTBgI351EWI7Oz1mG588l6fFUCUesAwTSYoZJquVT3YCM7Zfii1MRGbT+ARiQgwlohJiO9S01zDRBBBqMQB2XR6fWJg0CyAy2QifiJ53GCbEE3pqAuhhwoAVmU3DBHhFpmICVEK8Z4OYEC8wIZ+UNZhKqGdAQIRxLFAJxUQTQA0TUXYIEdNks4gAGiYmmhSrBjUgokkxNdkAkWZMiFHgGdQD9iMRislVF5kT8CBS15jJdhLRdEd1tQBSbHreIUQsQ2mvrHdnAvheVACJE5CoxDSoLbcCKMWWAGq2IzIbdFOSpJjyCXGgayrxmE2THdVQGiaPBQVQc7cXXUE1TIgjw3QrYFJsYaI50AfsQUQzHiEmy8NEImKa9kR3mjFBHDtMTpUQIgAVarIRIr2YBOMToBITE0AEMhsgQmxHFEBNd1RmQ/6HXq+kHRPGsZbf+EEBRMD2YoJ810LDRNNiKsUD9gsRiAmRnfHJZyLEV0eagWWmveW/b73M1o4J8tkfUQAl22lnNotPVGCHyWN5Di8TE0uLIRHNX8gvD5Mx21tE82k1TYs93YECyNwKJCL9zKZh0upW4AF7AzPBMzutgp3rAAAAAElFTkSuQmCC" id="image6c71f3574c" transform="scale(1 -1) translate(0 -239.76)" x="570.96" y="-23.76" width="12.24" height="239.76"/>
+   <g id="matplotlib.axis_3"/>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_8">
+     <g id="line2d_42">
+      <defs>
+       <path id="m13cb248cb8" d="M 0 0 
+L 3.5 0 
+" style="stroke: #565f89; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m13cb248cb8" x="583.016506" y="223.761975" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_33">
+      <!-- 0.2 -->
+      <g style="fill: #c0caf5" transform="translate(590.016506 226.421428) scale(0.07 -0.07)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-32" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#m13cb248cb8" x="583.016506" y="173.901013" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_34">
+      <!-- 0.4 -->
+      <g style="fill: #c0caf5" transform="translate(590.016506 176.560466) scale(0.07 -0.07)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-34" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m13cb248cb8" x="583.016506" y="124.04005" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_35">
+      <!-- 0.6 -->
+      <g style="fill: #c0caf5" transform="translate(590.016506 126.699503) scale(0.07 -0.07)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-36" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#m13cb248cb8" x="583.016506" y="74.179088" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_36">
+      <!-- 0.8 -->
+      <g style="fill: #c0caf5" transform="translate(590.016506 76.838541) scale(0.07 -0.07)">
+       <use xlink:href="#DejaVuSans-30"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-38" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m13cb248cb8" x="583.016506" y="24.318125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_37">
+      <!-- 1.0 -->
+      <g style="fill: #c0caf5" transform="translate(590.016506 26.977578) scale(0.07 -0.07)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="95.410156"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_38">
+     <!-- relative position probability (2021 MCMC) -->
+     <g style="fill: #c0caf5" transform="translate(611.227444 227.13006) rotate(-90) scale(0.08 -0.08)">
+      <defs>
        <path id="DejaVuSans-4d" d="M 628 4666 
 L 1569 4666 
 L 2759 1491 
@@ -3987,7 +4374,7 @@ z
     </g>
    </g>
    <g id="LineCollection_1"/>
-   <g id="patch_10">
+   <g id="patch_11">
     <path d="M 571.049875 263.650745 
 L 577.033191 263.650745 
 L 583.016506 263.650745 
@@ -4000,7 +4387,7 @@ z
    </g>
   </g>
   <g id="axes_3">
-   <g id="patch_11">
+   <g id="patch_12">
     <path d="M 48.761875 434.574125 
 L 584.441875 434.574125 
 L 584.441875 334.8522 
@@ -4009,134 +4396,134 @@ L 48.761875 434.574125
 z
 " style="fill: none"/>
    </g>
-   <g id="patch_12">
+   <g id="patch_13">
     <path d="M 73.110966 434.574125 
 L 99.599517 434.574125 
 L 99.599517 391.798721 
 L 73.110966 391.798721 
 z
-" clip-path="url(#p976f6006f4)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
-   <g id="patch_13">
+   <g id="patch_14">
     <path d="M 174.990007 434.574125 
 L 201.478558 434.574125 
 L 201.478558 387.866818 
 L 174.990007 387.866818 
 z
-" clip-path="url(#p976f6006f4)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
-   <g id="patch_14">
+   <g id="patch_15">
     <path d="M 276.869049 434.574125 
 L 303.3576 434.574125 
 L 303.3576 386.89458 
 L 276.869049 386.89458 
 z
-" clip-path="url(#p976f6006f4)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
-   <g id="patch_15">
+   <g id="patch_16">
     <path d="M 378.74809 434.574125 
 L 405.236641 434.574125 
 L 405.236641 388.01572 
 L 378.74809 388.01572 
 z
-" clip-path="url(#p976f6006f4)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
-   <g id="patch_16">
+   <g id="patch_17">
     <path d="M 480.627132 434.574125 
 L 507.115683 434.574125 
 L 507.115683 389.581304 
 L 480.627132 389.581304 
 z
-" clip-path="url(#p976f6006f4)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
-   <g id="patch_17">
+   <g id="patch_18">
     <path d="M 99.599517 434.574125 
 L 126.088067 434.574125 
 L 126.088067 432.58188 
 L 99.599517 432.58188 
 z
-" clip-path="url(#p976f6006f4)" style="fill: #bb9af7; opacity: 0.9"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: #bb9af7; opacity: 0.9"/>
    </g>
-   <g id="patch_18">
+   <g id="patch_19">
     <path d="M 201.478558 434.574125 
 L 227.967109 434.574125 
 L 227.967109 432.5797 
 L 201.478558 432.5797 
 z
-" clip-path="url(#p976f6006f4)" style="fill: #bb9af7; opacity: 0.9"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: #bb9af7; opacity: 0.9"/>
    </g>
-   <g id="patch_19">
+   <g id="patch_20">
     <path d="M 303.3576 434.574125 
 L 329.84615 434.574125 
 L 329.84615 432.579686 
 L 303.3576 432.579686 
 z
-" clip-path="url(#p976f6006f4)" style="fill: #bb9af7; opacity: 0.9"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: #bb9af7; opacity: 0.9"/>
    </g>
-   <g id="patch_20">
+   <g id="patch_21">
     <path d="M 405.236641 434.574125 
 L 431.725192 434.574125 
 L 431.725192 432.579686 
 L 405.236641 432.579686 
 z
-" clip-path="url(#p976f6006f4)" style="fill: #bb9af7; opacity: 0.9"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: #bb9af7; opacity: 0.9"/>
    </g>
-   <g id="patch_21">
+   <g id="patch_22">
     <path d="M 507.115683 434.574125 
 L 533.604233 434.574125 
 L 533.604233 432.579686 
 L 507.115683 432.579686 
 z
-" clip-path="url(#p976f6006f4)" style="fill: #bb9af7; opacity: 0.9"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: #bb9af7; opacity: 0.9"/>
    </g>
-   <g id="patch_22">
+   <g id="patch_23">
     <path d="M 126.088067 434.574125 
 L 152.576618 434.574125 
 L 152.576618 379.409751 
 L 126.088067 379.409751 
 z
-" clip-path="url(#p976f6006f4)" style="fill: #c0caf5; opacity: 0.9"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: #c0caf5; opacity: 0.9"/>
    </g>
-   <g id="patch_23">
+   <g id="patch_24">
     <path d="M 227.967109 434.574125 
 L 254.45566 434.574125 
 L 254.45566 374.307213 
 L 227.967109 374.307213 
 z
-" clip-path="url(#p976f6006f4)" style="fill: #c0caf5; opacity: 0.9"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: #c0caf5; opacity: 0.9"/>
    </g>
-   <g id="patch_24">
+   <g id="patch_25">
     <path d="M 329.84615 434.574125 
 L 356.334701 434.574125 
 L 356.334701 373.067702 
 L 329.84615 373.067702 
 z
-" clip-path="url(#p976f6006f4)" style="fill: #c0caf5; opacity: 0.9"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: #c0caf5; opacity: 0.9"/>
    </g>
-   <g id="patch_25">
+   <g id="patch_26">
     <path d="M 431.725192 434.574125 
 L 458.213743 434.574125 
 L 458.213743 373.434879 
 L 431.725192 373.434879 
 z
-" clip-path="url(#p976f6006f4)" style="fill: #c0caf5; opacity: 0.9"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: #c0caf5; opacity: 0.9"/>
    </g>
-   <g id="patch_26">
+   <g id="patch_27">
     <path d="M 533.604233 434.574125 
 L 560.092784 434.574125 
 L 560.092784 373.801124 
 L 533.604233 373.801124 
 z
-" clip-path="url(#p976f6006f4)" style="fill: #c0caf5; opacity: 0.9"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: #c0caf5; opacity: 0.9"/>
    </g>
    <g id="matplotlib.axis_5">
     <g id="xtick_14">
-     <g id="line2d_45">
+     <g id="line2d_47">
       <g>
-       <use xlink:href="#m9de694df24" x="112.843792" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="112.843792" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_37">
+     <g id="text_39">
       <!-- 2016 B&amp;B -->
       <g style="fill: #565f89" transform="translate(94.879357 454.968255) rotate(-12) scale(0.075 -0.075)">
        <use xlink:href="#DejaVuSans-32"/>
@@ -4151,12 +4538,12 @@ z
      </g>
     </g>
     <g id="xtick_15">
-     <g id="line2d_46">
+     <g id="line2d_48">
       <g>
-       <use xlink:href="#m9de694df24" x="214.722834" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="214.722834" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_38">
+     <g id="text_40">
       <!-- 2016 B&amp;B -->
       <g style="fill: #565f89" transform="translate(196.758398 454.968255) rotate(-12) scale(0.075 -0.075)">
        <use xlink:href="#DejaVuSans-32"/>
@@ -4171,12 +4558,12 @@ z
      </g>
     </g>
     <g id="xtick_16">
-     <g id="line2d_47">
+     <g id="line2d_49">
       <g>
-       <use xlink:href="#m9de694df24" x="316.601875" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="316.601875" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_39">
+     <g id="text_41">
       <!-- 2019 Batygin+ -->
       <g style="fill: #565f89" transform="translate(289.411712 458.890233) rotate(-12) scale(0.075 -0.075)">
        <use xlink:href="#DejaVuSans-32"/>
@@ -4196,12 +4583,12 @@ z
      </g>
     </g>
     <g id="xtick_17">
-     <g id="line2d_48">
+     <g id="line2d_50">
       <g>
-       <use xlink:href="#m9de694df24" x="418.480916" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="418.480916" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_40">
+     <g id="text_42">
       <!-- 2021 Brown &amp; Batygin -->
       <g style="fill: #565f89" transform="translate(377.661642 464.684147) rotate(-12) scale(0.075 -0.075)">
        <use xlink:href="#DejaVuSans-32"/>
@@ -4228,12 +4615,12 @@ z
      </g>
     </g>
     <g id="xtick_18">
-     <g id="line2d_49">
+     <g id="line2d_51">
       <g>
-       <use xlink:href="#m9de694df24" x="520.359958" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m0bdc7879fd" x="520.359958" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_41">
+     <g id="text_43">
       <!-- 2024 Siraj+ -->
       <g style="fill: #565f89" transform="translate(499.093128 456.372146) rotate(-12) scale(0.075 -0.075)">
        <use xlink:href="#DejaVuSans-32"/>
@@ -4253,17 +4640,17 @@ z
    </g>
    <g id="matplotlib.axis_6">
     <g id="ytick_13">
-     <g id="line2d_50">
+     <g id="line2d_52">
       <path d="M 48.761875 434.574125 
 L 584.441875 434.574125 
-" clip-path="url(#p976f6006f4)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_51">
+     <g id="line2d_53">
       <g>
-       <use xlink:href="#me86f7f4261" x="48.761875" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m397f7840c7" x="48.761875" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_42">
+     <g id="text_44">
       <!-- 0 -->
       <g style="fill: #c0caf5" transform="translate(37.308125 437.233578) scale(0.07 -0.07)">
        <use xlink:href="#DejaVuSans-30"/>
@@ -4271,17 +4658,17 @@ L 584.441875 434.574125
      </g>
     </g>
     <g id="ytick_14">
-     <g id="line2d_52">
+     <g id="line2d_54">
       <path d="M 48.761875 409.643644 
 L 584.441875 409.643644 
-" clip-path="url(#p976f6006f4)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_53">
+     <g id="line2d_55">
       <g>
-       <use xlink:href="#me86f7f4261" x="48.761875" y="409.643644" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m397f7840c7" x="48.761875" y="409.643644" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_43">
+     <g id="text_45">
       <!-- 25 -->
       <g style="fill: #c0caf5" transform="translate(32.854375 412.303097) scale(0.07 -0.07)">
        <use xlink:href="#DejaVuSans-32"/>
@@ -4290,17 +4677,17 @@ L 584.441875 409.643644
      </g>
     </g>
     <g id="ytick_15">
-     <g id="line2d_54">
+     <g id="line2d_56">
       <path d="M 48.761875 384.713162 
 L 584.441875 384.713162 
-" clip-path="url(#p976f6006f4)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_55">
+     <g id="line2d_57">
       <g>
-       <use xlink:href="#me86f7f4261" x="48.761875" y="384.713162" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m397f7840c7" x="48.761875" y="384.713162" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_44">
+     <g id="text_46">
       <!-- 50 -->
       <g style="fill: #c0caf5" transform="translate(32.854375 387.372616) scale(0.07 -0.07)">
        <use xlink:href="#DejaVuSans-35"/>
@@ -4309,17 +4696,17 @@ L 584.441875 384.713162
      </g>
     </g>
     <g id="ytick_16">
-     <g id="line2d_56">
+     <g id="line2d_58">
       <path d="M 48.761875 359.782681 
 L 584.441875 359.782681 
-" clip-path="url(#p976f6006f4)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_57">
+     <g id="line2d_59">
       <g>
-       <use xlink:href="#me86f7f4261" x="48.761875" y="359.782681" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m397f7840c7" x="48.761875" y="359.782681" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_45">
+     <g id="text_47">
       <!-- 75 -->
       <g style="fill: #c0caf5" transform="translate(32.854375 362.442134) scale(0.07 -0.07)">
        <use xlink:href="#DejaVuSans-37"/>
@@ -4328,17 +4715,17 @@ L 584.441875 359.782681
      </g>
     </g>
     <g id="ytick_17">
-     <g id="line2d_58">
+     <g id="line2d_60">
       <path d="M 48.761875 334.8522 
 L 584.441875 334.8522 
-" clip-path="url(#p976f6006f4)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p575e9fbfc9)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
-     <g id="line2d_59">
+     <g id="line2d_61">
       <g>
-       <use xlink:href="#me86f7f4261" x="48.761875" y="334.8522" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m397f7840c7" x="48.761875" y="334.8522" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
-     <g id="text_46">
+     <g id="text_48">
       <!-- 100 -->
       <g style="fill: #c0caf5" transform="translate(28.400625 337.511653) scale(0.07 -0.07)">
        <use xlink:href="#DejaVuSans-31"/>
@@ -4347,7 +4734,7 @@ L 584.441875 334.8522
       </g>
      </g>
     </g>
-    <g id="text_47">
+    <g id="text_49">
      <!-- P(detect) [%] -->
      <g style="fill: #c0caf5" transform="translate(22.528906 414.552381) rotate(-90) scale(0.09 -0.09)">
       <defs>
@@ -4437,27 +4824,27 @@ z
      </g>
     </g>
    </g>
-   <g id="patch_27">
+   <g id="patch_28">
     <path d="M 48.761875 434.574125 
 L 48.761875 334.8522 
 " style="fill: none; stroke: #565f89; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_28">
+   <g id="patch_29">
     <path d="M 584.441875 434.574125 
 L 584.441875 334.8522 
 " style="fill: none; stroke: #565f89; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_29">
+   <g id="patch_30">
     <path d="M 48.761875 434.574125 
 L 584.441875 434.574125 
 " style="fill: none; stroke: #565f89; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_30">
+   <g id="patch_31">
     <path d="M 48.761875 334.8522 
 L 584.441875 334.8522 
 " style="fill: none; stroke: #565f89; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="text_48">
+   <g id="text_50">
     <!-- Can a survey catch it? Detection probability = P(in footprint AND brighter than depth) -->
     <g style="fill: #c0caf5" transform="translate(90.68207 328.8522) scale(0.105 -0.105)">
      <defs>
@@ -4472,27 +4859,6 @@ L 4684 1631
 L 4684 1100 
 L 678 1100 
 L 678 1631 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-66" d="M 2375 4863 
-L 2375 4384 
-L 1825 4384 
-Q 1516 4384 1395 4259 
-Q 1275 4134 1275 3809 
-L 1275 3500 
-L 2222 3500 
-L 2222 3053 
-L 1275 3053 
-L 1275 0 
-L 697 0 
-L 697 3053 
-L 147 3053 
-L 147 3500 
-L 697 3500 
-L 697 3744 
-Q 697 4328 969 4595 
-Q 1241 4863 1831 4863 
-L 2375 4863 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-4e" d="M 628 4666 
@@ -4598,7 +4964,7 @@ z
     </g>
    </g>
    <g id="legend_2">
-    <g id="patch_31">
+    <g id="patch_32">
      <path d="M 440.837875 372.31695 
 L 579.401875 372.31695 
 Q 580.841875 372.31695 580.841875 370.87695 
@@ -4612,7 +4978,7 @@ L 440.837875 372.31695
 z
 " style="fill: none; opacity: 0"/>
     </g>
-    <g id="patch_32">
+    <g id="patch_33">
      <path d="M 442.277875 346.803075 
 L 456.677875 346.803075 
 L 456.677875 341.763075 
@@ -4620,7 +4986,7 @@ L 442.277875 341.763075
 z
 " style="fill: #7dcfff; opacity: 0.9"/>
     </g>
-    <g id="text_49">
+    <g id="text_51">
      <!-- Rubin / LSST (m&lt;24.5) -->
      <g style="fill: #c0caf5" transform="translate(462.437875 346.803075) scale(0.072 -0.072)">
       <defs>
@@ -4674,7 +5040,7 @@ z
       <use xlink:href="#DejaVuSans-29" x="1098.673828"/>
      </g>
     </g>
-    <g id="patch_33">
+    <g id="patch_34">
      <path d="M 442.277875 357.371325 
 L 456.677875 357.371325 
 L 456.677875 352.331325 
@@ -4682,7 +5048,7 @@ L 442.277875 352.331325
 z
 " style="fill: #bb9af7; opacity: 0.9"/>
     </g>
-    <g id="text_50">
+    <g id="text_52">
      <!-- Roman (m&lt;26.0) -->
      <g style="fill: #c0caf5" transform="translate(462.437875 357.371325) scale(0.072 -0.072)">
       <use xlink:href="#DejaVuSans-52"/>
@@ -4701,7 +5067,7 @@ z
       <use xlink:href="#DejaVuSans-29" x="822.892578"/>
      </g>
     </g>
-    <g id="patch_34">
+    <g id="patch_35">
      <path d="M 442.277875 367.939575 
 L 456.677875 367.939575 
 L 456.677875 362.899575 
@@ -4709,24 +5075,9 @@ L 442.277875 362.899575
 z
 " style="fill: #c0caf5; opacity: 0.9"/>
     </g>
-    <g id="text_51">
+    <g id="text_53">
      <!-- JBT 0.5 m + SPENCER (m&lt;24.5) -->
      <g style="fill: #c0caf5" transform="translate(462.437875 367.939575) scale(0.072 -0.072)">
-      <defs>
-       <path id="DejaVuSans-4a" d="M 628 4666 
-L 1259 4666 
-L 1259 325 
-Q 1259 -519 939 -900 
-Q 619 -1281 -91 -1281 
-L -331 -1281 
-L -331 -750 
-L -134 -750 
-Q 284 -750 456 -515 
-Q 628 -281 628 325 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-      </defs>
       <use xlink:href="#DejaVuSans-4a"/>
       <use xlink:href="#DejaVuSans-42" x="29.492188"/>
       <use xlink:href="#DejaVuSans-54" x="98.095703"/>
@@ -4761,13 +5112,13 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pbca7bb30fa">
+  <clipPath id="p05be3ac94f">
    <rect x="48.761875" y="24.318125" width="516.9312" height="239.33262"/>
   </clipPath>
-  <clipPath id="p8e4e78cf92">
+  <clipPath id="pdfedda7f79">
    <rect x="571.049875" y="24.318125" width="11.966631" height="239.33262"/>
   </clipPath>
-  <clipPath id="p976f6006f4">
+  <clipPath id="p575e9fbfc9">
    <rect x="48.761875" y="334.8522" width="535.68" height="99.721925"/>
   </clipPath>
  </defs>

--- a/crates/p9-survey/src/bin/refine.rs
+++ b/crates/p9-survey/src/bin/refine.rs
@@ -1,11 +1,14 @@
-//! Refine JBT/SPENCER's target: cede Rubin's southern sky and remove what ZTF,
-//! Pan-STARRS and DES have already covered deep enough, then re-run the 4-day
-//! observing plan on the residual.
+//! Refine JBT/SPENCER's target: cede Rubin's southern sky, remove what ZTF,
+//! Pan-STARRS and DES have already covered (real footprints + plane depth
+//! degradation), and fold in the Cassini/Iorio ephemeris favored-ν phase
+//! prior. Then re-run the 4-day observing plan on the residual.
 //!
 //! Usage: cargo run -p p9-survey --bin refine -- [--hours H] [--duty D]
 
+use p9_survey::ephemeris::nu_weight;
 use p9_survey::plan::{capture, TimeBudget};
-use p9_survey::refine::{prior_surveys, refine, residual_mass, RUBIN_DEC_MAX_DEG};
+use p9_survey::refine::{prior_surveys, refine, RUBIN_DEC_MAX_DEG};
+use p9_survey::skymap::ephemeris_weighted_grid;
 use p9_survey::{default_grid, run_survey};
 
 fn main() {
@@ -33,61 +36,85 @@ fn main() {
         fov_deg2: 0.32,
     };
     let area = budget.area_deg2();
+    let (nu_lo, nu_hi) = (
+        d.constraints.favored_nu_lo_deg,
+        d.constraints.favored_nu_hi_deg,
+    );
+    let arc_dec_lo = d
+        .constraints
+        .favored_arc
+        .iter()
+        .map(|p| p[1])
+        .fold(f64::MAX, f64::min);
+    let arc_dec_hi = d
+        .constraints
+        .favored_arc
+        .iter()
+        .map(|p| p[1])
+        .fold(f64::MIN, f64::max);
 
     println!(
-        "Refined JBT target — cede Rubin (Dec ≤ {:+.0}°), survive ZTF/PS1/DES.\n\
-         {hours:.0} h / duty {:.0}% → coverable area ≈ {area:.0} deg² (wide-shallow, depth ~V24).\n",
-        RUBIN_DEC_MAX_DEG,
-        duty * 100.0,
+        "Refined JBT target — cede Rubin (Dec ≤ {:+.0}°) + ZTF/PS1/DES survival + Cassini ν∈[{:.0},{:.0}]°.\n\
+         {hours:.0} h / duty {:.0}% → coverable area ≈ {area:.0} deg² (wide-shallow, depth ~V24).\n\
+         NOTE: the Cassini favored-ν arc lands at Dec {:+.0}…{:+.0}° — {} Rubin's +12° line, so the\n\
+         ephemeris phase prior and the Rubin-cede pull against each other (see resid+eph below).\n",
+        RUBIN_DEC_MAX_DEG, nu_lo, nu_hi, duty * 100.0, arc_dec_lo, arc_dec_hi,
+        if arc_dec_hi <= RUBIN_DEC_MAX_DEG { "entirely south of" } else { "straddling" },
     );
     println!(
-        "  {:30} {:>6}  {:>9}  {:>9}  {:>10}   {}",
-        "solution (source V)", "rawcap", "residual", "JBT 4-day", "vs raw", "residual field"
+        "  {:26} {:>9} {:>9}   {:>8} {:>8}   {}",
+        "solution (V)", "resid R+S", "resid+eph", "4d R+S", "4d+eph", "ephemeris-cut field"
     );
-    println!("  {}", "-".repeat(98));
+    println!("  {}", "-".repeat(96));
 
     for s in &d.studies {
         let v = s.v_median;
-        let raw_cap = capture(&s.prob, &grid, area).captured_prob; // full prior, no cuts
-        let resid = residual_mass(&s.prob, &grid, v, &surveys); // JBT's niche size
-        let refined = refine(&s.prob, &grid, v, &surveys);
-        let cov = capture(&refined, &grid, area); // 4-day reach on the residual
-        let gain = if raw_cap > 0.0 {
-            cov.captured_prob / raw_cap
-        } else {
-            0.0
-        };
-        let field = if cov.captured_prob > 1e-4 {
+
+        // (a) Rubin-cede + survey survival on the uniform-phase prior.
+        let refined_rs = refine(&s.prob, &grid, v, &surveys);
+        let resid_rs: f64 = refined_rs.iter().sum();
+        let cov_rs = capture(&refined_rs, &grid, area);
+
+        // (b) Same, but on the ephemeris-phase-weighted prior.
+        let ephem = ephemeris_weighted_grid(&s.solution, &grid, 200_000, 4242, &nu_weight);
+        let refined_eph = refine(&ephem, &grid, v, &surveys);
+        let resid_eph: f64 = refined_eph.iter().sum();
+        let cov_eph = capture(&refined_eph, &grid, area);
+
+        let field = if cov_eph.captured_prob > 1e-4 {
             format!(
                 "RA {:.1}–{:.1}h Dec {:+.0}…{:+.0}°",
-                cov.ra_lo_deg / 15.0,
-                cov.ra_hi_deg / 15.0,
-                cov.dec_lo_deg,
-                cov.dec_hi_deg
+                cov_eph.ra_lo_deg / 15.0,
+                cov_eph.ra_hi_deg / 15.0,
+                cov_eph.dec_lo_deg,
+                cov_eph.dec_hi_deg
             )
         } else {
-            "(little left — others cover it)".to_string()
+            "(little left)".to_string()
         };
+        let _ = cov_rs;
         println!(
-            "  {:30} {:5.1}%  {:8.1}%  {:8.1}%  {:9.2}×   {}",
+            "  {:26} {:8.1}% {:8.1}%   {:7.1}% {:7.1}%   {}",
             format!(
-                "{} (V{:.1})",
+                "{} V{:.1}",
                 s.solution.name.split('(').next().unwrap().trim(),
                 v
             ),
-            100.0 * raw_cap,
-            100.0 * resid,
-            100.0 * cov.captured_prob,
-            gain,
+            100.0 * resid_rs,
+            100.0 * resid_eph,
+            100.0 * cov_rs.captured_prob,
+            100.0 * cov_eph.captured_prob,
             field,
         );
     }
 
     println!(
-        "\n  rawcap   = fraction of the full prior JBT could cover in 4 days (no cuts)\n  \
-         residual = prior mass left for JBT after Rubin-cede + ZTF/PS1/DES survival (its niche)\n  \
-         JBT 4-day= fraction actually caught in 4 days pointed at the residual\n  \
-         Read-off: bright/close solutions → tiny residual (Rubin+ZTF+PS1 mop them up);\n  \
-         faint/distant solutions → JBT owns the deep northern sky nobody else reaches."
+        "\n  resid R+S  = prior mass left after Rubin-cede + ZTF/PS1/DES survival\n  \
+         resid+eph  = …and after the Cassini favored-ν phase prior\n  \
+         4d R+S / 4d+eph = fraction caught in 4 days, without / with the ν cut\n  \
+         Result: the Cassini favored-ν zone sits SOUTH of +12° — in Rubin's sky — so the\n  \
+         ν prior and the Rubin-cede oppose each other: folding it in *shrinks* JBT's residual\n  \
+         (4d+eph < 4d R+S). Read another way, the ν prior says 'if Cassini is right, let Rubin\n  \
+         have it'; JBT's northern niche is the case where the (weak) Cassini fit does NOT hold."
     );
 }

--- a/crates/p9-survey/src/ephemeris.rs
+++ b/crates/p9-survey/src/ephemeris.rs
@@ -1,0 +1,104 @@
+//! Ephemeris constraint on Planet Nine's *current orbital phase*.
+//!
+//! Cassini Earth–Saturn range residuals (Fienga et al. 2016) and Saturn-
+//! precession bounds (Iorio 2026) favor P9 being near true anomaly
+//! ν ≈ 108–129° on the Brown & Batygin orbit right now (and disfavor large
+//! complementary arcs). That is a statement about *where on its orbit* P9 sits
+//! today — i.e. a prior on the current true anomaly — which directly cuts the
+//! sky RA range, not just the declination.
+//!
+//! The favored interval and tolerance are sourced from the reproduction crate
+//! `p9_2016_cassini_ranging::published`; here we turn them into (1) a smooth
+//! ν-weight to reweight the otherwise-uniform orbital phase, and (2) the
+//! favored-ν sky arc for plotting.
+
+use nalgebra::Vector3;
+use p9_2016_cassini_ranging::geometry::p9_position_at_true_anomaly;
+use p9_2016_cassini_ranging::published::{FAVORED_INTERVAL_DEG, TRUE_ANOMALY_TOLERANCE_DEG};
+use p9_core::constants::DEG2RAD;
+use p9_core::coords::sky::ecliptic_vec_to_equatorial_deg;
+use p9_core::types::P9Params;
+
+/// Favored true-anomaly interval (deg), from Fienga et al. 2016 via the
+/// cassini-ranging crate.
+pub fn favored_interval_deg() -> (f64, f64) {
+    FAVORED_INTERVAL_DEG
+}
+
+/// 1σ tolerance (deg) on the favored interval edges.
+pub fn tolerance_deg() -> f64 {
+    TRUE_ANOMALY_TOLERANCE_DEG / 2.0
+}
+
+/// Smallest absolute angular separation (deg) of `nu_deg` from the interval
+/// `[lo, hi]` on the circle.
+fn distance_to_interval(nu_deg: f64, lo: f64, hi: f64) -> f64 {
+    let n = nu_deg.rem_euclid(360.0);
+    if n >= lo && n <= hi {
+        return 0.0;
+    }
+    let d1 = ((n - lo + 540.0).rem_euclid(360.0) - 180.0).abs();
+    let d2 = ((n - hi + 540.0).rem_euclid(360.0) - 180.0).abs();
+    d1.min(d2)
+}
+
+/// Ephemeris weight in [0, 1] for a sample at true anomaly `nu_deg`: flat at 1
+/// inside the favored interval, Gaussian wings outside with σ = [`tolerance_deg`].
+pub fn nu_weight(nu_deg: f64) -> f64 {
+    let (lo, hi) = favored_interval_deg();
+    let d = distance_to_interval(nu_deg, lo, hi);
+    if d == 0.0 {
+        1.0
+    } else {
+        let sigma = tolerance_deg().max(1.0);
+        (-0.5 * (d / sigma).powi(2)).exp()
+    }
+}
+
+/// Sky arc (RA, Dec in deg) traced by the favored-ν zone (interval ± tolerance)
+/// on a given orbit — for plotting the "ephemeris says here" band.
+pub fn favored_arc(orbit: &P9Params, n: usize) -> Vec<[f64; 2]> {
+    let (lo, hi) = favored_interval_deg();
+    let tol = tolerance_deg();
+    let (a, b) = (lo - tol, hi + tol);
+    (0..n)
+        .map(|k| {
+            let nu = (a + (b - a) * k as f64 / (n.max(2) - 1) as f64) * DEG2RAD;
+            let pos: Vector3<f64> = p9_position_at_true_anomaly(orbit, nu).position;
+            let (ra, dec) = ecliptic_vec_to_equatorial_deg(&pos);
+            [ra, dec]
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn weight_peaks_in_favored_interval() {
+        let (lo, hi) = favored_interval_deg();
+        assert_eq!(nu_weight((lo + hi) / 2.0), 1.0);
+        assert_eq!(nu_weight(lo), 1.0);
+        // Aphelion (180°) is outside the favored zone → suppressed.
+        assert!(nu_weight(180.0) < 0.5);
+        // The opposite side of the orbit is strongly suppressed.
+        assert!(nu_weight(300.0) < 0.05);
+    }
+
+    #[test]
+    fn distance_wraps_on_circle() {
+        // 350° is 11° from 1°-edge interval... sanity on wrap.
+        assert!((distance_to_interval(350.0, 0.0, 10.0) - 10.0).abs() < 1e-9);
+        assert_eq!(distance_to_interval(5.0, 0.0, 10.0), 0.0);
+    }
+
+    #[test]
+    fn favored_arc_is_on_sky() {
+        let arc = favored_arc(&P9Params::mcmc_2021(), 16);
+        assert_eq!(arc.len(), 16);
+        for p in &arc {
+            assert!((0.0..=360.0).contains(&p[0]) && (-90.0..=90.0).contains(&p[1]));
+        }
+    }
+}

--- a/crates/p9-survey/src/lib.rs
+++ b/crates/p9-survey/src/lib.rs
@@ -15,6 +15,7 @@
 //! rendering of numerical outputs of the reproduced papers — nothing is drawn
 //! that the Rust side did not compute.
 
+pub mod ephemeris;
 pub mod parallax;
 pub mod plan;
 pub mod refine;
@@ -23,7 +24,7 @@ pub mod skymap;
 pub mod studies;
 pub mod telescope;
 
-use schema::{SkyGrid, SurveyDataset, TelescopeResult, SCHEMA_VERSION};
+use schema::{Constraints, SkyGrid, SurveyDataset, TelescopeResult, SCHEMA_VERSION};
 
 /// The fixed RA/Dec grid used for every probability map: full RA, ±60° Dec, 3°
 /// cells (P9's declination never leaves this band for any surveyed solution).
@@ -71,6 +72,14 @@ pub fn run_survey(n_samples: usize, seed: u64) -> SurveyDataset {
         })
         .collect();
 
+    let (nu_lo, nu_hi) = ephemeris::favored_interval_deg();
+    let constraints = Constraints {
+        rubin_dec_max_deg: refine::RUBIN_DEC_MAX_DEG,
+        favored_nu_lo_deg: nu_lo,
+        favored_nu_hi_deg: nu_hi,
+        favored_arc: ephemeris::favored_arc(&p9_core::types::P9Params::mcmc_2021(), 64),
+    };
+
     SurveyDataset {
         schema_version: SCHEMA_VERSION,
         generated_by: "p9-survey".to_string(),
@@ -80,6 +89,7 @@ pub fn run_survey(n_samples: usize, seed: u64) -> SurveyDataset {
         studies: studies_out,
         telescopes: telescopes_out,
         overlays: skymap::overlays(360),
+        constraints,
     }
 }
 

--- a/crates/p9-survey/src/refine.rs
+++ b/crates/p9-survey/src/refine.rs
@@ -2,30 +2,33 @@
 //! have already effectively covered — so JBT/SPENCER is pointed only where it
 //! adds something new.
 //!
-//! Two cuts:
+//! Three cuts (the third optional):
 //!
 //! 1. **Cede Rubin's sky.** Rubin/LSST will survey the south to r≈24.5 (deeper
-//!    than any plausible P9). Assume it gets anything it can reach, so drop all
-//!    cells with Dec ≤ its northern limit (~+12°).
+//!    than any plausible P9). Drop all cells with Dec ≤ its northern limit
+//!    (~+12°).
 //!
-//! 2. **Survive prior optical surveys.** ZTF (r≈20.5) and Pan-STARRS (r≈21.5)
-//!    have already imaged the northern sky; DES (r≈23.8) the south. If a survey
-//!    covered a cell to a depth fainter than the source would be there, a P9
-//!    would already have been found — so that cell survives only with
-//!    probability `1 − coverage`. The product over surveys is the chance P9 is
-//!    *still* there and *un-found*.
+//! 2. **Survive prior optical surveys — with real footprints, not dec bands.**
+//!    ZTF (Dec ≳ −31°) and Pan-STARRS 3π (Dec ≳ −30°) cover the whole northern
+//!    sky *including the galactic plane*; DES covers a ~5000 deg² South-
+//!    Galactic-Cap polygon. Crucially the plane is **not a hole** — the surveys
+//!    imaged it, just shallower (crowding + extinction), so a survey's
+//!    *effective depth* and *completeness* degrade toward |b|→0. A cell
+//!    survives a survey with probability `1 − coverage(b)` only if the source
+//!    is brighter than that survey's effective depth there. The product over
+//!    surveys is the chance P9 is still there and un-found — so a faint P9 in
+//!    the plane survives because the surveys are *shallow* there, not absent.
 //!
-//! The crucial consequence: a **bright** P9 (the close 2021/2024 solutions,
-//! V≈19) in the north is mostly excluded by ZTF/PS1 already, so JBT adds little
-//! there. JBT's unique value is a **faint/distant** P9 (V≳22, the wide 2016-era
-//! solutions) in the north — fainter than ZTF/PS1 and out of Rubin's reach: a
-//! region nothing else covers deep enough.
+//! 3. **Ephemeris phase prior** (applied upstream, in `skymap`): see
+//!    [`crate::ephemeris`] — concentrates the prior onto the Cassini/Iorio
+//!    favored-ν sky arc, cutting the RA range.
 //!
-//! Survey footprints/depths reuse `p9_core::analysis::surveys`; the refined map
-//! is intentionally *not* renormalized — its sum is the residual probability
-//! mass that is genuinely JBT's to chase.
+//! The plane depth/coverage degradation is a documented parametric stand-in for
+//! each survey's true crowding/extinction map; the footprint *boundaries* are
+//! the real survey limits. The refined map is left un-normalized — its sum is
+//! the residual probability mass genuinely left for JBT.
 
-use crate::schema::{Footprint, SkyGrid};
+use crate::schema::SkyGrid;
 use p9_core::analysis::surveys::limiting_magnitude;
 use p9_core::constants::DEG2RAD;
 use p9_core::coords::sky::equatorial_to_galactic_matrix;
@@ -33,49 +36,92 @@ use p9_core::coords::sky::equatorial_to_galactic_matrix;
 /// Rubin/LSST northern survey limit (deg); cells at or below are ceded.
 pub const RUBIN_DEC_MAX_DEG: f64 = 12.0;
 
-/// A survey that has already observed part of the sky, with the depth it
-/// reached and how completely it covered its footprint.
+/// Galactic-latitude scale over which plane crowding/extinction bites (deg).
+const PLANE_B_SCALE_DEG: f64 = 8.0;
+
+/// Footprint shape of a prior survey.
+#[derive(Debug, Clone, Copy)]
+pub enum Footprint {
+    /// Everything north of a declination limit (ground survey from the north).
+    NorthOf(f64),
+    /// The DES South-Galactic-Cap region: Dec ∈ [−68, +5], RA in the SGC
+    /// longitudes, |b| ≥ 18°.
+    DesSgc,
+}
+
+impl Footprint {
+    fn covers(&self, _ra_deg: f64, dec_deg: f64, gal_b_deg: f64) -> bool {
+        match self {
+            Footprint::NorthOf(dmin) => dec_deg >= *dmin,
+            Footprint::DesSgc => {
+                let ra = _ra_deg.rem_euclid(360.0);
+                (-68.0..=5.0).contains(&dec_deg)
+                    && (ra <= 100.0 || ra >= 300.0)
+                    && gal_b_deg.abs() >= 18.0
+            }
+        }
+    }
+}
+
+/// A survey that has already observed part of the sky, with the depth and
+/// completeness it reached in clean (high-|b|) sky, degraded toward the plane.
 #[derive(Debug, Clone)]
 pub struct PriorSurvey {
     pub name: &'static str,
     pub footprint: Footprint,
-    pub limiting_mag: f64,
+    /// Limiting magnitude away from the galactic plane.
+    pub clean_depth: f64,
+    /// Completeness fraction away from the plane.
+    pub clean_coverage: f64,
+    /// Magnitudes of depth lost at b = 0 (crowding + extinction).
+    pub plane_depth_penalty: f64,
+    /// Fraction of completeness lost at b = 0.
+    pub plane_cov_loss: f64,
+}
+
+impl PriorSurvey {
+    /// 1 at the plane, →0 away from it.
+    fn plane_factor(gal_b_deg: f64) -> f64 {
+        (-0.5 * (gal_b_deg / PLANE_B_SCALE_DEG).powi(2)).exp()
+    }
+    pub fn effective_depth(&self, gal_b_deg: f64) -> f64 {
+        self.clean_depth - self.plane_depth_penalty * Self::plane_factor(gal_b_deg)
+    }
+    pub fn coverage(&self, gal_b_deg: f64) -> f64 {
+        self.clean_coverage * (1.0 - self.plane_cov_loss * Self::plane_factor(gal_b_deg))
+    }
 }
 
 /// The optical surveys whose non-detections constrain P9's current sky cell.
 /// (WISE is omitted: a cold P9's thermal flux at W1 is negligible — see
-/// `p9-2018-wise-search` — so it excludes essentially nothing here.)
+/// `p9-2018-wise-search`.)
 pub fn prior_surveys() -> Vec<PriorSurvey> {
     vec![
         PriorSurvey {
             name: "ZTF",
-            footprint: Footprint {
-                dec_min_deg: -30.0,
-                dec_max_deg: 90.0,
-                galactic_lat_min_deg: 10.0,
-                coverage_fraction: 0.70,
-            },
-            limiting_mag: limiting_magnitude("ZTF").unwrap_or(20.5),
+            footprint: Footprint::NorthOf(-31.0),
+            clean_depth: limiting_magnitude("ZTF").unwrap_or(20.5),
+            clean_coverage: 0.70,
+            plane_depth_penalty: 2.5,
+            plane_cov_loss: 0.5,
         },
         PriorSurvey {
             name: "PS1 3pi",
-            footprint: Footprint {
-                dec_min_deg: -30.0,
-                dec_max_deg: 90.0,
-                galactic_lat_min_deg: 10.0,
-                coverage_fraction: 0.75,
-            },
-            limiting_mag: limiting_magnitude("PS1 3pi").unwrap_or(21.5),
+            footprint: Footprint::NorthOf(-30.0),
+            clean_depth: limiting_magnitude("PS1 3pi").unwrap_or(21.5),
+            clean_coverage: 0.75,
+            plane_depth_penalty: 2.5,
+            plane_cov_loss: 0.5,
         },
         PriorSurvey {
             name: "DES",
-            footprint: Footprint {
-                dec_min_deg: -70.0,
-                dec_max_deg: 5.0,
-                galactic_lat_min_deg: 0.0,
-                coverage_fraction: 0.30,
-            },
-            limiting_mag: limiting_magnitude("DES").unwrap_or(23.8),
+            footprint: Footprint::DesSgc,
+            clean_depth: limiting_magnitude("DES").unwrap_or(23.8),
+            clean_coverage: 0.60,
+            // The DES footprint is high-|b| by construction, so plane terms
+            // never engage; keep them zero.
+            plane_depth_penalty: 0.0,
+            plane_cov_loss: 0.0,
         },
     ]
 }
@@ -89,16 +135,14 @@ pub fn galactic_latitude_deg(ra_deg: f64, dec_deg: f64) -> f64 {
 }
 
 /// Probability a source of magnitude `v` at (`ra`,`dec`) is still un-found by
-/// the prior surveys: ∏ (1 − coverage) over surveys that cover the cell to a
-/// depth fainter than `v`.
+/// the prior surveys: ∏ (1 − coverage(b)) over surveys that cover the cell to
+/// an effective depth fainter than `v`.
 pub fn survival_probability(v: f64, ra_deg: f64, dec_deg: f64, surveys: &[PriorSurvey]) -> f64 {
     let gal_b = galactic_latitude_deg(ra_deg, dec_deg);
     let mut s = 1.0;
     for sv in surveys {
-        let covered = sv.footprint.accepts(dec_deg, gal_b);
-        let detectable = v <= sv.limiting_mag;
-        if covered && detectable {
-            s *= 1.0 - sv.footprint.coverage_fraction;
+        if sv.footprint.covers(ra_deg, dec_deg, gal_b) && v <= sv.effective_depth(gal_b) {
+            s *= 1.0 - sv.coverage(gal_b);
         }
     }
     s
@@ -138,16 +182,35 @@ mod tests {
     use crate::{default_grid, run_survey};
 
     #[test]
+    fn plane_is_shallower_than_clean_sky() {
+        let s = &prior_surveys()[0]; // ZTF
+        let clean = s.effective_depth(40.0);
+        let plane = s.effective_depth(0.0);
+        assert!((clean - 20.5).abs() < 0.05, "clean = {clean}");
+        assert!(plane < clean - 2.0, "plane depth {plane} not shallower");
+        assert!(s.coverage(0.0) < s.coverage(40.0));
+    }
+
+    #[test]
     fn faint_source_survives_shallow_surveys() {
         let s = prior_surveys();
-        // A V=22.7 source in the northern ZTF/PS1 sky: fainter than both
-        // (20.5, 21.5) → not excluded by them → survives fully.
-        let surv = survival_probability(22.7, 60.0, 20.0, &s);
-        assert!(surv > 0.99, "faint north survival = {surv}");
-        // A bright V=19.6 source in the same cell IS within ZTF+PS1 depth →
-        // heavily suppressed.
-        let bright = survival_probability(19.6, 60.0, 20.0, &s);
-        assert!(bright < 0.1, "bright north survival = {bright}");
+        // A V=22.7 source off the plane in the northern ZTF/PS1 sky: fainter
+        // than both clean depths (20.5, 21.5) → not excluded → survives.
+        let surv = survival_probability(22.7, 60.0, 25.0, &s);
+        assert!(surv > 0.99, "faint clean-north survival = {surv}");
+        // A bright V=19.6 source there IS within ZTF+PS1 depth → suppressed.
+        let bright = survival_probability(19.6, 60.0, 25.0, &s);
+        assert!(bright < 0.1, "bright clean-north survival = {bright}");
+        // The SAME bright source in the galactic plane survives better, because
+        // ZTF/PS1 are shallow & incomplete there (crowding) — the new physics.
+        let bright_plane = survival_probability(19.6, 82.0, 20.0, &s);
+        let b_here = galactic_latitude_deg(82.0, 20.0);
+        if b_here.abs() < 6.0 {
+            assert!(
+                bright_plane > bright,
+                "plane survival {bright_plane} should exceed clean {bright}"
+            );
+        }
     }
 
     #[test]
@@ -180,11 +243,9 @@ mod tests {
             .unwrap();
         let r_bright = residual_mass(&bright.prob, &grid, bright.v_median, &s);
         let r_faint = residual_mass(&faint.prob, &grid, faint.v_median, &s);
-        // The faint/distant solution leaves JBT a bigger un-covered niche than
-        // the bright close one (which Rubin + ZTF + PS1 mostly mop up).
         assert!(
             r_faint > r_bright,
-            "faint residual {r_faint} should exceed bright {r_bright}"
+            "faint {r_faint} should exceed bright {r_bright}"
         );
     }
 }

--- a/crates/p9-survey/src/schema.rs
+++ b/crates/p9-survey/src/schema.rs
@@ -15,7 +15,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Schema version. The Python loader asserts the file matches this exactly.
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// One paper's Planet Nine orbit solution and the (documented, assumed)
 /// 1σ spreads used to turn it into a sky-position probability cloud.
@@ -172,6 +172,19 @@ pub struct Overlays {
     pub ecliptic: Vec<[f64; 2]>,
 }
 
+/// Search-narrowing constraints for the plotter to overlay: the Rubin cede
+/// line and the Cassini/Iorio ephemeris favored-ν sky arc.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Constraints {
+    /// Rubin/LSST northern limit (deg); JBT cedes everything at/below it.
+    pub rubin_dec_max_deg: f64,
+    /// Favored true-anomaly interval (deg) from the Cassini ephemeris fit.
+    pub favored_nu_lo_deg: f64,
+    pub favored_nu_hi_deg: f64,
+    /// Favored-ν zone mapped onto the sky (RA, Dec deg) for the 2021 orbit.
+    pub favored_arc: Vec<[f64; 2]>,
+}
+
 /// The complete dataset written to JSON and read by the plotter.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SurveyDataset {
@@ -184,4 +197,5 @@ pub struct SurveyDataset {
     pub studies: Vec<StudyResult>,
     pub telescopes: Vec<TelescopeResult>,
     pub overlays: Overlays,
+    pub constraints: Constraints,
 }

--- a/crates/p9-survey/src/skymap.rs
+++ b/crates/p9-survey/src/skymap.rs
@@ -20,7 +20,7 @@ use p9_core::coords::sky::{
     ecliptic_to_equatorial_matrix, ecliptic_vec_to_equatorial_deg, equatorial_to_galactic_matrix,
     galactic_to_ecliptic_matrix,
 };
-use p9_core::types::{elements_to_cartesian, OrbitalElements};
+use p9_core::types::{elements_to_cartesian, solve_kepler, OrbitalElements};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use rand_distr::{Distribution, Normal, Uniform};
@@ -182,6 +182,66 @@ pub fn run_study(
         v_p84: percentile(&vmags, 0.84),
     };
     (result, detections)
+}
+
+/// Position-probability grid with the orbital phase reweighted by an ephemeris
+/// prior on the current true anomaly `nu` (degrees). Same sampling as
+/// [`run_study`], but each draw contributes `nu_weight(ν)` instead of 1, then
+/// the grid is renormalized to sum 1 — i.e. P(sky position | ephemeris phase
+/// constraint). Use it in place of the uniform-phase prior to fold in the
+/// Cassini/Iorio favored-ν zone.
+pub fn ephemeris_weighted_grid(
+    sol: &OrbitSolution,
+    grid: &SkyGrid,
+    n_samples: usize,
+    seed: u64,
+    nu_weight: &dyn Fn(f64) -> f64,
+) -> Vec<f64> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let na = Normal::new(sol.a_au, sol.a_sigma_au).unwrap();
+    let ne = Normal::new(sol.e, sol.e_sigma).unwrap();
+    let ni = Normal::new(sol.i_deg, sol.i_sigma_deg).unwrap();
+    let nom = Normal::new(sol.omega_deg, sol.omega_sigma_deg).unwrap();
+    let nbom = Normal::new(sol.omega_big_deg, sol.omega_big_sigma_deg).unwrap();
+    let um = Uniform::new(0.0, std::f64::consts::TAU);
+
+    let mut prob = vec![0.0_f64; grid.len()];
+    for _ in 0..n_samples {
+        let a = na.sample(&mut rng).clamp(150.0, 1500.0);
+        let e = ne.sample(&mut rng).clamp(0.01, 0.9);
+        let i = ni.sample(&mut rng).clamp(0.0, 60.0) * DEG2RAD;
+        let omega = nom.sample(&mut rng) * DEG2RAD;
+        let omega_big = nbom.sample(&mut rng) * DEG2RAD;
+        let m = um.sample(&mut rng);
+
+        // True anomaly from the sampled mean anomaly.
+        let ea = solve_kepler(e, m);
+        let nu =
+            2.0 * ((1.0 + e).sqrt() * (ea / 2.0).sin()).atan2((1.0 - e).sqrt() * (ea / 2.0).cos());
+        let w = nu_weight(nu.to_degrees().rem_euclid(360.0));
+        if w <= 0.0 {
+            continue;
+        }
+
+        let elem = OrbitalElements {
+            a,
+            e,
+            i,
+            omega,
+            omega_big,
+            mean_anomaly: m,
+        };
+        let pos = elements_to_cartesian(&elem, GM_SUN).pos;
+        let (ra, dec) = ecliptic_vec_to_equatorial_deg(&pos);
+        prob[grid.index(ra, dec)] += w;
+    }
+    let total: f64 = prob.iter().sum();
+    if total > 0.0 {
+        for p in prob.iter_mut() {
+            *p /= total;
+        }
+    }
+    prob
 }
 
 /// Precompute sky overlays (galactic plane and ecliptic) as RA/Dec polylines,

--- a/scripts/plot_survey.py
+++ b/scripts/plot_survey.py
@@ -18,7 +18,7 @@ from typing import Any, get_args, get_origin
 
 import numpy as np
 
-SCHEMA_VERSION = 1  # must equal p9_survey::schema::SCHEMA_VERSION
+SCHEMA_VERSION = 2  # must equal p9_survey::schema::SCHEMA_VERSION
 
 # Tokyo-Night palette (portal dark background #1a1b26)
 FG, MUTE = "#c0caf5", "#565f89"
@@ -92,6 +92,13 @@ class Overlays:
 
 
 @dataclass
+class Constraints:
+    rubin_dec_max_deg: float
+    favored_nu_lo_deg: float; favored_nu_hi_deg: float
+    favored_arc: list
+
+
+@dataclass
 class SurveyDataset:
     schema_version: int; generated_by: str
     samples_per_study: int; rng_seed: int
@@ -99,6 +106,7 @@ class SurveyDataset:
     studies: list[StudyResult]
     telescopes: list[TelescopeResult]
     overlays: Overlays
+    constraints: Constraints
 
 
 def _coerce(value: Any, typ: Any, path: str) -> Any:
@@ -215,6 +223,15 @@ def main() -> None:
                                        alpha=0.9, zorder=3, label="Galactic plane (hard zone)")
     oe = np.argsort(ec[:, 0]); ax.plot(ec[oe, 0], ec[oe, 1], ls=":", color=FG, lw=0.9,
                                        alpha=0.5, zorder=3, label="Ecliptic")
+
+    # Search-narrowing overlays: Rubin cede line + Cassini favored-ν arc.
+    c = d.constraints
+    ax.axhspan(g.dec_min_deg, c.rubin_dec_max_deg, color=MUTE, alpha=0.10, zorder=1)
+    ax.axhline(c.rubin_dec_max_deg, color="#f7768e", ls="-.", lw=1.2, alpha=0.85, zorder=3,
+               label=f"Rubin limit Dec +{c.rubin_dec_max_deg:.0f}° (JBT keeps north)")
+    arc = np.array(c.favored_arc)
+    ax.scatter(arc[:, 0], arc[:, 1], s=10, c="#e0af68", marker="D", edgecolors="none",
+               zorder=7, label=f"Cassini favored-ν arc (ν {c.favored_nu_lo_deg:.0f}–{c.favored_nu_hi_deg:.0f}°)")
 
     ax.set_xlim(g.ra_min_deg, g.ra_max_deg); ax.set_ylim(g.dec_min_deg, g.dec_max_deg)
     ax.invert_xaxis()


### PR DESCRIPTION
Two refinements requested, both wired into the planning + plotting tools.

## 1. Ephemeris favored-ν phase prior (`ephemeris.rs`)
Cassini (Fienga 2016) / Iorio favor P9 near true anomaly ν ≈ 108–129° now (sourced from `p9_2016_cassini_ranging::published`). New `skymap::ephemeris_weighted_grid` reweights the otherwise-uniform orbital phase by a smooth ν-window → P(sky | ephemeris phase). This cuts the **RA** range, not just Dec.

## 2. Real footprint masks (`refine.rs`)
Replaced the dec-band + hard galactic cut with: real footprint boundaries (ZTF Dec>−31°, PS1 Dec>−30° — both *including* the plane; DES SGC polygon) plus a **galactic-plane depth/completeness degradation** (crowding+extinction brighten the effective limit and drop coverage toward |b|→0) instead of a hard hole. So a faint P9 survives in the plane because the surveys are *shallow* there, not absent.

## Plotting
Schema bumped to v2 with a `constraints` block (Rubin dec limit + favored-ν sky arc); `plot_survey.py` (typed loader, version-checked) draws the Rubin-cede line and the favored-ν arc.

## Headline result (honest, and it corrects the earlier optimistic hand-wave)
The Cassini favored-ν arc lands at **Dec −20…0° — entirely *south* of Rubin's +12° line.** So the ν-prior and the Rubin-cede **pull against each other**: folding it in *shrinks* JBT's residual (e.g. 2016 faint solution 39% → 4.9%) because Cassini argues P9 is in Rubin's sky. Read the other way: JBT's northern niche is precisely the scenario where the (weak) Cassini fit does **not** hold. The `refine` binary now states this tension explicitly.

26 tests pass; `cargo build/test/fmt` green. Figure regenerated.