### PR TITLE
Fix Cassini nu-arc orbit + improve figure overlay colors

### DIFF
--- a/crates/p9-survey/p9_survey_sky.svg
+++ b/crates/p9-survey/p9_survey_sky.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-15T10:37:26.521837</dc:date>
+    <dc:date>2026-06-15T10:45:51.414233</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -45,18 +45,18 @@ L 48.761875 120.051173
 L 565.693075 120.051173 
 L 565.693075 263.650745 
 z
-" clip-path="url(#p05be3ac94f)" style="fill: #565f89; opacity: 0.1; stroke: #565f89; stroke-linejoin: miter"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: #565f89; opacity: 0.16; stroke: #565f89; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m0bdc7879fd" d="M 0 0 
+       <path id="m405bce3227" d="M 0 0 
 L 0 3.5 
 " style="stroke: #565f89; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m0bdc7879fd" x="565.693075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="565.693075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -112,7 +112,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m0bdc7879fd" x="522.615475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="522.615475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -152,7 +152,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m0bdc7879fd" x="479.537875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="479.537875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -187,7 +187,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m0bdc7879fd" x="436.460275" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="436.460275" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -233,7 +233,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m0bdc7879fd" x="393.382675" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="393.382675" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -288,7 +288,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m0bdc7879fd" x="350.305075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="350.305075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -319,7 +319,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m0bdc7879fd" x="307.227475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="307.227475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -334,7 +334,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m0bdc7879fd" x="264.149875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="264.149875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -349,7 +349,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m0bdc7879fd" x="221.072275" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="221.072275" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -364,7 +364,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m0bdc7879fd" x="177.994675" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="177.994675" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -379,7 +379,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m0bdc7879fd" x="134.917075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="134.917075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -394,7 +394,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m0bdc7879fd" x="91.839475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="91.839475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -409,7 +409,7 @@ z
     <g id="xtick_13">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m0bdc7879fd" x="48.761875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="48.761875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -678,12 +678,12 @@ z
     <g id="ytick_1">
      <g id="line2d_14">
       <defs>
-       <path id="m397f7840c7" d="M 0 0 
+       <path id="mb12d12cfab" d="M 0 0 
 L -3.5 0 
 " style="stroke: #565f89; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m397f7840c7" x="48.761875" y="233.734168" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mb12d12cfab" x="48.761875" y="233.734168" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -756,7 +756,7 @@ z
     <g id="ytick_2">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m397f7840c7" x="48.761875" y="203.81759" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mb12d12cfab" x="48.761875" y="203.81759" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -806,7 +806,7 @@ z
     <g id="ytick_3">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m397f7840c7" x="48.761875" y="173.901013" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mb12d12cfab" x="48.761875" y="173.901013" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -822,7 +822,7 @@ z
     <g id="ytick_4">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m397f7840c7" x="48.761875" y="143.984435" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mb12d12cfab" x="48.761875" y="143.984435" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -854,7 +854,7 @@ z
     <g id="ytick_5">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m397f7840c7" x="48.761875" y="114.067858" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mb12d12cfab" x="48.761875" y="114.067858" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -870,7 +870,7 @@ z
     <g id="ytick_6">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m397f7840c7" x="48.761875" y="84.15128" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mb12d12cfab" x="48.761875" y="84.15128" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -886,7 +886,7 @@ z
     <g id="ytick_7">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m397f7840c7" x="48.761875" y="54.234703" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mb12d12cfab" x="48.761875" y="54.234703" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
@@ -977,15 +977,16 @@ z
      </g>
     </g>
    </g>
-   <g clip-path="url(#p05be3ac94f)">
+   <g clip-path="url(#pdf7aa51c55)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAs4AAAFNCAYAAAAQIOnHAAAZg0lEQVR4nO3dWXcc57kd4KqunoDGRIKTJlOjLctnSNbKXe6yVv5FfmuuspKTUbZlWTq2HEm2TFEUBxAgph6qcpuzuL/kwzm0RUnPc7lRrC4WgO6Nunjftmm6Bw0AAPD/NPquLwAAAL4PFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFcbf9QX89bWFtLviaUp/c1z1b5H+iscXDFc7z9AMha+UzlM6HgDgx8ETZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAV/goLUAoLR9pJIc+XNGqnOR/lvCvms8L5C687KlznC/qbY7jiApRh2BTyfJ7S+UvH9/065pv+Mh8/5OOHQt4Py3x8X8ibfB4AgL82T5wBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgArjtjTKuTDXuBvN84m67ZhPxoucd4V8tBXzWbubj28Lxzf5eqZDPn4y5HnN4xc06rovzFMu5SVDm49fN3m+86ZZ5bzN85FXTZ7XvGou8usO+fhi3p/FfLk5za9bzPN5+v756zQjGgB4ETxxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqjA92PohfKM1Tno/2Y77THsZ8tz/IxzeF8xfmR8+7LuazUe7+41Eb80nhT4Wuzcd3heOHIeebQt4X/kFfOL4QF4/fFM5fup5VX5gHXXiB1ZCPXw15fvSqMFf6fJTnO190eS7zs/YoHz8cx3zZP3s+2zyfNU3TLNcnMV+t8/GbwgzqYchzogGAl0XueW07K+S5j3riDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKDC+N90/z5+YT7Kg593xznfm+YOvjPJA6e382macT68uLiksOekMOb66otFygtHcr4uLhzJV3TVBSibvIekKcTF69z0+YYWz1P4Quk6V6VFKv0i5svNtZhf9Hdifjas8vHt88tITid5ccnp9Cjnw8P8muvHMb9c5fMUF6kUFrIMzTrmAMA/1bbTmI+7vZhvTfOivq3J9ZjP2t2Ye+IMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFQY/7s7ea7uvMtzeBeFfKvLg36no9Jk4Kw073g1FPIrHn+xya+7LBxfmst8WThPMS/MNS7PWc55aW7yujQQ+opKc7FHbWkydtYVDu8KX5gX8p0h/223GSaFfOu5bN3nmY5nm5sxPx3uxvx4nOcvP508ivlJ/yDmF5ujmJfmQS/XxzHvN3k+tXnQALy88ud91+W5ybNx3vOwM8t7Hq53+TP8Tv9qzA/Hz/eGpmmaxbiLuSfOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAECF8b89zLNpu9HV5gJvCvOUzzZ5Dt7Jehzziz53+ZN1Pv/JKufPCqNsT1f5/3W2zoOTLwuDli8Kg5bP+vzCy6GQN3nw86aQ901+3VI+KvxtVMonTf6+jAvHt4V5jKXjx23hdUeFvHD8tDD3eRIGUZdmRG+P87kPhnwPDtd51uPZJs+YPG1+EvNn49OYH0+e5OOHPA/6dPVtzC+W+TzL9VHMh+Ei5gDw/9O205hPxgcx35oexnx/8kbMbw9vxfy1Ln/2vr7Iex5e285d4OYs96dFYT+JJ84AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKoz355fxC+tN7tSnqzxY+uEyD8D+5iIvk3hwmc//7UVeOPJ0mQdRHy3zYpGnfV7q8KzNyyfO2uOYXzR5QcxqOM95fxbz9ZDv86bP+TDk/+9VtYUFIqM2fx+7Nn+/SseX8nE7i/m03c75kJeLbPd7OV/n8+yE152P8hKeWWHpyjgsUWmappmPS3m+BwdDztd9vvaLTR4KfzLkofCPJ09j/mR6L59nfT/m58uHMb9cHcW87/PvUNNcbWkSAC+f0Wgn5vNJ/ozanb8a81vtuzF/rbkT8ze25zlf5M/eN7bzorhX57n/3dzK+WK6jPnYAhQAAPjnU5wBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBh/PnxbvzCyTrPvn24zF37/nmes3fvLM/Zu3+RZ8F+2z6J+XH7bcxP+zyD9mJ9FPPl+iTmmz7P8dsU5kEPQ54fXc7zfWiaFzOvuSx/v9o2f3/Lx5fmO+e8dPy4y3Mau1Ge+zzpFjGfdYX5zu2157JFf5CP3eRZlYsmX+O8MLN6q8v3ct7le7k9zvneNJ9nf5Pv5eE6z74+Xl+P+ePR3Zxv5/nOz/oHMT9d5vxi+Sjm603+nWua0u8EAFeXP0PGXe55W7ObMd+f/iTmrw0/jfk70/yZ8/Zevp63F/m9/81F3oPxyk7ui3uL3M/mW7mHlaxW+TN5vczX74kzAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBh/B8fTOMXjpd5vvCjyzzv+H5/FPNvR3/K5+/vxfx8mecyr9bPYl6es3wZ86YZCvkPVZ6XWJ4rnQ2F23bVKdSrdZ733RbmT7aj/PM5GuVZy5Nu+7lsOs4zLKddnuM8G9XPiG6aptnb5Hx/nV93v8szqxeT/HfsdJTv2WSaj19M8r25tsmve2d9EPOnzZsxfzjPc5wfT/Pv+unqm5ifF+Y+b9bHMR+aq83mBPg+a5vCPoTxQcwX8zsxvz55K+av92/H/J15/ux6/yB/5nywm/vWT6/lPnfzdp7tv3UjN4p2mj8D+8tcTC4f5+t8+ijvPnhwkrvAk8tC/4gpAADwTyjOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAECF9oNr/yFuMzhtnsR/cLrOyw/OCssMLtf5PP3mLOaWHPAv8/yg9LbNiz+6whKVUj6d5KHw89Iw+u5mzA+GPKT+YMiLV/YL17MY56Uxs66wMKWwSKW0Euhyk7/ybJWX5zzenMf8UZvfGx43XxXOfz/mpYUpq9LClCEvRwL4LrRt4bOl8BmyO3815jfG78b8zeFuzN/aya/7fv7Iaf5mP7+X/+xmfg8+fC+/107eyK/bzvJil+F8FfPVn/OCladfTmL+xTd5KdnvC4tOPj/Nn6UPC3v0PHEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACq0k/HtOJi5H5bxH5i/zA9fnnfctnlmZNfl2ZDTrjD3eZpnTO50t2K+2+Z50Nf6w5yPtmK+N8mzM7fH+e/naeHP6j7HzbIw9/l0nfOjVX6Pedgc5bz9c8yP1/difnaZZ84v1/n8fZ9nl5YnXQM/DvkzoSu9x0/ye/Pu7LWY32l/GvO3R7dj/t5+/ix6fy/P2P/F/rOYv/Nansu8+7P8ntfdzYOf2938mdMscy/s7+XZ+2ef5MHJn39+PeYfPd6P+W+P82fdH47z9fxx9TTmj0bfxNwTZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgQts0XR52CvyLtE2eJTnqtmM+KcyDnk/zDMvFOM933m/vxLw09/mgzddzMM2zQncn+e/tWZdnnY5y3BTGPjcnyzwp+vFlnsH5sM8zSh+M8nzno82fYn62fBjzy3We8bnZ5NcdCjPwgZdD205jPu7ynOLtWWGW/vStmL/evxvzt+Z57vN7e13M/24/v5f8zY3HMX/l3TwfefazRcxHr+fPlmY3fyY0l/l6hnv5epaf5uu599v8Wffhg/wZ9eun+fv18ZNVzP+wyfOXvx4+ifnJRf6sWG5OYu6JMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQwRxneGkU5iCPtmI+Ls19nlyL+fYkzyLdG+W5zzf7nN8Y5de9Pstzqw9m+e/zeR5dWrgLTXO5yfnJKg+EflL4B4/W5zH/ts1znJ82eSboyfp+zC9WhZmm6zzTtN+cxXxo8txq+LEqzcbvCu+F0/F+zBezWzE/7PJc5rv9T2L+9m5+b34/j4NuPtjL7z2/eOXbmN/41/k9bPy3r+QXeDW/xw/zPAe5PbvI5/k6X8/6V/k978GH+fy/up+v58Ojecx/8yT/f3+3yu/BX/Ufxfz4Is/qvyy8Nw9D4T4UeOIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoIIFKPAD07Z5GH1pSUBpYcpiWlgSMHoz5rf62zG/PdmO+fXCBpS9SV6BUlqYMipsTCktTDkt7BV5uuxj/uQy/4MnfV5m8GiUF6kcDfcK15OXDVws87D+1eZZzC1S4WWW3pdGo7wIYzYuLHGaHsZ8b/xazG8XFpe8XliM8tZeXrDy8738ZvJ3B3mp0dt3H8V891/l9+bRL16P+fBOvv5hL19/e3qa8y+/inn/6y9i/vS/LGP+yy/yUqx/eJTf4z8uLDT5tLDQ5M/Dx/l6zr+M+eUqv9cOQ77+F8UTZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCggjnO8CPXNnl2aTfei/lWYZbq7vSVmB82d2N+Z8hzom9O82zXG1t5kPNBHo3azAqPBUpzn1d5jHNz8ReeB/2oz/OXH4/yfOfjIb9ln23y7NjL1dOcr3Pe9xeF/DLmTVO4Qbyk8i9A2+Tfr7Ywa3nc5dm90/FuzLcm15/Ldrs8F/hmn+cavz4+yPliEvO3d4aYv7uTf5bfP3wS81c/yLPTp3+f3wvb9wpzme/k97xhN9+zZp3fM9qv7+fjf/m7GJ/+p6OY/+Yf8+z9//o4X8//epTf2z6+zHOZv+o/inlpLvNynWfX/6XnMl+VJ84AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAVznIEruerc5+3pzZjvTl+N+Y3mJzG/M+Tz3JrPYn59lufS7l9x7vOsy7NgS1Z9npN7Xhh3fLLK+XFhHnQpP1rn2bRHTZ5B+3SU5z6fDjlf9vk8y03OV+s8n3q1OY15X5jV2veFGa5DnnE7NKXvV2FQd1HpPIVB4EX5B6ttC3OT2/z7Vcq7wpzlbpR/0CfdIuaz0tz20bWY7zd5BvDN4UbOJ1vPZa8u8v/pzcXV5i+/d+0o5q+8eRzzrZ8/fy1N0zSjn78W8+Gd/J40XM9znJsuf2+bZyf5db/6Op//t5/H/Ow/H8X8o0+uNpf5V4/zff74PM+Q/3L4ZcyPzvN1rlaFucxNYQj+94QnzgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqWIAC/EW1bV7EMO7ywoX5NC9c2J2+EvPD5m7MbxUWptyc5uUHh4UNKPvTvPCitEhlPspLBbor7s1YFfZvLAsLVs4KOwVOC/nxMr/As1VeFHK6zhtczvq8weVZc5GPb/PClLM2L4e4HPLx68L5131ektEP+Tr7wmKUYch5217teVPXTgp5XtwzbbdjPmt3Yr495OUWO4V8t80//9cn+Qf6xlZe5nE7711pXt/KPyd3F+fPZW/s5+/57bs5n3+Q783oZ3mZ0nC3sNDk1q2c7+R7VtI+zsuCRp/975j3H+b8+B/yz/KvP88LTf7b4/yz8KvH+d5/svwm5l/1H8W8tNBkucr/36YpbHf6gfLEGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACoYI4z8FJpm3HMuy7PLp1PD2O+mOZZrddGb8T8Rn8n5re6RT5+nq/z2izPWT4ozH1ejPM85e0u57PinOic91ecB31ZyC9K+aaU59e9ar4s/AeWm0JeOH6TxzIXpji/uKdK41G+P/PCYO+tcc4X+cet2c1jopuDSf6f3Zzlwd6353n+9Su7pzG/cSfP195+M19/9/bz89nb12/EY4dX8/zi4Ubh+L39mDej/F1sT/O1t9/kecftH76M+ebDP8X82/+eX/d/fpXfY/7HkzzT+zdP8uzxT/s/xvzr9ccxPz7Px6/XT2LeNIU3DZqm8cQZAACqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKhgjjPwPdfltDB/eTZ+fp5s0zTNdmEe9N74tZgf9q/G/FabZ8oezvIg52uz/Pzieh7t2lyb5hmr1wpzexfjPCB5Upj7PCrkeTpv+firKp2/dPZ+yP9iU8hLSvOvS3np/1sY19zMu3z/F5M8o3d7uszHb+V8azfn82v552FyKw9+Ht3ejnl7J/++NHfy78tw62bO9/fCxRSGm6/zrOnmNM+Ubh8+yvmf78e8/+RezE9+me/lZ1/k+dEfHe3m/Gl+T/rk6XnMf9/+LubfXn4a89PLr2O+2RzHnBfLE2cAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFSxAAWiaZjTKCyAmXVjc0DTNfJoXQ+xM7sT8oM0LUw77vFzhRpev53A+zsfP8waOw1le2LE7zvmiy4szdsalBSt5WcV2YfHKVuH4eSGfTXI+LlznuLTwZVLIt3I+Lty3tissQCns8ugW+fsy2i8sItkvbL7ZnefrWeS82SnkWzkfCnkzK1xPaeNLyfnFc1H78Em+lq8exnz92dOYP/l9vpdffJN/Rz853on5p8d5cclnx3lZzZebfJ33mn+M+dH5lzE/X34T82F4/p7x3fPEGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACoYI4zwD9D2+R5yl2XZ8ROx/sxL86D7m7F/FrzSswPh+s5H2/F/GCWZ9buTfJ83v3CnOKDaZ5rvF+Y+7xfmKe8W5jXvNXlfDHNs3VL+fbWZcznO/n4yfwFzXHezc+nRrv556dd5JnEbWF+d3Gecp+vs1nm+z9c5vvcPyvkJ/k8y8f5ZU8ePT8P+puj3XjsH58tYv75Wb43nz/L9+CPz5Yx/6p/FPOvm89i/vTyjzG/WObzrDcnMW+afM/4fvHEGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACoYI4zwHeobecx77rtmM8K86Bnk5xvd4cx32vznOjd/iDm19o8n3p/nGfr7k3znOidwpzoRWFM8VY+TbMzznOKdwvzo3cnhXyc5xTPuzxzt/S0qRvl65mO8nmm45xPRvk62zaff73JV3Sxzjf0tJCfrPL38WiVj3+yyq/7ZJm/v4/CGO0H5/kePFiexfz+6H7MH/d/ivmz5dcxv1g9iflmfRzzock/I/w4eeIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoIIFKAA/AG07jXk3yotUxoUFK5PxIubz8UHMZ6O9mG+313I+5OO3hq2cN/n/NW3zYo7tUc63xvk50bzLCzumhbz0tKnNhzejwhcKhzejwhc2ef9Js+nzFy4K/+B8nfOTdV7ycdKHzSVN0xy3z/Lx7eOYnw4Pn8vO1vnYi2XOV5v8mv0mL0yxuIS/BE+cAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAK5jgD8H8pzB1uJzEfjeYx7wr5eJTnNXddaQ71LL9uYY7zuM3HjwvnGTf5Okvn75p8H16Uoelj3jebnA95VvG6uYj5qj+/Ur5cneTzF47f9Pl1+5APwzIeCy8zT5wBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgArmOAPwEijMj266wuGl5z45bwvHt4V5ze1VnysVr6dgyPOaS3Och8LxZaXz5LnPw7AqnGe44uvCD5snzgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAq5MnvAPBXlRdtDE1e2HHVvRyDPR7AC+CJMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFRQnAEAoILiDAAAFRRnAACooDgDAEAFxRkAACoozgAAUEFxBgCACoozAABUUJwBAKCC4gwAABUUZwAAqKA4AwBABcUZAAAqKM4AAFBBcQYAgAqKMwAAVFCcAQCgguIMAAAVFGcAAKigOAMAQAXFGQAAKijOAABQQXEGAIAKijMAAFT4P93k/D7/mvQDAAAAAElFTkSuQmCC" id="image413211f04e" transform="scale(1 -1) translate(0 -239.76)" x="48.761875" y="-23.890745" width="516.96" height="239.76"/>
+iVBORw0KGgoAAAANSUhEUgAAAs4AAAFNCAYAAAAQIOnHAAAaIUlEQVR4nO3dx7ObZ5YfYIQPOd5ASiQlquXu8taecZVrli4vvPNf77FnRh2UqETyBuACFxnwpjc2z2G9mGJ3S+rnWf741YtwEQ6x+J1aDQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAX7f63/oOlGo0ms04b4SPodmMr282qyrK6/V6eE690WiU3sdarVZr1OP7c67j6Xj6EOecjsdjmJ9O4fnH9Po4Px7j+3k6ncLrD4f94Zz7AwDwc3HWUAgAAH+vDM4AAFDA4AwAAAUMzgAAUMDgDAAABQzOAABQwOAMAAAFDM4AAFDg7GUd2SKSbOFIq9VuheekC0qSc6r4nKrVCheaVFUruz7M37MwJcwzjXq8MOWYLBA5V7bQJFuYcjrGi0iy6/e73S7Ks8Ulh8MhzI9Jvttvw/Pz243P2e/L76flKgDAh+AXZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAAChgcAYAgAIGZwAAKFAfDEbD6B+y/uJ2u9OJ8k63G+edXje5Pszb7U47ylut+Haz69Nz2u3wnFarHfZBZ/3O5zoek57lU9yzfO45Wc9ydn7Wm7zf7/ZRvtsl/ctJn3KWb7eb7Tn5Zr1eh/lmFebR48rOzu7jbhc/B8dj3CkNAPy61Ov1cNeJX5wBAKCAwRkAAAoYnAEAoIDBGQAAChicAQCggMEZAAAKGJwBAKBA9enL3/4m/IdWK+w17nb7/SgfDsdhH/RgOBpFeX8wHER51vvc7cZ5q9VOep/brSivqvhxZX3N9UbjrP9cZH3Kh0PcAXw6Hs/qcT6dTlmPc9g9nN3uB+trTvqgd9n5280mylerx1WUr5P88XGxDK9fv9vvnHU+Zx3R2W2uk3Oyx6QPGgD+uhqNeJ47d+9H1WqFc6RfnAEAoIDBGQAAChicAQCggMEZAAAKGJwBAKCAwRkAAAoYnAEAoIDBGQAAClT/6R/+6b9E/9BJFo4MBvFCk9F4Oo7yfj9edJItHGk06kkeLyKp1+v1KM+carVwgUh6/TFeOHI6HcP8eDzFi06S67OFJqdTfD9Ptfj64+EQLlJJF6+c4sUr2eM9d8FKtggmW6Sy3W62Ub7ZxEtKVqtluKQkWmqSLUB5XMZLVJbLh0WULxbzh3POyRaprFbLxyjPnoPsOcteOwDwS5PNc1UVLyLJ5tRs7jx3UV+2kM8vzgAAUMDgDAAABQzOAABQwOAMAAAFDM4AAFDA4AwAAAUMzgAAUKD6z//4T/81+oesZ7mqqrBPL+9ljvuXM1k37fEY9w7n+SnrNQ77iI/HuAc5Pz/pLz4ew3y33YZdvGlHb3a7SR902tecnFNP/i6NeuOsXuxMs1mFr4csz/oS+/192Mc4nV4V903vdrvwb75eP4Z9ylkv82Ixj/udH2bz5Pqw93mZ5Kuk9/ncPuis+3q/j58HAPjQGo14Luwm/cvdXr8X5cPhOOxZHk8uJlF+efX0SZRfP/n4aXj95ZOrKM/6oP3iDAAABQzOAABQwOAMAAAFDM4AAFDA4AwAAAUMzgAAUMDgDAAABaonT558HP1Do1FP+nzjPOs7znqTd7vdNsr3+3d7eN93/W4X9yDv9/swX69XSSdu3JW7Wa/CTtysA3izXm+ifLvdhHnWrRv1EddqtdrxGPc4n6vRiPuaq6qV9HTH/cv1Rj38z1d2fXZ+q9Wqzrk+y9vtTvuds9udTnRtL+mMHI0m4yi/2F6Hr8HstfP4GPdBZz3RWb/zcvkQ9kc/zO9nUZ71TS8XD+H5m038Gt9uN+HjzbrWAfj1arXa73y/1mq1WifpZR4Ox8MoT79jkz7lrH/5o49fPIvyZ88/+zS+3VF4u91uN5wFqqoK5xK/OAMAQAGDMwAAFDA4AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFKg6nXa4HCJbaLLbxYtFttttuERhtcoWjqzDBSKPj8twOcR8dncf5vM4f5jfz+Pz4+UTm/U6vP/nLofI8t12G+bpopNTvOjkdDyFf5dsEUmjHi86qTca4fX5ApRmuNDk3EUn0YKS9+WdbjcsVu/1Bv0o7/eHg+CM8DXeasWLUbJlLJ1OXPKe5VnJ++FwOER59lrLFpc8PMSv8fu7m7soz98rs/CcbCHLZhMv+Vkny4KOx/jxAvCXV6/Hi+uy765sOdhgOB5F+cXldbi45OnT5x9F+Ucff/I8yp+9ePlJlF9eXl+H92cwCBes9Pv9d+aAWq1W63Q64eNttapwXsnmJL84AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFDA4AwBAgerhYRF2uO52u7B3eLPZZH3NYS/zm9c//hTn3/8Y5be3b26jfPEwm0V51sv8uIzz1eox7JXO+pePSefubr8N+6yzjt7snEzWo32uRtZDmPQyZ73P7+lxDjuPs/OzjuRWO+5U7iY9k92kZzLqn4y6nf98RtgF3esNwrOzTulzuzA73V54f4bDcdhJOZlcTqN8tboO33MXl0/CTs20C312F763ZrPb8PqHh7j3eZH0QWfvUb3PAOdrNOLv1243/i7KvgPHk4tJlGe9zB8/+/RFlL/87HefR/nzpJd5OBqFOw6Gg0HYE93v98Pvxna7He5/qKpm2Mtci+usa8fDIZy3jsdj+F3kF2cAAChgcAYAgAIGZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAAChQvXr16uvoH5aL+UOU3929vYnyt29+fB3lN29/ehvls/vbuyhfJLe7zvuXN0ke9jLv97ukf3kf9vWdTqdTlP+9qdfjAsR6Pe6Jfk/vc5LH11etVtjH2G53wv7GqFM561/O+pq73azfOe5lHgzHYffkaDwJuypHo2mYZ12b2XOQndPrDcL7Px5fTKN8/eQx7IN+mN+Hvcz39zfhe/fuNv5syK7PPmOyDvbNZh32Pu/3u32UA/wSVFW836DTib+7su+c6cXVRZRfXT29jvKsl/mzz//jb6P8o4+fPwtvdzq5jPLJeDyN8kHS19zuxPscmo1GOB8ckp7l7WYbzoXr9SqcIx9Xq/A7Z7eN95n4xRkAAAoYnAEAoIDBGQAAChicAQCggMEZAAAKGJwBAKCAwRkAAAoYnAEAoED9v/33//k/on9YrZZhUfTDwyxcirBI8myZwWq1DJcunLu4xIKSX7dGI1ukUr5gJVuW0m7HZeutdju8PluY0h/Ei0tGo3gBynA0mYTXj+OFJtk56QKXXrzAJXvOMrvtNnwvZkuKskUns7ub23Oun8/u7qM8++zJF6aswoUp2WeMzxLgHNlisHMWdNVqtdpgOAoXglxcPrmK8qdPn38U5c9ffPZplL/87HefR/nV9fWTKJ9Op+FCk2zRyWg0Cr/Ter1e9l0ULnw5HA7hMqv1eh3Oo4vFIvwums8f7uN8HubZOatkMYpfnAEAoIDBGQAAChicAQCggMEZAAAKGJwBAKCAwRkAAAoYnAEAoED96UcvnkX/kPUmb9bndaPqX+ZvLevajDqfa7VaraparTBvxXmv1w/7lHu9QdhhORiOhmE+GIddnqNx3OM8mVxOo3w8uQg7NQeDuCs066FuVe3w8WbWSW/yevUYdrbPZ3ezKL+/j3uf727f3CTXn9UHvVjMF1G+Wa/P+mw7Hg+HKAd+mbK9AVkv87kd/lkv85Onzz6O8k9f/vazKP/sN7/7D1E+mUwuwnwa59NJ3Ms8Ho+nUZ71MrdaVfhdcTwej1G+Wq3D74SHh4fkO+E+/k64u0++E+LrX3371TdR/sP3X38b5bPkO8ovzgAAUMDgDAAABQzOAABQwOAMAAAFDM4AAFDA4AwAAAUMzgAAUKCe9RbqKIX/V9YHnfU+Z92fnW6vG+VZH3S/n3SFjqdhX/N4HPc4Ty+uws7OYdI5Osn6oIdx33T2eJvN+DNmt9vto3y5mD9EedbXfHf7NuzyvL15/TY5J+z4fJjfz6P88XGxjPLV6nEV5VnXvU57+Ms497M5+wzOPmuzz8LLq6dPovzZ85cvovzFJ7/5NMqfv3j5MsovLi7C3ueLi2mYZz3Oo9Ew/IzPepmz5y2bC1erdfhZmPUy393H/cu3N7fhZ/bt7d2bKP/6q9//Kcm/jPLXP333fXh/bt+G3wmr1TLsm/aLMwAAFDA4AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFAi7D4G/nKpqVVHebnc6Ud5qt8N+5F5vEPY+D4ajsGd5OBwPo3wyjfudp9OrsBP04vI67BDNrh9PLqZR3mrFXaGZw+EQ9j4vFvNFlM9nd/dRnvU+Zz3R93dxvniYhb3Pi6SHOuuDznqft9vNNsr1QfNr8aG68Xu9QdhH3B/EvczjM3uZn7/47JMof/nZ7z6P8idPnn4U5dPpJPyszfqaLy8vr6N8PB5No7zbjXuZm81G2KWffaauVuuwv3g2m91H+d3dXdi/fHNzG/Yv397G+Tdf/ynsX/7yT//6hyj//ruvX4Xn37wOz3+Yx5/Zq9Uy7KHOPmv94gwAAAUMzgAAUMDgDAAABQzOAABQwOAMAAAFDM4AAFDA4AwAAAUMzgAAUMACFPiZazSaYXl9qxUvUmkli1R6vX6yMGUcLkyZJEsCLi6exGX91/HygOvrj5+G11/G5/T6/aTEP34earV4icLxeDhE+Xa73UT5w/w+LMfPFqNkC1bOvf4hWaSyTBaprFaPYVm/RSr8NX2Iz6Vup9eNru0mn1XZMqVs+dLV9dNwgcjHzz59EeWffPr5Z1E+mUziZVAX02QZ1EWyVCpegJItNBkMBuHSqlarFS6CyRaaLJeP4ZKo2WwWflbdJAtK3r5581OYv715HeXZQpM//fFfvojycxeazGZ3syhfrx7DBS77/S58fs7lF2cAAChgcAYAgAIGZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAACigxxn+TlRV3K/a6XTDLtX+YDiI8tFoOo7yrGP16iruUr1+kvQ7X8V90FfXH4XnZPe/2WyGj7dejz/3jsfjMcqzbtQP1Qc9u7+N89ntfXx+0vu8jHufl4uHsMN1tVqGXadZ7/Nuuw3zw2EfPj+HQ9yjfTjsw1x/9PvV63Ffeb3eCH8Ay3rPm80qyePr2+1O2Bnc6aYdzGEPe7//7udJ1hWffQY8e/4y7F9+9vzlJ1E+Ho/D80ejUZhPpklf8zTua86uHw2H4Wdkt9sN+6mbVRV+Vp2Ox/A9sV6vw/fu/X3Sy3wT9yy/efM26WWO82++/jLsZf79F//rX6L8u1dffRPen7c/vY3yrNP+L93LfC6/OAMAQAGDMwAAFDA4AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAE9zkDoQ/U+Z/3Ok8llmF+e2ft8fR3n04ursGM1u/9V1WxFeaMR9+RmH5/HU9IHvY/7jjebTdgHvVw8hL3MDw9xT/R8dncfXx93o2Z904+Pi2WUr1aPqyjfbFbrKM96n9fr+Pr9frcL812cn9sHnfV0/6Vlr59G2rMc562qHb4+q1b8Pq2qVnh9pxu//juduJd5OBwPozx7X0+n8fsu6mb+6OMXz8Kzz+xfHo/H4X0Zj+Pr83NG4TmDwSB8DjqdTvicZfb7ffhaXq1WYU/xfP4wi/Lb29s3UZ71Mr958+bHKP/u1Tdhz/Lvv/jnsJf522/++HV4/usfwvOzz5jss+R4jLvff2784gwAAAUMzgAAUMDgDAAABQzOAABQwOAMAAAFDM4AAFDA4AwAAAUMzgAAUMACFOCDaLXa7SjvdOPFCv1+vDAlW7gwvbi6jPKLi+swv7x+d+FCrVarXV19FC5YmU7j8/uDQXg/W+348VbNZriQol6vn/V5my3sOByP4ZKAwz5eHrDb78JFJI+Lh0WULxbzMM8Wo6xXj+HyhnMXqayTfLuNF8Rst5vwcWWLVNKFKcd4Ycq56o3479tsVuFCk2xBSbvdCV9X7XanE+XdXr8X5e95f42ifDK9DBeXXFw+uYrPGYXnDAb98P0bLREZDAfhGeNRvIhkNBqN43wYLjTp9/vhc5AtLqmqKvybZLbbbby8aLkMlxfd39/fRvnNTbzQ5O3bm9dxHi86+fabL7+M8j/8/n//W5R/9+qrcAHK2zc/hrc7n92FC1lWq2X4GZAtI/ql84szAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFDA4AwBAAYMzAAAU0OMM/E1kvc9Zj22vN+hH+WA4ynqfw17aSdLXfJn01V5ePQ17n6+SfDiahF2z7XYr7OGtqirsfW4mfdDNZjPsBW40GuEPIVmXatYHfTwc4v7ow2Gf5HGv9JnX7/f78Prddhv2NZ/b75z2OJ9O4ePN1Ov1s35warXaYTdwp9PNepnD13mrFfc+t1qt5H3UDs/POox7vV54u/1+L+xCjnqZ/5yH3cz9wbudyv1efHa32w27qduduMu6VVXhc5B1p2evzdVqHfYRL5fLsNv8Pb3Mcf/yzdswv3kb9zh/9eUXf4jyP/7h/3wR5T98982r+P78FJ6/TLrc/956mc/lF2cAAChgcAYAgAIGZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAACigxxn4RaiqVthr3G7H3a7dXj/sgh0Ox2HPbNa/PJlcTKL8Iu99fhLmyfWT6WXYN93pdMO+3U4n7ufNenurqgr7fxvNuPe5Xou7b7NO3J+b4+kY9zInDbTZ4/pQebPZCHu3qyruZc7+XnmPc9xhnL0eut34ddXtdsL3S/Y67HY7Ye9zJ+taDvqms+7x4zH+G2b9y5vtNuz0Xj2uwj7ih4eHWZTf38/CXub7+7swv727fxtef3d3E+W//7d//tco/+rLL/4Y5T/99OqHKL+7fRuev1zMH6J8s1mHzw//Pn5xBgCAAgZnAAAoYHAGAIACBmcAAChgcAYAgAIGZwAAKGBwBgCAAgZnAAAo8IsotAc4V6PRDBdPtNudcGFEJ1kM0esNwsUQo2RhynhyMT0nn06vwgUo04s4zxasTJLzO51O+LiyhRrZAo58MUecN5tVuLCm2Yz/LucuamnUkzxZqpEtIsnvZ3x9vV4/63arKj6/Sp631pmLUaqqGd//7Hab8fWNRvx4G81m8vzHz8PpdApXzRwOh8P/n22zxSWr1TLKl8vHRZTP5/Nwocl8/nAf5bPZ7O6c/Ntv/vRVlL/69stvovzHH779Lspvb14nC1NuwgUrq9VyFeW73XYb5fx1+MUZAAAKGJwBAKCAwRkAAAoYnAEAoIDBGQAAChicAQCggMEZAAAK6HEGeI9Wqx32Pmd90L3eoB/l/cFwEOWD4WgY5aPR9Kye6Pf0QV+G54wvJuHtjuN+6na7HfZBt9vZ89PuRHnWH91qVeE5VdprHPcR533T2e22wtvN+qY/WI/zmb3MWS95PfkWj9uUa7Xj8fhOn/Kf82OU7/f7fZLvojzrZl6vN+90Ej8+PiZ9zcuwr3mxWMyjfD6f30f5d6/inuUfvv/2+yh/8/r7H6P8JulfXsxn4f15fFyEj2u9Xq2j/Hh8t+Oany+/OAMAQAGDMwAAFDA4AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAE9zgAfUNa3m/U+Z3mn2w17k7Oe6KwPejAYj6J8OBzH1w9H4fWTyeU0PGcU9z6fe37WB91sxj3IrVbSg5z1NVdxT3TW75z1ONeS781GI25Uzl4PzWYj6WWO+6Dr9fj8rJf5cIi7gbP+5d1ud1Yv83vybZRH3cy3N6/fRNe+ffPj63Pyu7s3N1E+m93NwvuymD9E+eMy7l/ebNZh//J+vws7rvl184szAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFDA4AwBAAYMzAAAUMDgDAEABC1AAfoaqqhUu/sgWc7TanU6Udzu9cJFKK1k40usNeuE5vX64eKXfHw7ic/pnndPt9sL730nufzt7vMntdjrpQpnw+myRynsWo4SazSpZdFI/64er0+l0jPL9Ll7Csd1uwgUlj4/xko8sXyzm7ywuqdXOXyKyXD68c84iOSM7e7V6XEX5Zr0KF5Rst5twGctuFy9pgRJ+cQYAgAIGZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAAChgcAYAgAJ6nAF+xer1evg5X1VZT3HcO5z1GrfbnbAP+j152L+c9Vaf26ecPa5Wqx3m5/Zl1+uN8AenRiPOM8fjMexlPp3i/Hg8nqL8cDgc4uvjPOt3zrqQN5t1eH12TtadHOX73W53zhnZY4K/Jr84AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFDA4AwBAAT3OAPy7ZT3RWR/0uf3I6fVJb3Kj3gjvT71RT86P72cjuT+ZeiN+HjKn4ynsZc4ck37nU9IHfTyd1/ucdSofDvvw+uycrIf6dDrv8cLPlV+cAQCggMEZAAAKGJwBAKCAwRkAAAoYnAEAoIDBGQAAChicAQCggMEZAAAKWIACwK9etqjl/HPOW4xyrmyBSH69xSLw1+QXZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAAChgcAYAgAIGZwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPi78n8B/f87+/176jYAAAAASUVORK5CYII=" id="image3bd9cadd17" transform="scale(1 -1) translate(0 -239.76)" x="48.761875" y="-23.890745" width="516.96" height="239.76"/>
    </g>
    <g id="line2d_21"/>
    <g id="line2d_22"/>
    <g id="line2d_23"/>
    <g id="line2d_24"/>
    <g id="line2d_25"/>
+   <g id="line2d_26"/>
    <g id="patch_4">
     <path d="M 48.761875 263.650745 
 L 48.761875 24.318125 
@@ -1006,8 +1007,7 @@ L 565.693075 263.650745
 L 565.693075 24.318125 
 " style="fill: none; stroke: #565f89; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="line2d_26">
-    <path d="M 565.660164 19.772958 
+   <path d="M 565.660164 19.772958 
 L 559.536543 19.113246 
 L 553.302856 18.717238 
 L 547.013497 18.590756 
@@ -1129,8 +1129,130 @@ L 60.461429 21.843268
 L 54.694307 20.687041 
 L 51.734129 20.198908 
 L 51.734129 20.198908 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke-dasharray: 7.4,3.2; stroke-dashoffset: 0; stroke: #565f89; stroke-opacity: 0.9; stroke-width: 2"/>
-   </g>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #1a1b26; stroke-width: 4"/>
+   <path d="M 565.660164 19.772958 
+L 559.536543 19.113246 
+L 553.302856 18.717238 
+L 547.013497 18.590756 
+L 540.726117 18.735694 
+L 534.498254 19.149882 
+L 528.383963 19.827245 
+L 522.430951 20.75823 
+L 516.678543 21.930438 
+L 511.156652 23.329371 
+L 505.885687 24.939186 
+L 500.877228 26.743409 
+L 496.135199 28.725529 
+L 491.657283 30.869464 
+L 487.436369 33.1599 
+L 483.461906 35.582506 
+L 479.721057 38.124051 
+L 476.199643 40.772452 
+L 472.882882 43.516757 
+L 469.755924 46.347102 
+L 466.804242 49.254638 
+L 464.013885 52.231451 
+L 460.102149 56.811315 
+L 456.482754 61.510608 
+L 453.118922 66.311868 
+L 449.978048 71.200342 
+L 447.031377 76.163533 
+L 443.361268 82.879175 
+L 439.93992 89.687777 
+L 436.72336 96.57196 
+L 432.933838 105.261613 
+L 428.644177 115.782464 
+L 423.881095 128.143495 
+L 415.984721 149.429819 
+L 409.319457 167.138134 
+L 405.133641 177.696332 
+L 401.465077 186.429841 
+L 397.572104 195.081809 
+L 394.251231 201.927597 
+L 390.702968 208.688932 
+L 387.864002 213.693078 
+L 384.846937 218.629317 
+L 381.625207 223.486344 
+L 378.168643 228.250858 
+L 374.443092 232.90714 
+L 371.791164 235.942134 
+L 368.990252 238.914464 
+L 366.027087 241.817006 
+L 362.887674 244.641785 
+L 359.557452 247.379886 
+L 356.021565 250.021371 
+L 352.265249 252.555215 
+L 348.274395 254.969255 
+L 344.036287 257.250184 
+L 339.540568 259.383598 
+L 334.780412 261.354123 
+L 329.753878 263.145638 
+L 324.465367 264.741615 
+L 318.927029 266.125603 
+L 313.159907 267.281829 
+L 307.194564 268.195912 
+L 301.070943 268.855624 
+L 294.837256 269.251632 
+L 288.547897 269.378114 
+L 282.260517 269.233176 
+L 276.032654 268.818988 
+L 269.918363 268.141625 
+L 263.965351 267.210641 
+L 258.212943 266.038432 
+L 252.691052 264.6395 
+L 247.420087 263.029684 
+L 242.411628 261.225461 
+L 237.669599 259.243341 
+L 233.191683 257.099406 
+L 228.970769 254.80897 
+L 224.996306 252.386365 
+L 221.255457 249.844819 
+L 217.734043 247.196419 
+L 214.417282 244.452113 
+L 211.290324 241.621768 
+L 208.338642 238.714232 
+L 205.548285 235.73742 
+L 201.636549 231.157556 
+L 198.017154 226.458262 
+L 194.653322 221.657003 
+L 191.512448 216.768528 
+L 188.565777 211.805337 
+L 184.895668 205.089695 
+L 181.47432 198.281094 
+L 178.25776 191.396911 
+L 174.468238 182.707257 
+L 170.178577 172.186406 
+L 165.415495 159.825375 
+L 157.519121 138.539051 
+L 150.853857 120.830737 
+L 146.668041 110.272538 
+L 142.999477 101.539029 
+L 139.106504 92.887062 
+L 135.785631 86.041273 
+L 132.237368 79.279938 
+L 129.398402 74.275792 
+L 126.381337 69.339553 
+L 123.159607 64.482526 
+L 119.703043 59.718012 
+L 115.977492 55.061731 
+L 113.325564 52.026736 
+L 110.524652 49.054407 
+L 107.561487 46.151865 
+L 104.422074 43.327085 
+L 101.091852 40.588985 
+L 97.555965 37.947499 
+L 93.799649 35.413655 
+L 89.808795 32.999615 
+L 85.570687 30.718687 
+L 81.074968 28.585272 
+L 76.314812 26.614747 
+L 71.288278 24.823233 
+L 65.999767 23.227255 
+L 60.461429 21.843268 
+L 54.694307 20.687041 
+L 51.734129 20.198908 
+L 51.734129 20.198908 
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #9aa5ce; stroke-opacity: 0.9; stroke-width: 1.8"/>
    <g id="line2d_27">
     <path d="M 565.693075 143.984435 
 L 547.191331 132.970795 
@@ -1204,12 +1326,7 @@ L 73.936535 158.824866
 L 63.281677 152.666036 
 L 50.079327 144.777743 
 L 50.079327 144.777743 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke-dasharray: 0.9,1.485; stroke-dashoffset: 0; stroke: #c0caf5; stroke-opacity: 0.5; stroke-width: 0.9"/>
-   </g>
-   <g id="line2d_28">
-    <path d="M 48.761875 120.051173 
-L 565.693075 120.051173 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke-dasharray: 7.68,1.92,1.2,1.92; stroke-dashoffset: 0; stroke: #f7768e; stroke-opacity: 0.85; stroke-width: 1.2"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke-dasharray: 0.9,1.485; stroke-dashoffset: 0; stroke: #c0caf5; stroke-opacity: 0.5; stroke-width: 0.9"/>
    </g>
    <g id="text_23">
     <!-- Where is Planet 9? Dwell-time position probability across orbit solutions -->
@@ -1644,7 +1761,7 @@ L 59.531275 250.631838
 L 55.223515 249.909227 
 L 50.915755 249.398641 
 L 50.915755 249.398641 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 0.9"/>
     <path d="M 50.915755 154.196731 
 L 55.223515 155.549905 
 L 63.839035 160.282466 
@@ -1753,7 +1870,7 @@ L 554.923675 141.796709
 L 559.231435 145.082156 
 L 563.539195 147.288055 
 L 563.539195 147.288055 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 0.9"/>
    </g>
    <g id="PathCollection_2">
     <path d="M 563.539195 222.714652 
@@ -1839,7 +1956,7 @@ L 554.923675 162.912262
 L 559.231435 166.206966 
 L 563.539195 168.157047 
 L 563.539195 168.157047 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 50.915755 177.808694 
 L 55.223515 179.813444 
 L 59.531275 182.857932 
@@ -1863,7 +1980,7 @@ L 63.839035 222.26085
 L 59.531275 222.617585 
 L 55.223515 222.892123 
 L 50.915755 223.098217 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 1.6"/>
    </g>
    <g id="PathCollection_3">
     <path d="M 563.539195 245.681528 
@@ -1972,7 +2089,7 @@ L 55.223515 249.402432
 L 52.405851 248.692457 
 L 50.915755 248.44913 
 L 50.915755 248.44913 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 0.9"/>
     <path d="M 50.915755 153.832846 
 L 55.223515 154.982652 
 L 59.531275 156.960668 
@@ -2082,7 +2199,7 @@ L 554.923675 141.704086
 L 559.231435 144.618047 
 L 563.539195 146.606684 
 L 563.539195 146.606684 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 0.9"/>
    </g>
    <g id="PathCollection_4">
     <path d="M 563.539195 224.314488 
@@ -2192,7 +2309,7 @@ L 554.923675 160.999647
 L 559.231435 164.040514 
 L 563.539195 165.926713 
 L 563.539195 165.926713 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 50.915755 175.141404 
 L 55.223515 176.583079 
 L 55.81124 176.89267 
@@ -2226,7 +2343,7 @@ L 63.839035 226.750485
 L 59.531275 226.589266 
 L 55.223515 226.52877 
 L 50.915755 226.530946 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 1.6"/>
    </g>
    <g id="PathCollection_5">
     <path d="M 563.539195 218.026617 
@@ -2336,7 +2453,7 @@ L 72.454555 226.337958
 L 55.223515 222.131186 
 L 50.915755 221.329095 
 L 50.915755 221.329095 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 0.9"/>
     <path d="M 50.915755 147.692658 
 L 55.223515 148.7023 
 L 59.531275 150.452571 
@@ -2443,7 +2560,7 @@ L 559.231435 140.566899
 L 560.242304 140.992777 
 L 563.539195 141.962789 
 L 563.539195 141.962789 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 0.9"/>
    </g>
    <g id="PathCollection_6">
     <path d="M 563.539195 200.505249 
@@ -2529,7 +2646,7 @@ L 59.531275 204.654445
 L 55.223515 203.669833 
 L 50.915755 202.973512 
 L 50.915755 202.973512 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 50.915755 164.313798 
 L 55.223515 165.5314 
 L 59.531275 167.522079 
@@ -2621,7 +2738,7 @@ L 554.923675 154.867094
 L 559.231435 157.418593 
 L 563.539195 158.930987 
 L 563.539195 158.930987 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 1.6"/>
    </g>
    <g id="PathCollection_7">
     <path d="M 563.539195 174.954186 
@@ -2730,7 +2847,7 @@ L 58.719645 182.875986
 L 55.223515 181.736025 
 L 50.915755 180.667786 
 L 50.915755 180.667786 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 0.9"/>
     <path d="M 50.915755 140.218997 
 L 53.07907 140.992777 
 L 55.223515 141.359204 
@@ -2847,7 +2964,7 @@ L 553.970855 129.026146
 L 559.231435 131.608798 
 L 563.539195 133.585469 
 L 563.539195 133.585469 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 0.9"/>
    </g>
    <g id="PathCollection_8">
     <path d="M 563.539195 166.819028 
@@ -2974,7 +3091,7 @@ L 559.231435 140.191952
 L 561.092287 140.992777 
 L 563.539195 141.825846 
 L 563.539195 141.825846 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 50.915755 148.350771 
 L 55.223515 149.526465 
 L 59.531275 151.660751 
@@ -3035,22 +3152,27 @@ L 63.839035 176.622347
 L 59.531275 174.79249 
 L 55.223515 173.193179 
 L 50.915755 172.104921 
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 223.226155 176.91667 
 L 222.467581 176.89267 
 L 223.226155 176.845451 
 L 223.41229 176.89267 
 L 223.226155 176.91667 
 z
-" clip-path="url(#p05be3ac94f)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
+   </g>
+   <g id="line2d_28">
+    <path d="M 48.761875 120.051173 
+L 565.693075 120.051173 
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke-dasharray: 8.4,4.2; stroke-dashoffset: 0; stroke: #c0caf5; stroke-opacity: 0.9; stroke-width: 1.4"/>
    </g>
    <g id="legend_1">
     <g id="patch_8">
      <path d="M 53.801875 260.050745 
-L 428.267125 260.050745 
-Q 429.707125 260.050745 429.707125 258.610745 
-L 429.707125 206.489495 
-Q 429.707125 205.049495 428.267125 205.049495 
+L 455.97925 260.050745 
+Q 457.41925 260.050745 457.41925 258.610745 
+L 457.41925 206.489495 
+Q 457.41925 205.049495 455.97925 205.049495 
 L 53.801875 205.049495 
 Q 52.361875 205.049495 52.361875 206.489495 
 L 52.361875 258.610745 
@@ -3565,14 +3687,16 @@ z
       <use xlink:href="#DejaVuSans-55" x="2381.144531"/>
      </g>
     </g>
-    <g id="line2d_34">
-     <path d="M 266.512375 210.88037 
+    <path d="M 266.512375 210.88037 
 L 273.712375 210.88037 
 L 280.912375 210.88037 
-" style="fill: none; stroke-dasharray: 7.4,3.2; stroke-dashoffset: 0; stroke: #565f89; stroke-opacity: 0.9; stroke-width: 2"/>
-    </g>
+" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #1a1b26; stroke-width: 4"/>
+    <path d="M 266.512375 210.88037 
+L 273.712375 210.88037 
+L 280.912375 210.88037 
+" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #9aa5ce; stroke-opacity: 0.9; stroke-width: 1.8"/>
     <g id="text_29">
-     <!-- Galactic plane (hard zone) -->
+     <!-- Galactic plane (crowded zone) -->
      <g style="fill: #c0caf5" transform="translate(286.672375 213.40037) scale(0.072 -0.072)">
       <defs>
        <path id="DejaVuSans-47" d="M 3809 666 
@@ -3682,19 +3806,22 @@ z
       <use xlink:href="#DejaVuSans-65" x="652.490234"/>
       <use xlink:href="#DejaVuSans-20" x="714.013672"/>
       <use xlink:href="#DejaVuSans-28" x="745.800781"/>
-      <use xlink:href="#DejaVuSans-68" x="784.814453"/>
-      <use xlink:href="#DejaVuSans-61" x="848.193359"/>
-      <use xlink:href="#DejaVuSans-72" x="909.472656"/>
-      <use xlink:href="#DejaVuSans-64" x="948.835938"/>
-      <use xlink:href="#DejaVuSans-20" x="1012.3125"/>
-      <use xlink:href="#DejaVuSans-7a" x="1044.099609"/>
-      <use xlink:href="#DejaVuSans-6f" x="1096.589844"/>
-      <use xlink:href="#DejaVuSans-6e" x="1157.771484"/>
-      <use xlink:href="#DejaVuSans-65" x="1221.150391"/>
-      <use xlink:href="#DejaVuSans-29" x="1282.673828"/>
+      <use xlink:href="#DejaVuSans-63" x="784.814453"/>
+      <use xlink:href="#DejaVuSans-72" x="839.794922"/>
+      <use xlink:href="#DejaVuSans-6f" x="878.658203"/>
+      <use xlink:href="#DejaVuSans-77" x="939.839844"/>
+      <use xlink:href="#DejaVuSans-64" x="1021.626953"/>
+      <use xlink:href="#DejaVuSans-65" x="1085.103516"/>
+      <use xlink:href="#DejaVuSans-64" x="1146.626953"/>
+      <use xlink:href="#DejaVuSans-20" x="1210.103516"/>
+      <use xlink:href="#DejaVuSans-7a" x="1241.890625"/>
+      <use xlink:href="#DejaVuSans-6f" x="1294.380859"/>
+      <use xlink:href="#DejaVuSans-6e" x="1355.5625"/>
+      <use xlink:href="#DejaVuSans-65" x="1418.941406"/>
+      <use xlink:href="#DejaVuSans-29" x="1480.464844"/>
      </g>
     </g>
-    <g id="line2d_35">
+    <g id="line2d_34">
      <path d="M 266.512375 221.44862 
 L 273.712375 221.44862 
 L 280.912375 221.44862 
@@ -3730,41 +3857,24 @@ z
       <use xlink:href="#DejaVuSans-63" x="304.199219"/>
      </g>
     </g>
-    <g id="line2d_36">
+    <g id="line2d_35">
      <path d="M 266.512375 232.01687 
 L 273.712375 232.01687 
 L 280.912375 232.01687 
-" style="fill: none; stroke-dasharray: 7.68,1.92,1.2,1.92; stroke-dashoffset: 0; stroke: #f7768e; stroke-opacity: 0.85; stroke-width: 1.2"/>
+" style="fill: none; stroke-dasharray: 8.4,4.2; stroke-dashoffset: 0; stroke: #c0caf5; stroke-opacity: 0.9; stroke-width: 1.4"/>
     </g>
     <g id="text_31">
-     <!-- Rubin limit Dec +12° (JBT keeps north) -->
+     <!-- Rubin reach (Dec &lt; +12°) -->
      <g style="fill: #c0caf5" transform="translate(286.672375 234.53687) scale(0.072 -0.072)">
       <defs>
-       <path id="DejaVuSans-4a" d="M 628 4666 
-L 1259 4666 
-L 1259 325 
-Q 1259 -519 939 -900 
-Q 619 -1281 -91 -1281 
-L -331 -1281 
-L -331 -750 
-L -134 -750 
-Q 284 -750 456 -515 
-Q 628 -281 628 325 
-L 628 4666 
-z
-" transform="scale(0.015625)"/>
-       <path id="DejaVuSans-6b" d="M 581 4863 
-L 1159 4863 
-L 1159 1991 
-L 2875 3500 
-L 3609 3500 
-L 1753 1863 
-L 3688 0 
-L 2938 0 
-L 1159 1709 
-L 1159 0 
-L 581 0 
-L 581 4863 
+       <path id="DejaVuSans-3c" d="M 4684 3150 
+L 1459 2003 
+L 4684 863 
+L 4684 294 
+L 678 1747 
+L 678 2266 
+L 4684 3719 
+L 4684 3150 
 z
 " transform="scale(0.015625)"/>
       </defs>
@@ -3774,50 +3884,34 @@ z
       <use xlink:href="#DejaVuSans-69" x="191.837891"/>
       <use xlink:href="#DejaVuSans-6e" x="219.621094"/>
       <use xlink:href="#DejaVuSans-20" x="283"/>
-      <use xlink:href="#DejaVuSans-6c" x="314.787109"/>
-      <use xlink:href="#DejaVuSans-69" x="342.570312"/>
-      <use xlink:href="#DejaVuSans-6d" x="370.353516"/>
-      <use xlink:href="#DejaVuSans-69" x="467.765625"/>
-      <use xlink:href="#DejaVuSans-74" x="495.548828"/>
-      <use xlink:href="#DejaVuSans-20" x="534.757812"/>
-      <use xlink:href="#DejaVuSans-44" x="566.544922"/>
-      <use xlink:href="#DejaVuSans-65" x="643.546875"/>
-      <use xlink:href="#DejaVuSans-63" x="705.070312"/>
-      <use xlink:href="#DejaVuSans-20" x="760.050781"/>
-      <use xlink:href="#DejaVuSans-2b" x="791.837891"/>
-      <use xlink:href="#DejaVuSans-31" x="875.626953"/>
-      <use xlink:href="#DejaVuSans-32" x="939.25"/>
-      <use xlink:href="#DejaVuSans-b0" x="1002.873047"/>
-      <use xlink:href="#DejaVuSans-20" x="1052.873047"/>
-      <use xlink:href="#DejaVuSans-28" x="1084.660156"/>
-      <use xlink:href="#DejaVuSans-4a" x="1123.673828"/>
-      <use xlink:href="#DejaVuSans-42" x="1153.166016"/>
-      <use xlink:href="#DejaVuSans-54" x="1221.769531"/>
-      <use xlink:href="#DejaVuSans-20" x="1282.853516"/>
-      <use xlink:href="#DejaVuSans-6b" x="1314.640625"/>
-      <use xlink:href="#DejaVuSans-65" x="1368.925781"/>
-      <use xlink:href="#DejaVuSans-65" x="1430.449219"/>
-      <use xlink:href="#DejaVuSans-70" x="1491.972656"/>
-      <use xlink:href="#DejaVuSans-73" x="1555.449219"/>
-      <use xlink:href="#DejaVuSans-20" x="1607.548828"/>
-      <use xlink:href="#DejaVuSans-6e" x="1639.335938"/>
-      <use xlink:href="#DejaVuSans-6f" x="1702.714844"/>
-      <use xlink:href="#DejaVuSans-72" x="1763.896484"/>
-      <use xlink:href="#DejaVuSans-74" x="1805.009766"/>
-      <use xlink:href="#DejaVuSans-68" x="1844.21875"/>
-      <use xlink:href="#DejaVuSans-29" x="1907.597656"/>
+      <use xlink:href="#DejaVuSans-72" x="314.787109"/>
+      <use xlink:href="#DejaVuSans-65" x="353.650391"/>
+      <use xlink:href="#DejaVuSans-61" x="415.173828"/>
+      <use xlink:href="#DejaVuSans-63" x="476.453125"/>
+      <use xlink:href="#DejaVuSans-68" x="531.433594"/>
+      <use xlink:href="#DejaVuSans-20" x="594.8125"/>
+      <use xlink:href="#DejaVuSans-28" x="626.599609"/>
+      <use xlink:href="#DejaVuSans-44" x="665.613281"/>
+      <use xlink:href="#DejaVuSans-65" x="742.615234"/>
+      <use xlink:href="#DejaVuSans-63" x="804.138672"/>
+      <use xlink:href="#DejaVuSans-20" x="859.119141"/>
+      <use xlink:href="#DejaVuSans-3c" x="890.90625"/>
+      <use xlink:href="#DejaVuSans-20" x="974.695312"/>
+      <use xlink:href="#DejaVuSans-2b" x="1006.482422"/>
+      <use xlink:href="#DejaVuSans-31" x="1090.271484"/>
+      <use xlink:href="#DejaVuSans-32" x="1153.894531"/>
+      <use xlink:href="#DejaVuSans-b0" x="1217.517578"/>
+      <use xlink:href="#DejaVuSans-29" x="1267.517578"/>
      </g>
     </g>
-    <g id="PathCollection_9">
-     <path d="M 273.712375 245.451188 
-L 275.948443 243.21512 
-L 273.712375 240.979052 
-L 271.476307 243.21512 
-z
-" style="fill: #e0af68"/>
+    <g id="line2d_36">
+     <path d="M 266.512375 242.58512 
+L 273.712375 242.58512 
+L 280.912375 242.58512 
+" style="fill: none; stroke: #bb9af7; stroke-width: 2.8; stroke-linecap: square"/>
     </g>
     <g id="text_32">
-     <!-- Cassini favored-ν arc (ν 108–129°) -->
+     <!-- Cassini favoured-ν arc (ν 108–129°, B&amp;B orbit) -->
      <g style="fill: #c0caf5" transform="translate(286.672375 245.10512) scale(0.072 -0.072)">
       <defs>
        <path id="DejaVuSans-66" d="M 2375 4863 
@@ -3888,34 +3982,46 @@ z
       <use xlink:href="#DejaVuSans-61" x="421.240234"/>
       <use xlink:href="#DejaVuSans-76" x="482.519531"/>
       <use xlink:href="#DejaVuSans-6f" x="541.699219"/>
-      <use xlink:href="#DejaVuSans-72" x="602.880859"/>
-      <use xlink:href="#DejaVuSans-65" x="641.744141"/>
-      <use xlink:href="#DejaVuSans-64" x="703.267578"/>
-      <use xlink:href="#DejaVuSans-2d" x="766.744141"/>
-      <use xlink:href="#DejaVuSans-3bd" x="802.828125"/>
-      <use xlink:href="#DejaVuSans-20" x="858.6875"/>
-      <use xlink:href="#DejaVuSans-61" x="890.474609"/>
-      <use xlink:href="#DejaVuSans-72" x="951.753906"/>
-      <use xlink:href="#DejaVuSans-63" x="990.617188"/>
-      <use xlink:href="#DejaVuSans-20" x="1045.597656"/>
-      <use xlink:href="#DejaVuSans-28" x="1077.384766"/>
-      <use xlink:href="#DejaVuSans-3bd" x="1116.398438"/>
-      <use xlink:href="#DejaVuSans-20" x="1172.257812"/>
-      <use xlink:href="#DejaVuSans-31" x="1204.044922"/>
-      <use xlink:href="#DejaVuSans-30" x="1267.667969"/>
-      <use xlink:href="#DejaVuSans-38" x="1331.291016"/>
-      <use xlink:href="#DejaVuSans-2013" x="1394.914062"/>
-      <use xlink:href="#DejaVuSans-31" x="1444.914062"/>
-      <use xlink:href="#DejaVuSans-32" x="1508.537109"/>
-      <use xlink:href="#DejaVuSans-39" x="1572.160156"/>
-      <use xlink:href="#DejaVuSans-b0" x="1635.783203"/>
-      <use xlink:href="#DejaVuSans-29" x="1685.783203"/>
+      <use xlink:href="#DejaVuSans-75" x="602.880859"/>
+      <use xlink:href="#DejaVuSans-72" x="666.259766"/>
+      <use xlink:href="#DejaVuSans-65" x="705.123047"/>
+      <use xlink:href="#DejaVuSans-64" x="766.646484"/>
+      <use xlink:href="#DejaVuSans-2d" x="830.123047"/>
+      <use xlink:href="#DejaVuSans-3bd" x="866.207031"/>
+      <use xlink:href="#DejaVuSans-20" x="922.066406"/>
+      <use xlink:href="#DejaVuSans-61" x="953.853516"/>
+      <use xlink:href="#DejaVuSans-72" x="1015.132812"/>
+      <use xlink:href="#DejaVuSans-63" x="1053.996094"/>
+      <use xlink:href="#DejaVuSans-20" x="1108.976562"/>
+      <use xlink:href="#DejaVuSans-28" x="1140.763672"/>
+      <use xlink:href="#DejaVuSans-3bd" x="1179.777344"/>
+      <use xlink:href="#DejaVuSans-20" x="1235.636719"/>
+      <use xlink:href="#DejaVuSans-31" x="1267.423828"/>
+      <use xlink:href="#DejaVuSans-30" x="1331.046875"/>
+      <use xlink:href="#DejaVuSans-38" x="1394.669922"/>
+      <use xlink:href="#DejaVuSans-2013" x="1458.292969"/>
+      <use xlink:href="#DejaVuSans-31" x="1508.292969"/>
+      <use xlink:href="#DejaVuSans-32" x="1571.916016"/>
+      <use xlink:href="#DejaVuSans-39" x="1635.539062"/>
+      <use xlink:href="#DejaVuSans-b0" x="1699.162109"/>
+      <use xlink:href="#DejaVuSans-2c" x="1749.162109"/>
+      <use xlink:href="#DejaVuSans-20" x="1780.949219"/>
+      <use xlink:href="#DejaVuSans-42" x="1812.736328"/>
+      <use xlink:href="#DejaVuSans-26" x="1881.339844"/>
+      <use xlink:href="#DejaVuSans-42" x="1959.318359"/>
+      <use xlink:href="#DejaVuSans-20" x="2027.921875"/>
+      <use xlink:href="#DejaVuSans-6f" x="2059.708984"/>
+      <use xlink:href="#DejaVuSans-72" x="2120.890625"/>
+      <use xlink:href="#DejaVuSans-62" x="2162.003906"/>
+      <use xlink:href="#DejaVuSans-69" x="2225.480469"/>
+      <use xlink:href="#DejaVuSans-74" x="2253.263672"/>
+      <use xlink:href="#DejaVuSans-29" x="2292.472656"/>
      </g>
     </g>
    </g>
    <g id="line2d_37">
     <defs>
-     <path id="m16d15a823b" d="M 0 -7 
+     <path id="m440e3aeb70" d="M 0 -7 
 L -1.571598 -2.163119 
 L -6.657396 -2.163119 
 L -2.542899 0.826238 
@@ -3928,13 +4034,13 @@ L 1.571598 -2.163119
 z
 " style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#m16d15a823b" x="468.768475" y="129.026146" style="fill: #7dcfff; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pdf7aa51c55)">
+     <use xlink:href="#m440e3aeb70" x="468.768475" y="129.026146" style="fill: #7dcfff; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_38">
     <defs>
-     <path id="m85dec3bd2a" d="M 0 -7 
+     <path id="mc9a65b825c" d="M 0 -7 
 L -1.571598 -2.163119 
 L -6.657396 -2.163119 
 L -2.542899 0.826238 
@@ -3947,13 +4053,13 @@ L 1.571598 -2.163119
 z
 " style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#m85dec3bd2a" x="485.999515" y="146.976093" style="fill: #7aa2f7; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pdf7aa51c55)">
+     <use xlink:href="#mc9a65b825c" x="485.999515" y="146.976093" style="fill: #7aa2f7; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_39">
     <defs>
-     <path id="m1cd9f341a1" d="M 0 -7 
+     <path id="mce3a259ce9" d="M 0 -7 
 L -1.571598 -2.163119 
 L -6.657396 -2.163119 
 L -2.542899 0.826238 
@@ -3966,13 +4072,13 @@ L 1.571598 -2.163119
 z
 " style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#m1cd9f341a1" x="429.998635" y="99.109569" style="fill: #9ece6a; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pdf7aa51c55)">
+     <use xlink:href="#mce3a259ce9" x="429.998635" y="99.109569" style="fill: #9ece6a; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_40">
     <defs>
-     <path id="m6b1646db10" d="M 0 -7 
+     <path id="mc72d77dab9" d="M 0 -7 
 L -1.571598 -2.163119 
 L -6.657396 -2.163119 
 L -2.542899 0.826238 
@@ -3985,13 +4091,13 @@ L 1.571598 -2.163119
 z
 " style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#m6b1646db10" x="473.076235" y="117.059515" style="fill: #f7768e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pdf7aa51c55)">
+     <use xlink:href="#mc72d77dab9" x="473.076235" y="117.059515" style="fill: #f7768e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_41">
     <defs>
-     <path id="m684bd3a6f1" d="M 0 -7 
+     <path id="mf2d1bedc29" d="M 0 -7 
 L -1.571598 -2.163119 
 L -6.657396 -2.163119 
 L -2.542899 0.826238 
@@ -4004,212 +4110,140 @@ L 1.571598 -2.163119
 z
 " style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#m684bd3a6f1" x="494.615035" y="117.059515" style="fill: #e0af68; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    <g clip-path="url(#pdf7aa51c55)">
+     <use xlink:href="#mf2d1bedc29" x="494.615035" y="117.059515" style="fill: #e0af68; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </g>
    </g>
-   <g id="PathCollection_10">
-    <defs>
-     <path id="C0_0_9579c22793" d="M -0 2.236068 
-L 2.236068 -0 
-L 0 -2.236068 
-L -2.236068 -0 
-z
-"/>
-    </defs>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="64.279475" y="184.115478" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="63.093319" y="183.657066" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="61.91063" y="183.191077" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="60.731408" y="182.717629" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="59.555653" y="182.236841" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="58.38336" y="181.748832" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="57.214522" y="181.253723" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="56.049128" y="180.751635" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="54.887166" y="180.242688" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="53.728621" y="179.727004" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="52.573473" y="179.204706" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="51.421704" y="178.675915" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="50.273288" y="178.140753" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="49.128202" y="177.599344" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="564.917616" y="177.05181" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="563.779101" y="176.498275" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="562.643824" y="175.93886" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="561.511752" y="175.373689" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="560.382846" y="174.802885" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="559.257068" y="174.226572" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="558.134377" y="173.644871" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="557.014732" y="173.057906" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="555.898086" y="172.4658" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="554.784395" y="171.868675" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="553.673609" y="171.266654" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="552.565679" y="170.659859" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="551.460555" y="170.048412" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="550.358182" y="169.432435" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="549.258506" y="168.81205" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="548.161473" y="168.187378" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="547.067024" y="167.558539" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="545.9751" y="166.925656" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="544.885643" y="166.288848" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="543.798591" y="165.648236" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="542.713882" y="165.00394" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="541.631452" y="164.35608" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="540.551237" y="163.704775" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="539.473172" y="163.050144" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="538.39719" y="162.392306" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="537.323224" y="161.731379" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="536.251206" y="161.067482" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="535.181066" y="160.400733" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="534.112734" y="159.731249" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="533.046141" y="159.059147" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="531.981214" y="158.384545" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="530.917882" y="157.70756" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="529.856071" y="157.028307" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="528.795709" y="156.346903" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="527.736721" y="155.663465" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="526.679033" y="154.978107" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="525.622571" y="154.290946" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="524.567259" y="153.602096" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="523.51302" y="152.911673" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="522.45978" y="152.219792" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="521.40746" y="151.526566" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="520.355985" y="150.832112" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="519.305277" y="150.136542" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="518.255259" y="149.439972" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="517.205852" y="148.742514" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="516.156979" y="148.044284" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="515.108562" y="147.345395" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="514.060522" y="146.645961" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="513.012781" y="145.946095" style="fill: #e0af68"/>
-    </g>
-    <g clip-path="url(#p05be3ac94f)">
-     <use xlink:href="#C0_0_9579c22793" x="511.965261" y="145.245911" style="fill: #e0af68"/>
-    </g>
-   </g>
+   <path d="M 559.18031 197.969183 
+L 557.903464 197.638892 
+L 556.63042 197.297529 
+L 555.361262 196.945207 
+L 554.096069 196.582045 
+L 552.834916 196.208162 
+L 551.577871 195.823682 
+L 550.324999 195.428727 
+L 549.07636 195.023425 
+L 547.832009 194.607905 
+L 546.591996 194.182296 
+L 545.356367 193.74673 
+L 544.125161 193.301341 
+L 542.898415 192.846264 
+L 541.67616 192.381635 
+L 540.458422 191.907591 
+L 539.245224 191.424272 
+L 538.036584 190.931816 
+L 536.832514 190.430365 
+L 535.633024 189.920059 
+L 534.438118 189.401041 
+L 533.247797 188.873453 
+L 532.062058 188.337439 
+L 530.880893 187.793141 
+L 529.704292 187.240705 
+L 528.532239 186.680273 
+L 527.364716 186.111992 
+L 526.2017 185.536004 
+L 525.043166 184.952455 
+L 523.889086 184.361489 
+L 522.739426 183.763252 
+L 521.594152 183.157886 
+L 520.453225 182.545537 
+L 519.316605 181.926348 
+L 518.184246 181.300464 
+L 517.056102 180.668026 
+L 515.932124 180.02918 
+L 514.812259 179.384066 
+L 513.696454 178.732828 
+L 512.58465 178.075606 
+L 511.476789 177.412542 
+L 510.37281 176.743777 
+L 509.27265 176.06945 
+L 508.176243 175.389702 
+L 507.083521 174.70467 
+L 505.994417 174.014494 
+L 504.908858 173.319311 
+L 503.826774 172.619257 
+L 502.748089 171.91447 
+L 501.672727 171.205085 
+L 500.600614 170.491237 
+L 499.531669 169.77306 
+L 498.465813 169.050688 
+L 497.402965 168.324254 
+L 496.343044 167.593891 
+L 495.285967 166.85973 
+L 494.231648 166.121902 
+L 493.180004 165.380538 
+L 492.130947 164.635768 
+L 491.084392 163.887721 
+L 490.040249 163.136525 
+L 488.998431 162.382308 
+L 487.958849 161.625198 
+L 486.921411 160.865322 
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #1a1b26; stroke-width: 4; stroke-linecap: square"/>
+   <path d="M 559.18031 197.969183 
+L 557.903464 197.638892 
+L 556.63042 197.297529 
+L 555.361262 196.945207 
+L 554.096069 196.582045 
+L 552.834916 196.208162 
+L 551.577871 195.823682 
+L 550.324999 195.428727 
+L 549.07636 195.023425 
+L 547.832009 194.607905 
+L 546.591996 194.182296 
+L 545.356367 193.74673 
+L 544.125161 193.301341 
+L 542.898415 192.846264 
+L 541.67616 192.381635 
+L 540.458422 191.907591 
+L 539.245224 191.424272 
+L 538.036584 190.931816 
+L 536.832514 190.430365 
+L 535.633024 189.920059 
+L 534.438118 189.401041 
+L 533.247797 188.873453 
+L 532.062058 188.337439 
+L 530.880893 187.793141 
+L 529.704292 187.240705 
+L 528.532239 186.680273 
+L 527.364716 186.111992 
+L 526.2017 185.536004 
+L 525.043166 184.952455 
+L 523.889086 184.361489 
+L 522.739426 183.763252 
+L 521.594152 183.157886 
+L 520.453225 182.545537 
+L 519.316605 181.926348 
+L 518.184246 181.300464 
+L 517.056102 180.668026 
+L 515.932124 180.02918 
+L 514.812259 179.384066 
+L 513.696454 178.732828 
+L 512.58465 178.075606 
+L 511.476789 177.412542 
+L 510.37281 176.743777 
+L 509.27265 176.06945 
+L 508.176243 175.389702 
+L 507.083521 174.70467 
+L 505.994417 174.014494 
+L 504.908858 173.319311 
+L 503.826774 172.619257 
+L 502.748089 171.91447 
+L 501.672727 171.205085 
+L 500.600614 170.491237 
+L 499.531669 169.77306 
+L 498.465813 169.050688 
+L 497.402965 168.324254 
+L 496.343044 167.593891 
+L 495.285967 166.85973 
+L 494.231648 166.121902 
+L 493.180004 165.380538 
+L 492.130947 164.635768 
+L 491.084392 163.887721 
+L 490.040249 163.136525 
+L 488.998431 162.382308 
+L 487.958849 161.625198 
+L 486.921411 160.865322 
+" clip-path="url(#pdf7aa51c55)" style="fill: none; stroke: #bb9af7; stroke-width: 2.8; stroke-linecap: square"/>
   </g>
   <g id="axes_2">
    <g id="patch_9">
@@ -4222,26 +4256,26 @@ z
 " style="fill: none"/>
    </g>
    <g id="patch_10">
-    <path clip-path="url(#pdfedda7f79)" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.01; stroke-linejoin: miter"/>
+    <path clip-path="url(#p1e55c25115)" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.01; stroke-linejoin: miter"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFNCAYAAADmVoTCAAAB9UlEQVR4nO2cwQ3EMAgEwef+G70ikn/iHxNphHABKzzsYie6S0bsfxTXqgpEROyMrItEEiLAjlRM6sUgTHYClTBgI351EWI7Oz1mG588l6fFUCUesAwTSYoZJquVT3YCM7Zfii1MRGbT+ARiQgwlohJiO9S01zDRBBBqMQB2XR6fWJg0CyAy2QifiJ53GCbEE3pqAuhhwoAVmU3DBHhFpmICVEK8Z4OYEC8wIZ+UNZhKqGdAQIRxLFAJxUQTQA0TUXYIEdNks4gAGiYmmhSrBjUgokkxNdkAkWZMiFHgGdQD9iMRislVF5kT8CBS15jJdhLRdEd1tQBSbHreIUQsQ2mvrHdnAvheVACJE5CoxDSoLbcCKMWWAGq2IzIbdFOSpJjyCXGgayrxmE2THdVQGiaPBQVQc7cXXUE1TIgjw3QrYFJsYaI50AfsQUQzHiEmy8NEImKa9kR3mjFBHDtMTpUQIgAVarIRIr2YBOMToBITE0AEMhsgQmxHFEBNd1RmQ/6HXq+kHRPGsZbf+EEBRMD2YoJ810LDRNNiKsUD9gsRiAmRnfHJZyLEV0eagWWmveW/b73M1o4J8tkfUQAl22lnNotPVGCHyWN5Di8TE0uLIRHNX8gvD5Mx21tE82k1TYs93YECyNwKJCL9zKZh0upW4AF7AzPBMzutgp3rAAAAAElFTkSuQmCC" id="image6c71f3574c" transform="scale(1 -1) translate(0 -239.76)" x="570.96" y="-23.76" width="12.24" height="239.76"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFLCAYAAAAwD2ffAAABsElEQVR4nO2aQQ4DMQgDAe3/39x74IYrjZB5gOW42EtIM7MqlvVVZa5BFEzWABERX1UxjnNN2CyFJqnQRMBE1GypaDaKsKA+sQE7k1vJJmo2xXEwBnSyjUwwzXYq2UAGdLJ1JppksyYNBNNsqqkAMuQ47QcQzGdUNRVAhhwbcGTiZHtBMMl2zYCKZEMFNUVYG3Bigmk2ykQN6pNbmrjZ/sTEad/Ly7o/MbEBe117hsgMBZM1hkjYCEmfCDQJzhJGAqIIJcWvowolCYhEExvwBTkXSprjOJReEBvwLWvSC2RAazIwkaT9HsMGHEo2bjGmR5AmgTGgZBgmzfYOpadswF4oTbYQ9wx4ThPITsmhNDNZl6TtWUsYBhNQsyk+XpwVmajZNKEkYGIDDkwwmiTlSnvNgCJNILdRh1Iv1sJhzwSzIrMBe1mTXqpQguyUbMARBHIbBWkStwyIudJydtSq2d4GfJk4lDqTYwZUHIe1cGDsqB1KvUAGxPwX1AYcQSjvOxxNMOsg0APrMQNirrQ24AgCuY2Sms2h1EDilgFvaXLNgNakg2B21CRNMAbEPDr/AOO3CF58++VaAAAAAElFTkSuQmCC" id="imagedbcb2e51ca" transform="scale(1 -1) translate(0 -238.32)" x="570.96" y="-23.76" width="12.24" height="238.32"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_8">
      <g id="line2d_42">
       <defs>
-       <path id="m13cb248cb8" d="M 0 0 
+       <path id="m967b49ed88" d="M 0 0 
 L 3.5 0 
 " style="stroke: #565f89; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m13cb248cb8" x="583.016506" y="223.761975" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m967b49ed88" x="583.016506" y="219.691693" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_33">
       <!-- 0.2 -->
-      <g style="fill: #c0caf5" transform="translate(590.016506 226.421428) scale(0.07 -0.07)">
+      <g style="fill: #c0caf5" transform="translate(590.016506 222.351146) scale(0.07 -0.07)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-32" x="95.410156"/>
@@ -4251,12 +4285,12 @@ L 3.5 0
     <g id="ytick_9">
      <g id="line2d_43">
       <g>
-       <use xlink:href="#m13cb248cb8" x="583.016506" y="173.901013" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m967b49ed88" x="583.016506" y="170.848301" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_34">
       <!-- 0.4 -->
-      <g style="fill: #c0caf5" transform="translate(590.016506 176.560466) scale(0.07 -0.07)">
+      <g style="fill: #c0caf5" transform="translate(590.016506 173.507754) scale(0.07 -0.07)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-34" x="95.410156"/>
@@ -4266,12 +4300,12 @@ L 3.5 0
     <g id="ytick_10">
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m13cb248cb8" x="583.016506" y="124.04005" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m967b49ed88" x="583.016506" y="122.004909" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_35">
       <!-- 0.6 -->
-      <g style="fill: #c0caf5" transform="translate(590.016506 126.699503) scale(0.07 -0.07)">
+      <g style="fill: #c0caf5" transform="translate(590.016506 124.664362) scale(0.07 -0.07)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-36" x="95.410156"/>
@@ -4281,12 +4315,12 @@ L 3.5 0
     <g id="ytick_11">
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m13cb248cb8" x="583.016506" y="74.179088" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m967b49ed88" x="583.016506" y="73.161517" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_36">
       <!-- 0.8 -->
-      <g style="fill: #c0caf5" transform="translate(590.016506 76.838541) scale(0.07 -0.07)">
+      <g style="fill: #c0caf5" transform="translate(590.016506 75.82097) scale(0.07 -0.07)">
        <use xlink:href="#DejaVuSans-30"/>
        <use xlink:href="#DejaVuSans-2e" x="63.623047"/>
        <use xlink:href="#DejaVuSans-38" x="95.410156"/>
@@ -4296,7 +4330,7 @@ L 3.5 0
     <g id="ytick_12">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m13cb248cb8" x="583.016506" y="24.318125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m967b49ed88" x="583.016506" y="24.318125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_37">
@@ -4402,7 +4436,7 @@ L 99.599517 434.574125
 L 99.599517 391.798721 
 L 73.110966 391.798721 
 z
-" clip-path="url(#p575e9fbfc9)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#p3bf415b639)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
    <g id="patch_14">
     <path d="M 174.990007 434.574125 
@@ -4410,7 +4444,7 @@ L 201.478558 434.574125
 L 201.478558 387.866818 
 L 174.990007 387.866818 
 z
-" clip-path="url(#p575e9fbfc9)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#p3bf415b639)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
    <g id="patch_15">
     <path d="M 276.869049 434.574125 
@@ -4418,7 +4452,7 @@ L 303.3576 434.574125
 L 303.3576 386.89458 
 L 276.869049 386.89458 
 z
-" clip-path="url(#p575e9fbfc9)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#p3bf415b639)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
    <g id="patch_16">
     <path d="M 378.74809 434.574125 
@@ -4426,7 +4460,7 @@ L 405.236641 434.574125
 L 405.236641 388.01572 
 L 378.74809 388.01572 
 z
-" clip-path="url(#p575e9fbfc9)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#p3bf415b639)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
    <g id="patch_17">
     <path d="M 480.627132 434.574125 
@@ -4434,7 +4468,7 @@ L 507.115683 434.574125
 L 507.115683 389.581304 
 L 480.627132 389.581304 
 z
-" clip-path="url(#p575e9fbfc9)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#p3bf415b639)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
    <g id="patch_18">
     <path d="M 99.599517 434.574125 
@@ -4442,7 +4476,7 @@ L 126.088067 434.574125
 L 126.088067 432.58188 
 L 99.599517 432.58188 
 z
-" clip-path="url(#p575e9fbfc9)" style="fill: #bb9af7; opacity: 0.9"/>
+" clip-path="url(#p3bf415b639)" style="fill: #bb9af7; opacity: 0.9"/>
    </g>
    <g id="patch_19">
     <path d="M 201.478558 434.574125 
@@ -4450,7 +4484,7 @@ L 227.967109 434.574125
 L 227.967109 432.5797 
 L 201.478558 432.5797 
 z
-" clip-path="url(#p575e9fbfc9)" style="fill: #bb9af7; opacity: 0.9"/>
+" clip-path="url(#p3bf415b639)" style="fill: #bb9af7; opacity: 0.9"/>
    </g>
    <g id="patch_20">
     <path d="M 303.3576 434.574125 
@@ -4458,7 +4492,7 @@ L 329.84615 434.574125
 L 329.84615 432.579686 
 L 303.3576 432.579686 
 z
-" clip-path="url(#p575e9fbfc9)" style="fill: #bb9af7; opacity: 0.9"/>
+" clip-path="url(#p3bf415b639)" style="fill: #bb9af7; opacity: 0.9"/>
    </g>
    <g id="patch_21">
     <path d="M 405.236641 434.574125 
@@ -4466,7 +4500,7 @@ L 431.725192 434.574125
 L 431.725192 432.579686 
 L 405.236641 432.579686 
 z
-" clip-path="url(#p575e9fbfc9)" style="fill: #bb9af7; opacity: 0.9"/>
+" clip-path="url(#p3bf415b639)" style="fill: #bb9af7; opacity: 0.9"/>
    </g>
    <g id="patch_22">
     <path d="M 507.115683 434.574125 
@@ -4474,7 +4508,7 @@ L 533.604233 434.574125
 L 533.604233 432.579686 
 L 507.115683 432.579686 
 z
-" clip-path="url(#p575e9fbfc9)" style="fill: #bb9af7; opacity: 0.9"/>
+" clip-path="url(#p3bf415b639)" style="fill: #bb9af7; opacity: 0.9"/>
    </g>
    <g id="patch_23">
     <path d="M 126.088067 434.574125 
@@ -4482,7 +4516,7 @@ L 152.576618 434.574125
 L 152.576618 379.409751 
 L 126.088067 379.409751 
 z
-" clip-path="url(#p575e9fbfc9)" style="fill: #c0caf5; opacity: 0.9"/>
+" clip-path="url(#p3bf415b639)" style="fill: #c0caf5; opacity: 0.9"/>
    </g>
    <g id="patch_24">
     <path d="M 227.967109 434.574125 
@@ -4490,7 +4524,7 @@ L 254.45566 434.574125
 L 254.45566 374.307213 
 L 227.967109 374.307213 
 z
-" clip-path="url(#p575e9fbfc9)" style="fill: #c0caf5; opacity: 0.9"/>
+" clip-path="url(#p3bf415b639)" style="fill: #c0caf5; opacity: 0.9"/>
    </g>
    <g id="patch_25">
     <path d="M 329.84615 434.574125 
@@ -4498,7 +4532,7 @@ L 356.334701 434.574125
 L 356.334701 373.067702 
 L 329.84615 373.067702 
 z
-" clip-path="url(#p575e9fbfc9)" style="fill: #c0caf5; opacity: 0.9"/>
+" clip-path="url(#p3bf415b639)" style="fill: #c0caf5; opacity: 0.9"/>
    </g>
    <g id="patch_26">
     <path d="M 431.725192 434.574125 
@@ -4506,7 +4540,7 @@ L 458.213743 434.574125
 L 458.213743 373.434879 
 L 431.725192 373.434879 
 z
-" clip-path="url(#p575e9fbfc9)" style="fill: #c0caf5; opacity: 0.9"/>
+" clip-path="url(#p3bf415b639)" style="fill: #c0caf5; opacity: 0.9"/>
    </g>
    <g id="patch_27">
     <path d="M 533.604233 434.574125 
@@ -4514,13 +4548,13 @@ L 560.092784 434.574125
 L 560.092784 373.801124 
 L 533.604233 373.801124 
 z
-" clip-path="url(#p575e9fbfc9)" style="fill: #c0caf5; opacity: 0.9"/>
+" clip-path="url(#p3bf415b639)" style="fill: #c0caf5; opacity: 0.9"/>
    </g>
    <g id="matplotlib.axis_5">
     <g id="xtick_14">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m0bdc7879fd" x="112.843792" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="112.843792" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_39">
@@ -4540,7 +4574,7 @@ z
     <g id="xtick_15">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m0bdc7879fd" x="214.722834" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="214.722834" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_40">
@@ -4560,7 +4594,7 @@ z
     <g id="xtick_16">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m0bdc7879fd" x="316.601875" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="316.601875" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_41">
@@ -4585,7 +4619,7 @@ z
     <g id="xtick_17">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m0bdc7879fd" x="418.480916" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="418.480916" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_42">
@@ -4617,7 +4651,7 @@ z
     <g id="xtick_18">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m0bdc7879fd" x="520.359958" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#m405bce3227" x="520.359958" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_43">
@@ -4643,11 +4677,11 @@ z
      <g id="line2d_52">
       <path d="M 48.761875 434.574125 
 L 584.441875 434.574125 
-" clip-path="url(#p575e9fbfc9)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p3bf415b639)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m397f7840c7" x="48.761875" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mb12d12cfab" x="48.761875" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_44">
@@ -4661,11 +4695,11 @@ L 584.441875 434.574125
      <g id="line2d_54">
       <path d="M 48.761875 409.643644 
 L 584.441875 409.643644 
-" clip-path="url(#p575e9fbfc9)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p3bf415b639)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_55">
       <g>
-       <use xlink:href="#m397f7840c7" x="48.761875" y="409.643644" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mb12d12cfab" x="48.761875" y="409.643644" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_45">
@@ -4680,11 +4714,11 @@ L 584.441875 409.643644
      <g id="line2d_56">
       <path d="M 48.761875 384.713162 
 L 584.441875 384.713162 
-" clip-path="url(#p575e9fbfc9)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p3bf415b639)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_57">
       <g>
-       <use xlink:href="#m397f7840c7" x="48.761875" y="384.713162" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mb12d12cfab" x="48.761875" y="384.713162" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_46">
@@ -4699,11 +4733,11 @@ L 584.441875 384.713162
      <g id="line2d_58">
       <path d="M 48.761875 359.782681 
 L 584.441875 359.782681 
-" clip-path="url(#p575e9fbfc9)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p3bf415b639)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_59">
       <g>
-       <use xlink:href="#m397f7840c7" x="48.761875" y="359.782681" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mb12d12cfab" x="48.761875" y="359.782681" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_47">
@@ -4718,11 +4752,11 @@ L 584.441875 359.782681
      <g id="line2d_60">
       <path d="M 48.761875 334.8522 
 L 584.441875 334.8522 
-" clip-path="url(#p575e9fbfc9)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#p3bf415b639)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_61">
       <g>
-       <use xlink:href="#m397f7840c7" x="48.761875" y="334.8522" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mb12d12cfab" x="48.761875" y="334.8522" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_48">
@@ -5006,16 +5040,6 @@ L 628 0
 L 628 4666 
 z
 " transform="scale(0.015625)"/>
-       <path id="DejaVuSans-3c" d="M 4684 3150 
-L 1459 2003 
-L 4684 863 
-L 4684 294 
-L 678 1747 
-L 678 2266 
-L 4684 3719 
-L 4684 3150 
-z
-" transform="scale(0.015625)"/>
       </defs>
       <use xlink:href="#DejaVuSans-52"/>
       <use xlink:href="#DejaVuSans-75" x="64.982422"/>
@@ -5078,6 +5102,21 @@ z
     <g id="text_53">
      <!-- JBT 0.5 m + SPENCER (m&lt;24.5) -->
      <g style="fill: #c0caf5" transform="translate(462.437875 367.939575) scale(0.072 -0.072)">
+      <defs>
+       <path id="DejaVuSans-4a" d="M 628 4666 
+L 1259 4666 
+L 1259 325 
+Q 1259 -519 939 -900 
+Q 619 -1281 -91 -1281 
+L -331 -1281 
+L -331 -750 
+L -134 -750 
+Q 284 -750 456 -515 
+Q 628 -281 628 325 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      </defs>
       <use xlink:href="#DejaVuSans-4a"/>
       <use xlink:href="#DejaVuSans-42" x="29.492188"/>
       <use xlink:href="#DejaVuSans-54" x="98.095703"/>
@@ -5112,13 +5151,13 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p05be3ac94f">
+  <clipPath id="pdf7aa51c55">
    <rect x="48.761875" y="24.318125" width="516.9312" height="239.33262"/>
   </clipPath>
-  <clipPath id="pdfedda7f79">
+  <clipPath id="p1e55c25115">
    <rect x="571.049875" y="24.318125" width="11.966631" height="239.33262"/>
   </clipPath>
-  <clipPath id="p575e9fbfc9">
+  <clipPath id="p3bf415b639">
    <rect x="48.761875" y="334.8522" width="535.68" height="99.721925"/>
   </clipPath>
  </defs>

--- a/crates/p9-survey/src/lib.rs
+++ b/crates/p9-survey/src/lib.rs
@@ -77,7 +77,9 @@ pub fn run_survey(n_samples: usize, seed: u64) -> SurveyDataset {
         rubin_dec_max_deg: refine::RUBIN_DEC_MAX_DEG,
         favored_nu_lo_deg: nu_lo,
         favored_nu_hi_deg: nu_hi,
-        favored_arc: ephemeris::favored_arc(&p9_core::types::P9Params::mcmc_2021(), 64),
+        // The favored-ν zone belongs to the orbit Fienga et al. actually fit
+        // (the Brown & Batygin geometry), so map it through that orbit.
+        favored_arc: ephemeris::favored_arc(&p9_2016_cassini_ranging::brown_batygin_orbit(), 64),
     };
 
     SurveyDataset {

--- a/scripts/plot_survey.py
+++ b/scripts/plot_survey.py
@@ -191,6 +191,17 @@ def main() -> None:
     import matplotlib.pyplot as plt
     from matplotlib.gridspec import GridSpec
     from scipy.ndimage import gaussian_filter
+    from matplotlib.colors import LinearSegmentedColormap
+    import matplotlib.patheffects as pe
+
+    # Neutral grey "probability cloud" so the coloured overlays read clearly on
+    # the dark background (the warm magma map fought the orange/red overlays).
+    p9_cloud = LinearSegmentedColormap.from_list(
+        "p9cloud",
+        [(0.0, (0, 0, 0, 0.0)), (0.35, (0.50, 0.52, 0.60, 0.55)),
+         (1.0, (0.90, 0.92, 0.99, 1.0))],
+    )
+    outline = [pe.Stroke(linewidth=4.0, foreground="#1a1b26"), pe.Normal()]
 
     g = d.grid
     extent = [g.ra_min_deg, g.ra_max_deg, g.dec_min_deg, g.dec_max_deg]
@@ -204,7 +215,7 @@ def main() -> None:
     ax = fig.add_subplot(gs[0]); ax.set_facecolor("none")
     H = gaussian_filter(grid_2d(primary, g), 1.2)
     im = ax.imshow(H / H.max(), origin="lower", extent=extent, aspect="auto",
-                   cmap="magma", vmin=0.04, alpha=0.92, zorder=2)
+                   cmap=p9_cloud, vmin=0.02, zorder=2)
     xc = (np.arange(g.n_ra) + 0.5) * (g.ra_max_deg - g.ra_min_deg) / g.n_ra + g.ra_min_deg
     yc = (np.arange(g.n_dec) + 0.5) * (g.dec_max_deg - g.dec_min_deg) / g.n_dec + g.dec_min_deg
     for s in d.studies:
@@ -219,19 +230,31 @@ def main() -> None:
                 label=f"{s.solution.name.split('(')[0].strip()} — V≈{s.v_median:.1f}, {s.dist_median_au:.0f} AU")
 
     gp = np.array(d.overlays.galactic_plane); ec = np.array(d.overlays.ecliptic)
-    op = np.argsort(gp[:, 0]); ax.plot(gp[op, 0], gp[op, 1], ls="--", color=MUTE, lw=2,
-                                       alpha=0.9, zorder=3, label="Galactic plane (hard zone)")
+    op = np.argsort(gp[:, 0]); ax.plot(gp[op, 0], gp[op, 1], ls="--", color="#9aa5ce", lw=1.8,
+                                       alpha=0.9, zorder=3, path_effects=outline,
+                                       label="Galactic plane (crowded zone)")
     oe = np.argsort(ec[:, 0]); ax.plot(ec[oe, 0], ec[oe, 1], ls=":", color=FG, lw=0.9,
                                        alpha=0.5, zorder=3, label="Ecliptic")
 
     # Search-narrowing overlays: Rubin cede line + Cassini favored-ν arc.
     c = d.constraints
-    ax.axhspan(g.dec_min_deg, c.rubin_dec_max_deg, color=MUTE, alpha=0.10, zorder=1)
-    ax.axhline(c.rubin_dec_max_deg, color="#f7768e", ls="-.", lw=1.2, alpha=0.85, zorder=3,
-               label=f"Rubin limit Dec +{c.rubin_dec_max_deg:.0f}° (JBT keeps north)")
+    ax.axhspan(g.dec_min_deg, c.rubin_dec_max_deg, color=MUTE, alpha=0.16, zorder=1)
+    ax.axhline(c.rubin_dec_max_deg, color="#c0caf5", ls=(0, (6, 3)), lw=1.4, alpha=0.9,
+               zorder=5, label=f"Rubin reach (Dec < +{c.rubin_dec_max_deg:.0f}°)")
+    # The favored-ν arc is a compact curve that can cross RA = 0/360; draw it as
+    # connected segments (split on wrap) in a high-contrast colour with a dark
+    # outline so it reads on the grey cloud.
     arc = np.array(c.favored_arc)
-    ax.scatter(arc[:, 0], arc[:, 1], s=10, c="#e0af68", marker="D", edgecolors="none",
-               zorder=7, label=f"Cassini favored-ν arc (ν {c.favored_nu_lo_deg:.0f}–{c.favored_nu_hi_deg:.0f}°)")
+    ra_a, dec_a = arc[:, 0], arc[:, 1]
+    start = 0
+    for k in range(1, len(ra_a) + 1):
+        if k == len(ra_a) or abs(ra_a[k] - ra_a[k - 1]) > 180:
+            sl = slice(start, k)
+            ax.plot(ra_a[sl], dec_a[sl], color="#bb9af7", lw=2.8, zorder=8,
+                    path_effects=outline)
+            start = k
+    ax.plot([], [], color="#bb9af7", lw=2.8,
+            label=f"Cassini favoured-ν arc (ν {c.favored_nu_lo_deg:.0f}–{c.favored_nu_hi_deg:.0f}°, B&B orbit)")
 
     ax.set_xlim(g.ra_min_deg, g.ra_max_deg); ax.set_ylim(g.dec_min_deg, g.dec_max_deg)
     ax.invert_xaxis()


### PR DESCRIPTION
Two fixes prompted by review of the favored-ν arc.

**1. Map the arc through the correct orbit.** The favored ν∈[108,129°] is Fienga et al.'s fit on the Brown & Batygin orbit, so `run_survey` now emits the `favored_arc` via `p9_2016_cassini_ranging::brown_batygin_orbit()` (Ω=113°, i=30°, 700 AU, e=0.6) instead of the 2021 MCMC orbit. The real arc is a **compact** curve: core ν 108–129° → RA ≈ 1.4–2.7ʰ, Dec −15…−23° (with ±tolerance, RA 0.3–3.7ʰ, Dec −8…−27°), heliocentric ~550–720 AU — i.e. southern, in Cetus, well inside Rubin's reach. (The earlier "RA 0–24h" was an RA-wrap artifact of taking min/max across the 0h crossing.)

**2. Readable overlays.** Replaced the magma heatmap (which fought the warm overlays) with a neutral grey "probability cloud" so coloured overlays pop; the favored-ν arc is now a connected purple line (split on RA wrap) with a dark outline, the Rubin line a light dashed reach-marker, and the galactic plane/ecliptic carry dark outlines too.

`cargo build/test/fmt` green (26 tests); figure regenerated.