### PR TITLE
Add dark/standard theme switch to p9-survey plotter

### DIFF
--- a/crates/p9-survey/README.md
+++ b/crates/p9-survey/README.md
@@ -37,6 +37,8 @@ cargo run -p p9-survey --bin survey -- \
 # 2. Python renders it (no astronomy of its own — only what Rust emitted):
 python3 scripts/plot_survey.py \
     crates/p9-survey/p9_survey_data.json crates/p9-survey/p9_survey_sky.svg
+# add `--theme standard` for a conventional light/matplotlib scheme;
+# the default `--theme dark` is the Tokyo-Night palette used throughout.
 ```
 
 The JSON is a `schema::SurveyDataset` (see `src/schema.rs`); the plotter mirrors

--- a/crates/p9-survey/p9_survey_sky.svg
+++ b/crates/p9-survey/p9_survey_sky.svg
@@ -6,7 +6,7 @@
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-06-15T10:53:58.952442</dc:date>
+    <dc:date>2026-06-15T10:58:45.350434</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -45,18 +45,18 @@ L 48.761875 120.051173
 L 565.693075 120.051173 
 L 565.693075 263.650745 
 z
-" clip-path="url(#pca0bb86289)" style="fill: #565f89; opacity: 0.16; stroke: #565f89; stroke-linejoin: miter"/>
+" clip-path="url(#p0e05e55de8)" style="fill: #565f89; opacity: 0.16; stroke: #565f89; stroke-linejoin: miter"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m8777f8dc6c" d="M 0 0 
+       <path id="mefa7869d34" d="M 0 0 
 L 0 3.5 
 " style="stroke: #565f89; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8777f8dc6c" x="565.693075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="565.693075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
@@ -112,7 +112,7 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m8777f8dc6c" x="522.615475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="522.615475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
@@ -152,7 +152,7 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m8777f8dc6c" x="479.537875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="479.537875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
@@ -187,7 +187,7 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m8777f8dc6c" x="436.460275" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="436.460275" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
@@ -233,7 +233,7 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m8777f8dc6c" x="393.382675" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="393.382675" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
@@ -288,7 +288,7 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m8777f8dc6c" x="350.305075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="350.305075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
@@ -319,7 +319,7 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m8777f8dc6c" x="307.227475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="307.227475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
@@ -334,7 +334,7 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m8777f8dc6c" x="264.149875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="264.149875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
@@ -349,7 +349,7 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m8777f8dc6c" x="221.072275" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="221.072275" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
@@ -364,7 +364,7 @@ z
     <g id="xtick_10">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m8777f8dc6c" x="177.994675" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="177.994675" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
@@ -379,7 +379,7 @@ z
     <g id="xtick_11">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m8777f8dc6c" x="134.917075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="134.917075" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
@@ -394,7 +394,7 @@ z
     <g id="xtick_12">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m8777f8dc6c" x="91.839475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="91.839475" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
@@ -409,7 +409,7 @@ z
     <g id="xtick_13">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m8777f8dc6c" x="48.761875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="48.761875" y="263.650745" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
@@ -678,12 +678,12 @@ z
     <g id="ytick_1">
      <g id="line2d_14">
       <defs>
-       <path id="m05b190d6fa" d="M 0 0 
+       <path id="me988d85cd5" d="M 0 0 
 L -3.5 0 
 " style="stroke: #565f89; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m05b190d6fa" x="48.761875" y="233.734168" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me988d85cd5" x="48.761875" y="233.734168" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
@@ -756,7 +756,7 @@ z
     <g id="ytick_2">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m05b190d6fa" x="48.761875" y="203.81759" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me988d85cd5" x="48.761875" y="203.81759" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
@@ -806,7 +806,7 @@ z
     <g id="ytick_3">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m05b190d6fa" x="48.761875" y="173.901013" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me988d85cd5" x="48.761875" y="173.901013" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
@@ -822,7 +822,7 @@ z
     <g id="ytick_4">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m05b190d6fa" x="48.761875" y="143.984435" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me988d85cd5" x="48.761875" y="143.984435" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
@@ -854,7 +854,7 @@ z
     <g id="ytick_5">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m05b190d6fa" x="48.761875" y="114.067858" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me988d85cd5" x="48.761875" y="114.067858" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
@@ -870,7 +870,7 @@ z
     <g id="ytick_6">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m05b190d6fa" x="48.761875" y="84.15128" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me988d85cd5" x="48.761875" y="84.15128" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
@@ -886,7 +886,7 @@ z
     <g id="ytick_7">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m05b190d6fa" x="48.761875" y="54.234703" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me988d85cd5" x="48.761875" y="54.234703" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
@@ -977,9 +977,9 @@ z
      </g>
     </g>
    </g>
-   <g clip-path="url(#pca0bb86289)">
+   <g clip-path="url(#p0e05e55de8)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAs4AAAFNCAYAAAAQIOnHAAAaIUlEQVR4nO3dx7ObZ5YfYIQPOd5ASiQlquXu8taecZVrli4vvPNf77FnRh2UqETyBuACFxnwpjc2z2G9mGJ3S+rnWf741YtwEQ6x+J1aDQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAX7f63/oOlGo0ms04b4SPodmMr282qyrK6/V6eE690WiU3sdarVZr1OP7c67j6Xj6EOecjsdjmJ9O4fnH9Po4Px7j+3k6ncLrD4f94Zz7AwDwc3HWUAgAAH+vDM4AAFDA4AwAAAUMzgAAUMDgDAAABQzOAABQwOAMAAAFDM4AAFDg7GUd2SKSbOFIq9VuheekC0qSc6r4nKrVCheaVFUruz7M37MwJcwzjXq8MOWYLBA5V7bQJFuYcjrGi0iy6/e73S7Ks8Ulh8MhzI9Jvttvw/Pz243P2e/L76flKgDAh+AXZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAAChgcAYAgAIGZwAAKFAfDEbD6B+y/uJ2u9OJ8k63G+edXje5Pszb7U47ylut+Haz69Nz2u3wnFarHfZBZ/3O5zoek57lU9yzfO45Wc9ydn7Wm7zf7/ZRvtsl/ctJn3KWb7eb7Tn5Zr1eh/lmFebR48rOzu7jbhc/B8dj3CkNAPy61Ov1cNeJX5wBAKCAwRkAAAoYnAEAoIDBGQAAChicAQCggMEZAAAKGJwBAKBA9enL3/4m/IdWK+w17nb7/SgfDsdhH/RgOBpFeX8wHER51vvc7cZ5q9VOep/brSivqvhxZX3N9UbjrP9cZH3Kh0PcAXw6Hs/qcT6dTlmPc9g9nN3uB+trTvqgd9n5280mylerx1WUr5P88XGxDK9fv9vvnHU+Zx3R2W2uk3Oyx6QPGgD+uhqNeJ47d+9H1WqFc6RfnAEAoIDBGQAAChicAQCggMEZAAAKGJwBAKCAwRkAAAoYnAEAoIDBGQAAClT/6R/+6b9E/9BJFo4MBvFCk9F4Oo7yfj9edJItHGk06kkeLyKp1+v1KM+carVwgUh6/TFeOHI6HcP8eDzFi06S67OFJqdTfD9Ptfj64+EQLlJJF6+c4sUr2eM9d8FKtggmW6Sy3W62Ub7ZxEtKVqtluKQkWmqSLUB5XMZLVJbLh0WULxbzh3POyRaprFbLxyjPnoPsOcteOwDwS5PNc1UVLyLJ5tRs7jx3UV+2kM8vzgAAUMDgDAAABQzOAABQwOAMAAAFDM4AAFDA4AwAAAUMzgAAUKD6z//4T/81+oesZ7mqqrBPL+9ljvuXM1k37fEY9w7n+SnrNQ77iI/HuAc5Pz/pLz4ew3y33YZdvGlHb3a7SR902tecnFNP/i6NeuOsXuxMs1mFr4csz/oS+/192Mc4nV4V903vdrvwb75eP4Z9ylkv82Ixj/udH2bz5Pqw93mZ5Kuk9/ncPuis+3q/j58HAPjQGo14Luwm/cvdXr8X5cPhOOxZHk8uJlF+efX0SZRfP/n4aXj95ZOrKM/6oP3iDAAABQzOAABQwOAMAAAFDM4AAFDA4AwAAAUMzgAAUMDgDAAABaonT558HP1Do1FP+nzjPOs7znqTd7vdNsr3+3d7eN93/W4X9yDv9/swX69XSSdu3JW7Wa/CTtysA3izXm+ifLvdhHnWrRv1EddqtdrxGPc4n6vRiPuaq6qV9HTH/cv1Rj38z1d2fXZ+q9Wqzrk+y9vtTvuds9udTnRtL+mMHI0m4yi/2F6Hr8HstfP4GPdBZz3RWb/zcvkQ9kc/zO9nUZ71TS8XD+H5m038Gt9uN+HjzbrWAfj1arXa73y/1mq1WifpZR4Ox8MoT79jkz7lrH/5o49fPIvyZ88/+zS+3VF4u91uN5wFqqoK5xK/OAMAQAGDMwAAFDA4AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFKg6nXa4HCJbaLLbxYtFttttuERhtcoWjqzDBSKPj8twOcR8dncf5vM4f5jfz+Pz4+UTm/U6vP/nLofI8t12G+bpopNTvOjkdDyFf5dsEUmjHi86qTca4fX5ApRmuNDk3EUn0YKS9+WdbjcsVu/1Bv0o7/eHg+CM8DXeasWLUbJlLJ1OXPKe5VnJ++FwOER59lrLFpc8PMSv8fu7m7soz98rs/CcbCHLZhMv+Vkny4KOx/jxAvCXV6/Hi+uy765sOdhgOB5F+cXldbi45OnT5x9F+Ucff/I8yp+9ePlJlF9eXl+H92cwCBes9Pv9d+aAWq1W63Q64eNttapwXsnmJL84AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFDA4AwBAgerhYRF2uO52u7B3eLPZZH3NYS/zm9c//hTn3/8Y5be3b26jfPEwm0V51sv8uIzz1eox7JXO+pePSefubr8N+6yzjt7snEzWo32uRtZDmPQyZ73P7+lxDjuPs/OzjuRWO+5U7iY9k92kZzLqn4y6nf98RtgF3esNwrOzTulzuzA73V54f4bDcdhJOZlcTqN8tboO33MXl0/CTs20C312F763ZrPb8PqHh7j3eZH0QWfvUb3PAOdrNOLv1243/i7KvgPHk4tJlGe9zB8/+/RFlL/87HefR/nzpJd5OBqFOw6Gg0HYE93v98Pvxna7He5/qKpm2Mtci+usa8fDIZy3jsdj+F3kF2cAAChgcAYAgAIGZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAAChQvXr16uvoH5aL+UOU3929vYnyt29+fB3lN29/ehvls/vbuyhfJLe7zvuXN0ke9jLv97ukf3kf9vWdTqdTlP+9qdfjAsR6Pe6Jfk/vc5LH11etVtjH2G53wv7GqFM561/O+pq73azfOe5lHgzHYffkaDwJuypHo2mYZ12b2XOQndPrDcL7Px5fTKN8/eQx7IN+mN+Hvcz39zfhe/fuNv5syK7PPmOyDvbNZh32Pu/3u32UA/wSVFW836DTib+7su+c6cXVRZRfXT29jvKsl/mzz//jb6P8o4+fPwtvdzq5jPLJeDyN8kHS19zuxPscmo1GOB8ckp7l7WYbzoXr9SqcIx9Xq/A7Z7eN95n4xRkAAAoYnAEAoIDBGQAAChicAQCggMEZAAAKGJwBAKCAwRkAAAoYnAEAoED9v/33//k/on9YrZZhUfTDwyxcirBI8myZwWq1DJcunLu4xIKSX7dGI1ukUr5gJVuW0m7HZeutdju8PluY0h/Ei0tGo3gBynA0mYTXj+OFJtk56QKXXrzAJXvOMrvtNnwvZkuKskUns7ub23Oun8/u7qM8++zJF6aswoUp2WeMzxLgHNlisHMWdNVqtdpgOAoXglxcPrmK8qdPn38U5c9ffPZplL/87HefR/nV9fWTKJ9Op+FCk2zRyWg0Cr/Ter1e9l0ULnw5HA7hMqv1eh3Oo4vFIvwums8f7uN8HubZOatkMYpfnAEAoIDBGQAAChicAQCggMEZAAAKGJwBAKCAwRkAAAoYnAEAoED96UcvnkX/kPUmb9bndaPqX+ZvLevajDqfa7VaraparTBvxXmv1w/7lHu9QdhhORiOhmE+GIddnqNx3OM8mVxOo3w8uQg7NQeDuCs066FuVe3w8WbWSW/yevUYdrbPZ3ezKL+/j3uf727f3CTXn9UHvVjMF1G+Wa/P+mw7Hg+HKAd+mbK9AVkv87kd/lkv85Onzz6O8k9f/vazKP/sN7/7D1E+mUwuwnwa59NJ3Ms8Ho+nUZ71MrdaVfhdcTwej1G+Wq3D74SHh4fkO+E+/k64u0++E+LrX3371TdR/sP3X38b5bPkO8ovzgAAUMDgDAAABQzOAABQwOAMAAAFDM4AAFDA4AwAAAUMzgAAUKCe9RbqKIX/V9YHnfU+Z92fnW6vG+VZH3S/n3SFjqdhX/N4HPc4Ty+uws7OYdI5Osn6oIdx33T2eJvN+DNmt9vto3y5mD9EedbXfHf7NuzyvL15/TY5J+z4fJjfz6P88XGxjPLV6nEV5VnXvU57+Ms497M5+wzOPmuzz8LLq6dPovzZ85cvovzFJ7/5NMqfv3j5MsovLi7C3ueLi2mYZz3Oo9Ew/IzPepmz5y2bC1erdfhZmPUy393H/cu3N7fhZ/bt7d2bKP/6q9//Kcm/jPLXP333fXh/bt+G3wmr1TLsm/aLMwAAFDA4AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFAi7D4G/nKpqVVHebnc6Ud5qt8N+5F5vEPY+D4ajsGd5OBwPo3wyjfudp9OrsBP04vI67BDNrh9PLqZR3mrFXaGZw+EQ9j4vFvNFlM9nd/dRnvU+Zz3R93dxvniYhb3Pi6SHOuuDznqft9vNNsr1QfNr8aG68Xu9QdhH3B/EvczjM3uZn7/47JMof/nZ7z6P8idPnn4U5dPpJPyszfqaLy8vr6N8PB5No7zbjXuZm81G2KWffaauVuuwv3g2m91H+d3dXdi/fHNzG/Yv397G+Tdf/ynsX/7yT//6hyj//ruvX4Xn37wOz3+Yx5/Zq9Uy7KHOPmv94gwAAAUMzgAAUMDgDAAABQzOAABQwOAMAAAFDM4AAFDA4AwAAAUMzgAAUMACFPiZazSaYXl9qxUvUmkli1R6vX6yMGUcLkyZJEsCLi6exGX91/HygOvrj5+G11/G5/T6/aTEP34earV4icLxeDhE+Xa73UT5w/w+LMfPFqNkC1bOvf4hWaSyTBaprFaPYVm/RSr8NX2Iz6Vup9eNru0mn1XZMqVs+dLV9dNwgcjHzz59EeWffPr5Z1E+mUziZVAX02QZ1EWyVCpegJItNBkMBuHSqlarFS6CyRaaLJeP4ZKo2WwWflbdJAtK3r5581OYv715HeXZQpM//fFfvojycxeazGZ3syhfrx7DBS77/S58fs7lF2cAAChgcAYAgAIGZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAACigxxn+TlRV3K/a6XTDLtX+YDiI8tFoOo7yrGP16iruUr1+kvQ7X8V90FfXH4XnZPe/2WyGj7dejz/3jsfjMcqzbtQP1Qc9u7+N89ntfXx+0vu8jHufl4uHsMN1tVqGXadZ7/Nuuw3zw2EfPj+HQ9yjfTjsw1x/9PvV63Ffeb3eCH8Ay3rPm80qyePr2+1O2Bnc6aYdzGEPe7//7udJ1hWffQY8e/4y7F9+9vzlJ1E+Ho/D80ejUZhPpklf8zTua86uHw2H4Wdkt9sN+6mbVRV+Vp2Ox/A9sV6vw/fu/X3Sy3wT9yy/efM26WWO82++/jLsZf79F//rX6L8u1dffRPen7c/vY3yrNP+L93LfC6/OAMAQAGDMwAAFDA4AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAE9zkDoQ/U+Z/3Ok8llmF+e2ft8fR3n04ursGM1u/9V1WxFeaMR9+RmH5/HU9IHvY/7jjebTdgHvVw8hL3MDw9xT/R8dncfXx93o2Z904+Pi2WUr1aPqyjfbFbrKM96n9fr+Pr9frcL812cn9sHnfV0/6Vlr59G2rMc562qHb4+q1b8Pq2qVnh9pxu//juduJd5OBwPozx7X0+n8fsu6mb+6OMXz8Kzz+xfHo/H4X0Zj+Pr83NG4TmDwSB8DjqdTvicZfb7ffhaXq1WYU/xfP4wi/Lb29s3UZ71Mr958+bHKP/u1Tdhz/Lvv/jnsJf522/++HV4/usfwvOzz5jss+R4jLvff2784gwAAAUMzgAAUMDgDAAABQzOAABQwOAMAAAFDM4AAFDA4AwAAAUMzgAAUMACFOCDaLXa7SjvdOPFCv1+vDAlW7gwvbi6jPKLi+swv7x+d+FCrVarXV19FC5YmU7j8/uDQXg/W+348VbNZriQol6vn/V5my3sOByP4ZKAwz5eHrDb78JFJI+Lh0WULxbzMM8Wo6xXj+HyhnMXqayTfLuNF8Rst5vwcWWLVNKFKcd4Ycq56o3479tsVuFCk2xBSbvdCV9X7XanE+XdXr8X5e95f42ifDK9DBeXXFw+uYrPGYXnDAb98P0bLREZDAfhGeNRvIhkNBqN43wYLjTp9/vhc5AtLqmqKvybZLbbbby8aLkMlxfd39/fRvnNTbzQ5O3bm9dxHi86+fabL7+M8j/8/n//W5R/9+qrcAHK2zc/hrc7n92FC1lWq2X4GZAtI/ql84szAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFDA4AwBAAYMzAAAU0OMM/E1kvc9Zj22vN+hH+WA4ynqfw17aSdLXfJn01V5ePQ17n6+SfDiahF2z7XYr7OGtqirsfW4mfdDNZjPsBW40GuEPIVmXatYHfTwc4v7ow2Gf5HGv9JnX7/f78Prddhv2NZ/b75z2OJ9O4ePN1Ov1s35warXaYTdwp9PNepnD13mrFfc+t1qt5H3UDs/POox7vV54u/1+L+xCjnqZ/5yH3cz9wbudyv1efHa32w27qduduMu6VVXhc5B1p2evzdVqHfYRL5fLsNv8Pb3Mcf/yzdswv3kb9zh/9eUXf4jyP/7h/3wR5T98982r+P78FJ6/TLrc/956mc/lF2cAAChgcAYAgAIGZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAACigxxn4RaiqVthr3G7H3a7dXj/sgh0Ox2HPbNa/PJlcTKL8Iu99fhLmyfWT6WXYN93pdMO+3U4n7ufNenurqgr7fxvNuPe5Xou7b7NO3J+b4+kY9zInDbTZ4/pQebPZCHu3qyruZc7+XnmPc9xhnL0eut34ddXtdsL3S/Y67HY7Ye9zJ+taDvqms+7x4zH+G2b9y5vtNuz0Xj2uwj7ih4eHWZTf38/CXub7+7swv727fxtef3d3E+W//7d//tco/+rLL/4Y5T/99OqHKL+7fRuev1zMH6J8s1mHzw//Pn5xBgCAAgZnAAAoYHAGAIACBmcAAChgcAYAgAIGZwAAKGBwBgCAAgZnAAAo8IsotAc4V6PRDBdPtNudcGFEJ1kM0esNwsUQo2RhynhyMT0nn06vwgUo04s4zxasTJLzO51O+LiyhRrZAo58MUecN5tVuLCm2Yz/LucuamnUkzxZqpEtIsnvZ3x9vV4/63arKj6/Sp631pmLUaqqGd//7Hab8fWNRvx4G81m8vzHz8PpdApXzRwOh8P/n22zxSWr1TLKl8vHRZTP5/Nwocl8/nAf5bPZ7O6c/Ntv/vRVlL/69stvovzHH779Lspvb14nC1NuwgUrq9VyFeW73XYb5fx1+MUZAAAKGJwBAKCAwRkAAAoYnAEAoIDBGQAAChicAQCggMEZAAAK6HEGeI9Wqx32Pmd90L3eoB/l/cFwEOWD4WgY5aPR9Kye6Pf0QV+G54wvJuHtjuN+6na7HfZBt9vZ89PuRHnWH91qVeE5VdprHPcR533T2e22wtvN+qY/WI/zmb3MWS95PfkWj9uUa7Xj8fhOn/Kf82OU7/f7fZLvojzrZl6vN+90Ej8+PiZ9zcuwr3mxWMyjfD6f30f5d6/inuUfvv/2+yh/8/r7H6P8JulfXsxn4f15fFyEj2u9Xq2j/Hh8t+Oany+/OAMAQAGDMwAAFDA4AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAE9zgAfUNa3m/U+Z3mn2w17k7Oe6KwPejAYj6J8OBzH1w9H4fWTyeU0PGcU9z6fe37WB91sxj3IrVbSg5z1NVdxT3TW75z1ONeS781GI25Uzl4PzWYj6WWO+6Dr9fj8rJf5cIi7gbP+5d1ud1Yv83vybZRH3cy3N6/fRNe+ffPj63Pyu7s3N1E+m93NwvuymD9E+eMy7l/ebNZh//J+vws7rvl184szAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFDA4AwBAAYMzAAAUMDgDAEABC1AAfoaqqhUu/sgWc7TanU6Udzu9cJFKK1k40usNeuE5vX64eKXfHw7ic/pnndPt9sL730nufzt7vMntdjrpQpnw+myRynsWo4SazSpZdFI/64er0+l0jPL9Ll7Csd1uwgUlj4/xko8sXyzm7ywuqdXOXyKyXD68c84iOSM7e7V6XEX5Zr0KF5Rst5twGctuFy9pgRJ+cQYAgAIGZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAAChgcAYAgAJ6nAF+xer1evg5X1VZT3HcO5z1GrfbnbAP+j152L+c9Vaf26ecPa5Wqx3m5/Zl1+uN8AenRiPOM8fjMexlPp3i/Hg8nqL8cDgc4uvjPOt3zrqQN5t1eH12TtadHOX73W53zhnZY4K/Jr84AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFDA4AwBAAT3OAPy7ZT3RWR/0uf3I6fVJb3Kj3gjvT71RT86P72cjuT+ZeiN+HjKn4ynsZc4ck37nU9IHfTyd1/ucdSofDvvw+uycrIf6dDrv8cLPlV+cAQCggMEZAAAKGJwBAKCAwRkAAAoYnAEAoIDBGQAAChicAQCggMEZAAAKWIACwK9etqjl/HPOW4xyrmyBSH69xSLw1+QXZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAAChgcAYAgAIGZwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPi78n8B/f87+/176jYAAAAASUVORK5CYII=" id="imagef20bf66a27" transform="scale(1 -1) translate(0 -239.76)" x="48.761875" y="-23.890745" width="516.96" height="239.76"/>
+iVBORw0KGgoAAAANSUhEUgAAAs4AAAFNCAYAAAAQIOnHAAAaIUlEQVR4nO3dx7ObZ5YfYIQPOd5ASiQlquXu8taecZVrli4vvPNf77FnRh2UqETyBuACFxnwpjc2z2G9mGJ3S+rnWf741YtwEQ6x+J1aDQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAX7f63/oOlGo0ms04b4SPodmMr282qyrK6/V6eE690WiU3sdarVZr1OP7c67j6Xj6EOecjsdjmJ9O4fnH9Po4Px7j+3k6ncLrD4f94Zz7AwDwc3HWUAgAAH+vDM4AAFDA4AwAAAUMzgAAUMDgDAAABQzOAABQwOAMAAAFDM4AAFDg7GUd2SKSbOFIq9VuheekC0qSc6r4nKrVCheaVFUruz7M37MwJcwzjXq8MOWYLBA5V7bQJFuYcjrGi0iy6/e73S7Ks8Ulh8MhzI9Jvttvw/Pz243P2e/L76flKgDAh+AXZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAAChgcAYAgAIGZwAAKFAfDEbD6B+y/uJ2u9OJ8k63G+edXje5Pszb7U47ylut+Haz69Nz2u3wnFarHfZBZ/3O5zoek57lU9yzfO45Wc9ydn7Wm7zf7/ZRvtsl/ctJn3KWb7eb7Tn5Zr1eh/lmFebR48rOzu7jbhc/B8dj3CkNAPy61Ov1cNeJX5wBAKCAwRkAAAoYnAEAoIDBGQAAChicAQCggMEZAAAKGJwBAKBA9enL3/4m/IdWK+w17nb7/SgfDsdhH/RgOBpFeX8wHER51vvc7cZ5q9VOep/brSivqvhxZX3N9UbjrP9cZH3Kh0PcAXw6Hs/qcT6dTlmPc9g9nN3uB+trTvqgd9n5280mylerx1WUr5P88XGxDK9fv9vvnHU+Zx3R2W2uk3Oyx6QPGgD+uhqNeJ47d+9H1WqFc6RfnAEAoIDBGQAAChicAQCggMEZAAAKGJwBAKCAwRkAAAoYnAEAoIDBGQAAClT/6R/+6b9E/9BJFo4MBvFCk9F4Oo7yfj9edJItHGk06kkeLyKp1+v1KM+carVwgUh6/TFeOHI6HcP8eDzFi06S67OFJqdTfD9Ptfj64+EQLlJJF6+c4sUr2eM9d8FKtggmW6Sy3W62Ub7ZxEtKVqtluKQkWmqSLUB5XMZLVJbLh0WULxbzh3POyRaprFbLxyjPnoPsOcteOwDwS5PNc1UVLyLJ5tRs7jx3UV+2kM8vzgAAUMDgDAAABQzOAABQwOAMAAAFDM4AAFDA4AwAAAUMzgAAUKD6z//4T/81+oesZ7mqqrBPL+9ljvuXM1k37fEY9w7n+SnrNQ77iI/HuAc5Pz/pLz4ew3y33YZdvGlHb3a7SR902tecnFNP/i6NeuOsXuxMs1mFr4csz/oS+/192Mc4nV4V903vdrvwb75eP4Z9ylkv82Ixj/udH2bz5Pqw93mZ5Kuk9/ncPuis+3q/j58HAPjQGo14Luwm/cvdXr8X5cPhOOxZHk8uJlF+efX0SZRfP/n4aXj95ZOrKM/6oP3iDAAABQzOAABQwOAMAAAFDM4AAFDA4AwAAAUMzgAAUMDgDAAABaonT558HP1Do1FP+nzjPOs7znqTd7vdNsr3+3d7eN93/W4X9yDv9/swX69XSSdu3JW7Wa/CTtysA3izXm+ifLvdhHnWrRv1EddqtdrxGPc4n6vRiPuaq6qV9HTH/cv1Rj38z1d2fXZ+q9Wqzrk+y9vtTvuds9udTnRtL+mMHI0m4yi/2F6Hr8HstfP4GPdBZz3RWb/zcvkQ9kc/zO9nUZ71TS8XD+H5m038Gt9uN+HjzbrWAfj1arXa73y/1mq1WifpZR4Ox8MoT79jkz7lrH/5o49fPIvyZ88/+zS+3VF4u91uN5wFqqoK5xK/OAMAQAGDMwAAFDA4AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFKg6nXa4HCJbaLLbxYtFttttuERhtcoWjqzDBSKPj8twOcR8dncf5vM4f5jfz+Pz4+UTm/U6vP/nLofI8t12G+bpopNTvOjkdDyFf5dsEUmjHi86qTca4fX5ApRmuNDk3EUn0YKS9+WdbjcsVu/1Bv0o7/eHg+CM8DXeasWLUbJlLJ1OXPKe5VnJ++FwOER59lrLFpc8PMSv8fu7m7soz98rs/CcbCHLZhMv+Vkny4KOx/jxAvCXV6/Hi+uy765sOdhgOB5F+cXldbi45OnT5x9F+Ucff/I8yp+9ePlJlF9eXl+H92cwCBes9Pv9d+aAWq1W63Q64eNttapwXsnmJL84AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFDA4AwBAgerhYRF2uO52u7B3eLPZZH3NYS/zm9c//hTn3/8Y5be3b26jfPEwm0V51sv8uIzz1eox7JXO+pePSefubr8N+6yzjt7snEzWo32uRtZDmPQyZ73P7+lxDjuPs/OzjuRWO+5U7iY9k92kZzLqn4y6nf98RtgF3esNwrOzTulzuzA73V54f4bDcdhJOZlcTqN8tboO33MXl0/CTs20C312F763ZrPb8PqHh7j3eZH0QWfvUb3PAOdrNOLv1243/i7KvgPHk4tJlGe9zB8/+/RFlL/87HefR/nzpJd5OBqFOw6Gg0HYE93v98Pvxna7He5/qKpm2Mtci+usa8fDIZy3jsdj+F3kF2cAAChgcAYAgAIGZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAAChQvXr16uvoH5aL+UOU3929vYnyt29+fB3lN29/ehvls/vbuyhfJLe7zvuXN0ke9jLv97ukf3kf9vWdTqdTlP+9qdfjAsR6Pe6Jfk/vc5LH11etVtjH2G53wv7GqFM561/O+pq73azfOe5lHgzHYffkaDwJuypHo2mYZ12b2XOQndPrDcL7Px5fTKN8/eQx7IN+mN+Hvcz39zfhe/fuNv5syK7PPmOyDvbNZh32Pu/3u32UA/wSVFW836DTib+7su+c6cXVRZRfXT29jvKsl/mzz//jb6P8o4+fPwtvdzq5jPLJeDyN8kHS19zuxPscmo1GOB8ckp7l7WYbzoXr9SqcIx9Xq/A7Z7eN95n4xRkAAAoYnAEAoIDBGQAAChicAQCggMEZAAAKGJwBAKCAwRkAAAoYnAEAoED9v/33//k/on9YrZZhUfTDwyxcirBI8myZwWq1DJcunLu4xIKSX7dGI1ukUr5gJVuW0m7HZeutdju8PluY0h/Ei0tGo3gBynA0mYTXj+OFJtk56QKXXrzAJXvOMrvtNnwvZkuKskUns7ub23Oun8/u7qM8++zJF6aswoUp2WeMzxLgHNlisHMWdNVqtdpgOAoXglxcPrmK8qdPn38U5c9ffPZplL/87HefR/nV9fWTKJ9Op+FCk2zRyWg0Cr/Ter1e9l0ULnw5HA7hMqv1eh3Oo4vFIvwums8f7uN8HubZOatkMYpfnAEAoIDBGQAAChicAQCggMEZAAAKGJwBAKCAwRkAAAoYnAEAoED96UcvnkX/kPUmb9bndaPqX+ZvLevajDqfa7VaraparTBvxXmv1w/7lHu9QdhhORiOhmE+GIddnqNx3OM8mVxOo3w8uQg7NQeDuCs066FuVe3w8WbWSW/yevUYdrbPZ3ezKL+/j3uf727f3CTXn9UHvVjMF1G+Wa/P+mw7Hg+HKAd+mbK9AVkv87kd/lkv85Onzz6O8k9f/vazKP/sN7/7D1E+mUwuwnwa59NJ3Ms8Ho+nUZ71MrdaVfhdcTwej1G+Wq3D74SHh4fkO+E+/k64u0++E+LrX3371TdR/sP3X38b5bPkO8ovzgAAUMDgDAAABQzOAABQwOAMAAAFDM4AAFDA4AwAAAUMzgAAUKCe9RbqKIX/V9YHnfU+Z92fnW6vG+VZH3S/n3SFjqdhX/N4HPc4Ty+uws7OYdI5Osn6oIdx33T2eJvN+DNmt9vto3y5mD9EedbXfHf7NuzyvL15/TY5J+z4fJjfz6P88XGxjPLV6nEV5VnXvU57+Ms497M5+wzOPmuzz8LLq6dPovzZ85cvovzFJ7/5NMqfv3j5MsovLi7C3ueLi2mYZz3Oo9Ew/IzPepmz5y2bC1erdfhZmPUy393H/cu3N7fhZ/bt7d2bKP/6q9//Kcm/jPLXP333fXh/bt+G3wmr1TLsm/aLMwAAFDA4AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFAi7D4G/nKpqVVHebnc6Ud5qt8N+5F5vEPY+D4ajsGd5OBwPo3wyjfudp9OrsBP04vI67BDNrh9PLqZR3mrFXaGZw+EQ9j4vFvNFlM9nd/dRnvU+Zz3R93dxvniYhb3Pi6SHOuuDznqft9vNNsr1QfNr8aG68Xu9QdhH3B/EvczjM3uZn7/47JMof/nZ7z6P8idPnn4U5dPpJPyszfqaLy8vr6N8PB5No7zbjXuZm81G2KWffaauVuuwv3g2m91H+d3dXdi/fHNzG/Yv397G+Tdf/ynsX/7yT//6hyj//ruvX4Xn37wOz3+Yx5/Zq9Uy7KHOPmv94gwAAAUMzgAAUMDgDAAABQzOAABQwOAMAAAFDM4AAFDA4AwAAAUMzgAAUMACFPiZazSaYXl9qxUvUmkli1R6vX6yMGUcLkyZJEsCLi6exGX91/HygOvrj5+G11/G5/T6/aTEP34earV4icLxeDhE+Xa73UT5w/w+LMfPFqNkC1bOvf4hWaSyTBaprFaPYVm/RSr8NX2Iz6Vup9eNru0mn1XZMqVs+dLV9dNwgcjHzz59EeWffPr5Z1E+mUziZVAX02QZ1EWyVCpegJItNBkMBuHSqlarFS6CyRaaLJeP4ZKo2WwWflbdJAtK3r5581OYv715HeXZQpM//fFfvojycxeazGZ3syhfrx7DBS77/S58fs7lF2cAAChgcAYAgAIGZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAACigxxn+TlRV3K/a6XTDLtX+YDiI8tFoOo7yrGP16iruUr1+kvQ7X8V90FfXH4XnZPe/2WyGj7dejz/3jsfjMcqzbtQP1Qc9u7+N89ntfXx+0vu8jHufl4uHsMN1tVqGXadZ7/Nuuw3zw2EfPj+HQ9yjfTjsw1x/9PvV63Ffeb3eCH8Ay3rPm80qyePr2+1O2Bnc6aYdzGEPe7//7udJ1hWffQY8e/4y7F9+9vzlJ1E+Ho/D80ejUZhPpklf8zTua86uHw2H4Wdkt9sN+6mbVRV+Vp2Ox/A9sV6vw/fu/X3Sy3wT9yy/efM26WWO82++/jLsZf79F//rX6L8u1dffRPen7c/vY3yrNP+L93LfC6/OAMAQAGDMwAAFDA4AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAE9zkDoQ/U+Z/3Ok8llmF+e2ft8fR3n04ursGM1u/9V1WxFeaMR9+RmH5/HU9IHvY/7jjebTdgHvVw8hL3MDw9xT/R8dncfXx93o2Z904+Pi2WUr1aPqyjfbFbrKM96n9fr+Pr9frcL812cn9sHnfV0/6Vlr59G2rMc562qHb4+q1b8Pq2qVnh9pxu//juduJd5OBwPozx7X0+n8fsu6mb+6OMXz8Kzz+xfHo/H4X0Zj+Pr83NG4TmDwSB8DjqdTvicZfb7ffhaXq1WYU/xfP4wi/Lb29s3UZ71Mr958+bHKP/u1Tdhz/Lvv/jnsJf522/++HV4/usfwvOzz5jss+R4jLvff2784gwAAAUMzgAAUMDgDAAABQzOAABQwOAMAAAFDM4AAFDA4AwAAAUMzgAAUMACFOCDaLXa7SjvdOPFCv1+vDAlW7gwvbi6jPKLi+swv7x+d+FCrVarXV19FC5YmU7j8/uDQXg/W+348VbNZriQol6vn/V5my3sOByP4ZKAwz5eHrDb78JFJI+Lh0WULxbzMM8Wo6xXj+HyhnMXqayTfLuNF8Rst5vwcWWLVNKFKcd4Ycq56o3479tsVuFCk2xBSbvdCV9X7XanE+XdXr8X5e95f42ifDK9DBeXXFw+uYrPGYXnDAb98P0bLREZDAfhGeNRvIhkNBqN43wYLjTp9/vhc5AtLqmqKvybZLbbbby8aLkMlxfd39/fRvnNTbzQ5O3bm9dxHi86+fabL7+M8j/8/n//W5R/9+qrcAHK2zc/hrc7n92FC1lWq2X4GZAtI/ql84szAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFDA4AwBAAYMzAAAU0OMM/E1kvc9Zj22vN+hH+WA4ynqfw17aSdLXfJn01V5ePQ17n6+SfDiahF2z7XYr7OGtqirsfW4mfdDNZjPsBW40GuEPIVmXatYHfTwc4v7ow2Gf5HGv9JnX7/f78Prddhv2NZ/b75z2OJ9O4ePN1Ov1s35warXaYTdwp9PNepnD13mrFfc+t1qt5H3UDs/POox7vV54u/1+L+xCjnqZ/5yH3cz9wbudyv1efHa32w27qduduMu6VVXhc5B1p2evzdVqHfYRL5fLsNv8Pb3Mcf/yzdswv3kb9zh/9eUXf4jyP/7h/3wR5T98982r+P78FJ6/TLrc/956mc/lF2cAAChgcAYAgAIGZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAACigxxn4RaiqVthr3G7H3a7dXj/sgh0Ox2HPbNa/PJlcTKL8Iu99fhLmyfWT6WXYN93pdMO+3U4n7ufNenurqgr7fxvNuPe5Xou7b7NO3J+b4+kY9zInDbTZ4/pQebPZCHu3qyruZc7+XnmPc9xhnL0eut34ddXtdsL3S/Y67HY7Ye9zJ+taDvqms+7x4zH+G2b9y5vtNuz0Xj2uwj7ih4eHWZTf38/CXub7+7swv727fxtef3d3E+W//7d//tco/+rLL/4Y5T/99OqHKL+7fRuev1zMH6J8s1mHzw//Pn5xBgCAAgZnAAAoYHAGAIACBmcAAChgcAYAgAIGZwAAKGBwBgCAAgZnAAAo8IsotAc4V6PRDBdPtNudcGFEJ1kM0esNwsUQo2RhynhyMT0nn06vwgUo04s4zxasTJLzO51O+LiyhRrZAo58MUecN5tVuLCm2Yz/LucuamnUkzxZqpEtIsnvZ3x9vV4/63arKj6/Sp631pmLUaqqGd//7Hab8fWNRvx4G81m8vzHz8PpdApXzRwOh8P/n22zxSWr1TLKl8vHRZTP5/Nwocl8/nAf5bPZ7O6c/Ntv/vRVlL/69stvovzHH779Lspvb14nC1NuwgUrq9VyFeW73XYb5fx1+MUZAAAKGJwBAKCAwRkAAAoYnAEAoIDBGQAAChicAQCggMEZAAAK6HEGeI9Wqx32Pmd90L3eoB/l/cFwEOWD4WgY5aPR9Kye6Pf0QV+G54wvJuHtjuN+6na7HfZBt9vZ89PuRHnWH91qVeE5VdprHPcR533T2e22wtvN+qY/WI/zmb3MWS95PfkWj9uUa7Xj8fhOn/Kf82OU7/f7fZLvojzrZl6vN+90Ej8+PiZ9zcuwr3mxWMyjfD6f30f5d6/inuUfvv/2+yh/8/r7H6P8JulfXsxn4f15fFyEj2u9Xq2j/Hh8t+Oany+/OAMAQAGDMwAAFDA4AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAE9zgAfUNa3m/U+Z3mn2w17k7Oe6KwPejAYj6J8OBzH1w9H4fWTyeU0PGcU9z6fe37WB91sxj3IrVbSg5z1NVdxT3TW75z1ONeS781GI25Uzl4PzWYj6WWO+6Dr9fj8rJf5cIi7gbP+5d1ud1Yv83vybZRH3cy3N6/fRNe+ffPj63Pyu7s3N1E+m93NwvuymD9E+eMy7l/ebNZh//J+vws7rvl184szAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFDA4AwBAAYMzAAAUMDgDAEABC1AAfoaqqhUu/sgWc7TanU6Udzu9cJFKK1k40usNeuE5vX64eKXfHw7ic/pnndPt9sL730nufzt7vMntdjrpQpnw+myRynsWo4SazSpZdFI/64er0+l0jPL9Ll7Csd1uwgUlj4/xko8sXyzm7ywuqdXOXyKyXD68c84iOSM7e7V6XEX5Zr0KF5Rst5twGctuFy9pgRJ+cQYAgAIGZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAAChgcAYAgAJ6nAF+xer1evg5X1VZT3HcO5z1GrfbnbAP+j152L+c9Vaf26ecPa5Wqx3m5/Zl1+uN8AenRiPOM8fjMexlPp3i/Hg8nqL8cDgc4uvjPOt3zrqQN5t1eH12TtadHOX73W53zhnZY4K/Jr84AwBAAYMzAAAUMDgDAEABgzMAABQwOAMAQAGDMwAAFDA4AwBAAT3OAPy7ZT3RWR/0uf3I6fVJb3Kj3gjvT71RT86P72cjuT+ZeiN+HjKn4ynsZc4ck37nU9IHfTyd1/ucdSofDvvw+uycrIf6dDrv8cLPlV+cAQCggMEZAAAKGJwBAKCAwRkAAAoYnAEAoIDBGQAAChicAQCggMEZAAAKWIACwK9etqjl/HPOW4xyrmyBSH69xSLw1+QXZwAAKGBwBgCAAgZnAAAoYHAGAIACBmcAAChgcAYAgAIGZwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPi78n8B/f87+/176jYAAAAASUVORK5CYII=" id="imageb4207aa622" transform="scale(1 -1) translate(0 -239.76)" x="48.761875" y="-23.890745" width="516.96" height="239.76"/>
    </g>
    <g id="line2d_21"/>
    <g id="line2d_22"/>
@@ -1129,7 +1129,7 @@ L 60.461429 21.843268
 L 54.694307 20.687041 
 L 51.734129 20.198908 
 L 51.734129 20.198908 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #1a1b26; stroke-width: 4"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #1a1b26; stroke-width: 4"/>
    <path d="M 565.660164 19.772958 
 L 559.536543 19.113246 
 L 553.302856 18.717238 
@@ -1252,7 +1252,7 @@ L 60.461429 21.843268
 L 54.694307 20.687041 
 L 51.734129 20.198908 
 L 51.734129 20.198908 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #9aa5ce; stroke-opacity: 0.9; stroke-width: 1.8"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke-dasharray: 6.66,2.88; stroke-dashoffset: 0; stroke: #9aa5ce; stroke-opacity: 0.9; stroke-width: 1.8"/>
    <g id="line2d_27">
     <path d="M 565.693075 143.984435 
 L 547.191331 132.970795 
@@ -1326,7 +1326,7 @@ L 73.936535 158.824866
 L 63.281677 152.666036 
 L 50.079327 144.777743 
 L 50.079327 144.777743 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke-dasharray: 0.9,1.485; stroke-dashoffset: 0; stroke: #c0caf5; stroke-opacity: 0.5; stroke-width: 0.9"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke-dasharray: 0.9,1.485; stroke-dashoffset: 0; stroke: #c0caf5; stroke-opacity: 0.7; stroke-width: 0.9"/>
    </g>
    <g id="text_23">
     <!-- Where is Planet 9? Dwell-time position probability across orbit solutions -->
@@ -1761,7 +1761,7 @@ L 59.531275 250.631838
 L 55.223515 249.909227 
 L 50.915755 249.398641 
 L 50.915755 249.398641 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 0.9"/>
     <path d="M 50.915755 154.196731 
 L 55.223515 155.549905 
 L 63.839035 160.282466 
@@ -1870,7 +1870,7 @@ L 554.923675 141.796709
 L 559.231435 145.082156 
 L 563.539195 147.288055 
 L 563.539195 147.288055 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 0.9"/>
    </g>
    <g id="PathCollection_2">
     <path d="M 563.539195 222.714652 
@@ -1956,7 +1956,7 @@ L 554.923675 162.912262
 L 559.231435 166.206966 
 L 563.539195 168.157047 
 L 563.539195 168.157047 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 50.915755 177.808694 
 L 55.223515 179.813444 
 L 59.531275 182.857932 
@@ -1980,7 +1980,7 @@ L 63.839035 222.26085
 L 59.531275 222.617585 
 L 55.223515 222.892123 
 L 50.915755 223.098217 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #7dcfff; stroke-opacity: 0.95; stroke-width: 1.6"/>
    </g>
    <g id="PathCollection_3">
     <path d="M 563.539195 245.681528 
@@ -2089,7 +2089,7 @@ L 55.223515 249.402432
 L 52.405851 248.692457 
 L 50.915755 248.44913 
 L 50.915755 248.44913 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 0.9"/>
     <path d="M 50.915755 153.832846 
 L 55.223515 154.982652 
 L 59.531275 156.960668 
@@ -2199,7 +2199,7 @@ L 554.923675 141.704086
 L 559.231435 144.618047 
 L 563.539195 146.606684 
 L 563.539195 146.606684 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 0.9"/>
    </g>
    <g id="PathCollection_4">
     <path d="M 563.539195 224.314488 
@@ -2309,7 +2309,7 @@ L 554.923675 160.999647
 L 559.231435 164.040514 
 L 563.539195 165.926713 
 L 563.539195 165.926713 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 50.915755 175.141404 
 L 55.223515 176.583079 
 L 55.81124 176.89267 
@@ -2343,7 +2343,7 @@ L 63.839035 226.750485
 L 59.531275 226.589266 
 L 55.223515 226.52877 
 L 50.915755 226.530946 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #7aa2f7; stroke-opacity: 0.95; stroke-width: 1.6"/>
    </g>
    <g id="PathCollection_5">
     <path d="M 563.539195 218.026617 
@@ -2453,7 +2453,7 @@ L 72.454555 226.337958
 L 55.223515 222.131186 
 L 50.915755 221.329095 
 L 50.915755 221.329095 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 0.9"/>
     <path d="M 50.915755 147.692658 
 L 55.223515 148.7023 
 L 59.531275 150.452571 
@@ -2560,7 +2560,7 @@ L 559.231435 140.566899
 L 560.242304 140.992777 
 L 563.539195 141.962789 
 L 563.539195 141.962789 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 0.9"/>
    </g>
    <g id="PathCollection_6">
     <path d="M 563.539195 200.505249 
@@ -2646,7 +2646,7 @@ L 59.531275 204.654445
 L 55.223515 203.669833 
 L 50.915755 202.973512 
 L 50.915755 202.973512 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 50.915755 164.313798 
 L 55.223515 165.5314 
 L 59.531275 167.522079 
@@ -2738,7 +2738,7 @@ L 554.923675 154.867094
 L 559.231435 157.418593 
 L 563.539195 158.930987 
 L 563.539195 158.930987 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #9ece6a; stroke-opacity: 0.95; stroke-width: 1.6"/>
    </g>
    <g id="PathCollection_7">
     <path d="M 563.539195 174.954186 
@@ -2847,7 +2847,7 @@ L 58.719645 182.875986
 L 55.223515 181.736025 
 L 50.915755 180.667786 
 L 50.915755 180.667786 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 0.9"/>
     <path d="M 50.915755 140.218997 
 L 53.07907 140.992777 
 L 55.223515 141.359204 
@@ -2964,7 +2964,7 @@ L 553.970855 129.026146
 L 559.231435 131.608798 
 L 563.539195 133.585469 
 L 563.539195 133.585469 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 0.9"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 0.9"/>
    </g>
    <g id="PathCollection_8">
     <path d="M 563.539195 166.819028 
@@ -3091,7 +3091,7 @@ L 559.231435 140.191952
 L 561.092287 140.992777 
 L 563.539195 141.825846 
 L 563.539195 141.825846 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 50.915755 148.350771 
 L 55.223515 149.526465 
 L 59.531275 151.660751 
@@ -3152,19 +3152,19 @@ L 63.839035 176.622347
 L 59.531275 174.79249 
 L 55.223515 173.193179 
 L 50.915755 172.104921 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
     <path d="M 223.226155 176.91667 
 L 222.467581 176.89267 
 L 223.226155 176.845451 
 L 223.41229 176.89267 
 L 223.226155 176.91667 
 z
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #e0af68; stroke-opacity: 0.95; stroke-width: 1.6"/>
    </g>
    <g id="line2d_28">
     <path d="M 48.761875 120.051173 
 L 565.693075 120.051173 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke-dasharray: 8.4,4.2; stroke-dashoffset: 0; stroke: #c0caf5; stroke-opacity: 0.9; stroke-width: 1.4"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke-dasharray: 8.4,4.2; stroke-dashoffset: 0; stroke: #c0caf5; stroke-opacity: 0.9; stroke-width: 1.4"/>
    </g>
    <g id="legend_1">
     <g id="patch_8">
@@ -3825,7 +3825,7 @@ z
      <path d="M 266.512375 221.44862 
 L 273.712375 221.44862 
 L 280.912375 221.44862 
-" style="fill: none; stroke-dasharray: 0.9,1.485; stroke-dashoffset: 0; stroke: #c0caf5; stroke-opacity: 0.5; stroke-width: 0.9"/>
+" style="fill: none; stroke-dasharray: 0.9,1.485; stroke-dashoffset: 0; stroke: #c0caf5; stroke-opacity: 0.7; stroke-width: 0.9"/>
     </g>
     <g id="text_30">
      <!-- Ecliptic -->
@@ -4021,7 +4021,7 @@ z
    </g>
    <g id="line2d_37">
     <defs>
-     <path id="me30620d9ac" d="M 0 -7 
+     <path id="me561a0175a" d="M 0 -7 
 L -1.571598 -2.163119 
 L -6.657396 -2.163119 
 L -2.542899 0.826238 
@@ -4034,13 +4034,13 @@ L 1.571598 -2.163119
 z
 " style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pca0bb86289)">
-     <use xlink:href="#me30620d9ac" x="468.768475" y="129.026146" style="fill: #7dcfff; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p0e05e55de8)">
+     <use xlink:href="#me561a0175a" x="468.768475" y="129.026146" style="fill: #7dcfff; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_38">
     <defs>
-     <path id="m2fc4c8d367" d="M 0 -7 
+     <path id="m36dbcc9839" d="M 0 -7 
 L -1.571598 -2.163119 
 L -6.657396 -2.163119 
 L -2.542899 0.826238 
@@ -4053,13 +4053,13 @@ L 1.571598 -2.163119
 z
 " style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pca0bb86289)">
-     <use xlink:href="#m2fc4c8d367" x="485.999515" y="146.976093" style="fill: #7aa2f7; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p0e05e55de8)">
+     <use xlink:href="#m36dbcc9839" x="485.999515" y="146.976093" style="fill: #7aa2f7; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_39">
     <defs>
-     <path id="m2d5d175fe0" d="M 0 -7 
+     <path id="m5b910e2d9b" d="M 0 -7 
 L -1.571598 -2.163119 
 L -6.657396 -2.163119 
 L -2.542899 0.826238 
@@ -4072,13 +4072,13 @@ L 1.571598 -2.163119
 z
 " style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pca0bb86289)">
-     <use xlink:href="#m2d5d175fe0" x="429.998635" y="99.109569" style="fill: #9ece6a; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p0e05e55de8)">
+     <use xlink:href="#m5b910e2d9b" x="429.998635" y="99.109569" style="fill: #9ece6a; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_40">
     <defs>
-     <path id="mec5fc4c132" d="M 0 -7 
+     <path id="m8aac9709c6" d="M 0 -7 
 L -1.571598 -2.163119 
 L -6.657396 -2.163119 
 L -2.542899 0.826238 
@@ -4091,13 +4091,13 @@ L 1.571598 -2.163119
 z
 " style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pca0bb86289)">
-     <use xlink:href="#mec5fc4c132" x="473.076235" y="117.059515" style="fill: #f7768e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p0e05e55de8)">
+     <use xlink:href="#m8aac9709c6" x="473.076235" y="117.059515" style="fill: #f7768e; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </g>
    </g>
    <g id="line2d_41">
     <defs>
-     <path id="me814ce926c" d="M 0 -7 
+     <path id="mc124718514" d="M 0 -7 
 L -1.571598 -2.163119 
 L -6.657396 -2.163119 
 L -2.542899 0.826238 
@@ -4110,8 +4110,8 @@ L 1.571598 -2.163119
 z
 " style="stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </defs>
-    <g clip-path="url(#pca0bb86289)">
-     <use xlink:href="#me814ce926c" x="494.615035" y="117.059515" style="fill: #e0af68; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
+    <g clip-path="url(#p0e05e55de8)">
+     <use xlink:href="#mc124718514" x="494.615035" y="117.059515" style="fill: #e0af68; stroke: #ffffff; stroke-width: 0.5; stroke-linejoin: bevel"/>
     </g>
    </g>
    <path d="M 559.18031 197.969183 
@@ -4178,7 +4178,7 @@ L 490.040249 163.136525
 L 488.998431 162.382308 
 L 487.958849 161.625198 
 L 486.921411 160.865322 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #1a1b26; stroke-width: 4; stroke-linecap: square"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #1a1b26; stroke-width: 4; stroke-linecap: square"/>
    <path d="M 559.18031 197.969183 
 L 557.903464 197.638892 
 L 556.63042 197.297529 
@@ -4243,7 +4243,7 @@ L 490.040249 163.136525
 L 488.998431 162.382308 
 L 487.958849 161.625198 
 L 486.921411 160.865322 
-" clip-path="url(#pca0bb86289)" style="fill: none; stroke: #bb9af7; stroke-width: 2.8; stroke-linecap: square"/>
+" clip-path="url(#p0e05e55de8)" style="fill: none; stroke: #bb9af7; stroke-width: 2.8; stroke-linecap: square"/>
   </g>
   <g id="axes_2">
    <g id="patch_9">
@@ -4256,21 +4256,21 @@ z
 " style="fill: none"/>
    </g>
    <g id="patch_10">
-    <path clip-path="url(#p514828ed03)" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.01; stroke-linejoin: miter"/>
+    <path clip-path="url(#p4b783f7d70)" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.01; stroke-linejoin: miter"/>
    </g>
    <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAABEAAAFLCAYAAAAwD2ffAAABsElEQVR4nO2aQQ4DMQgDAe3/39x74IYrjZB5gOW42EtIM7MqlvVVZa5BFEzWABERX1UxjnNN2CyFJqnQRMBE1GypaDaKsKA+sQE7k1vJJmo2xXEwBnSyjUwwzXYq2UAGdLJ1JppksyYNBNNsqqkAMuQ47QcQzGdUNRVAhhwbcGTiZHtBMMl2zYCKZEMFNUVYG3Bigmk2ykQN6pNbmrjZ/sTEad/Ly7o/MbEBe117hsgMBZM1hkjYCEmfCDQJzhJGAqIIJcWvowolCYhEExvwBTkXSprjOJReEBvwLWvSC2RAazIwkaT9HsMGHEo2bjGmR5AmgTGgZBgmzfYOpadswF4oTbYQ9wx4ThPITsmhNDNZl6TtWUsYBhNQsyk+XpwVmajZNKEkYGIDDkwwmiTlSnvNgCJNILdRh1Iv1sJhzwSzIrMBe1mTXqpQguyUbMARBHIbBWkStwyIudJydtSq2d4GfJk4lDqTYwZUHIe1cGDsqB1KvUAGxPwX1AYcQSjvOxxNMOsg0APrMQNirrQ24AgCuY2Sms2h1EDilgFvaXLNgNakg2B21CRNMAbEPDr/AOO3CF58++VaAAAAAElFTkSuQmCC" id="imaged586c3be22" transform="scale(1 -1) translate(0 -238.32)" x="570.96" y="-23.76" width="12.24" height="238.32"/>
+iVBORw0KGgoAAAANSUhEUgAAABEAAAFLCAYAAAAwD2ffAAABsElEQVR4nO2aQQ4DMQgDAe3/39x74IYrjZB5gOW42EtIM7MqlvVVZa5BFEzWABERX1UxjnNN2CyFJqnQRMBE1GypaDaKsKA+sQE7k1vJJmo2xXEwBnSyjUwwzXYq2UAGdLJ1JppksyYNBNNsqqkAMuQ47QcQzGdUNRVAhhwbcGTiZHtBMMl2zYCKZEMFNUVYG3Bigmk2ykQN6pNbmrjZ/sTEad/Ly7o/MbEBe117hsgMBZM1hkjYCEmfCDQJzhJGAqIIJcWvowolCYhEExvwBTkXSprjOJReEBvwLWvSC2RAazIwkaT9HsMGHEo2bjGmR5AmgTGgZBgmzfYOpadswF4oTbYQ9wx4ThPITsmhNDNZl6TtWUsYBhNQsyk+XpwVmajZNKEkYGIDDkwwmiTlSnvNgCJNILdRh1Iv1sJhzwSzIrMBe1mTXqpQguyUbMARBHIbBWkStwyIudJydtSq2d4GfJk4lDqTYwZUHIe1cGDsqB1KvUAGxPwX1AYcQSjvOxxNMOsg0APrMQNirrQ24AgCuY2Sms2h1EDilgFvaXLNgNakg2B21CRNMAbEPDr/AOO3CF58++VaAAAAAElFTkSuQmCC" id="image814dcee8cc" transform="scale(1 -1) translate(0 -238.32)" x="570.96" y="-23.76" width="12.24" height="238.32"/>
    <g id="matplotlib.axis_3"/>
    <g id="matplotlib.axis_4">
     <g id="ytick_8">
      <g id="line2d_42">
       <defs>
-       <path id="m173559ef4f" d="M 0 0 
+       <path id="mee4933ee67" d="M 0 0 
 L 3.5 0 
 " style="stroke: #565f89; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m173559ef4f" x="583.016506" y="219.691693" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mee4933ee67" x="583.016506" y="219.691693" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_33">
@@ -4285,7 +4285,7 @@ L 3.5 0
     <g id="ytick_9">
      <g id="line2d_43">
       <g>
-       <use xlink:href="#m173559ef4f" x="583.016506" y="170.848301" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mee4933ee67" x="583.016506" y="170.848301" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_34">
@@ -4300,7 +4300,7 @@ L 3.5 0
     <g id="ytick_10">
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m173559ef4f" x="583.016506" y="122.004909" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mee4933ee67" x="583.016506" y="122.004909" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_35">
@@ -4315,7 +4315,7 @@ L 3.5 0
     <g id="ytick_11">
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m173559ef4f" x="583.016506" y="73.161517" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mee4933ee67" x="583.016506" y="73.161517" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_36">
@@ -4330,7 +4330,7 @@ L 3.5 0
     <g id="ytick_12">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m173559ef4f" x="583.016506" y="24.318125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mee4933ee67" x="583.016506" y="24.318125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_37">
@@ -4436,7 +4436,7 @@ L 101.123194 434.574125
 L 101.123194 391.798721 
 L 73.110966 391.798721 
 z
-" clip-path="url(#p75c6e57096)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#pb2c9d13032)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
    <g id="patch_14">
     <path d="M 180.850306 434.574125 
@@ -4444,7 +4444,7 @@ L 208.862535 434.574125
 L 208.862535 387.866818 
 L 180.850306 387.866818 
 z
-" clip-path="url(#p75c6e57096)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#pb2c9d13032)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
    <g id="patch_15">
     <path d="M 288.589647 434.574125 
@@ -4452,7 +4452,7 @@ L 316.601875 434.574125
 L 316.601875 386.89458 
 L 288.589647 386.89458 
 z
-" clip-path="url(#p75c6e57096)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#pb2c9d13032)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
    <g id="patch_16">
     <path d="M 396.328987 434.574125 
@@ -4460,7 +4460,7 @@ L 424.341215 434.574125
 L 424.341215 388.01572 
 L 396.328987 388.01572 
 z
-" clip-path="url(#p75c6e57096)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#pb2c9d13032)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
    <g id="patch_17">
     <path d="M 504.068327 434.574125 
@@ -4468,7 +4468,7 @@ L 532.080556 434.574125
 L 532.080556 389.581304 
 L 504.068327 389.581304 
 z
-" clip-path="url(#p75c6e57096)" style="fill: #7dcfff; opacity: 0.9"/>
+" clip-path="url(#pb2c9d13032)" style="fill: #7dcfff; opacity: 0.9"/>
    </g>
    <g id="patch_18">
     <path d="M 101.123194 434.574125 
@@ -4476,7 +4476,7 @@ L 129.135423 434.574125
 L 129.135423 379.409751 
 L 101.123194 379.409751 
 z
-" clip-path="url(#p75c6e57096)" style="fill: #9ece6a; opacity: 0.9"/>
+" clip-path="url(#pb2c9d13032)" style="fill: #9ece6a; opacity: 0.9"/>
    </g>
    <g id="patch_19">
     <path d="M 208.862535 434.574125 
@@ -4484,7 +4484,7 @@ L 236.874763 434.574125
 L 236.874763 374.307213 
 L 208.862535 374.307213 
 z
-" clip-path="url(#p75c6e57096)" style="fill: #9ece6a; opacity: 0.9"/>
+" clip-path="url(#pb2c9d13032)" style="fill: #9ece6a; opacity: 0.9"/>
    </g>
    <g id="patch_20">
     <path d="M 316.601875 434.574125 
@@ -4492,7 +4492,7 @@ L 344.614103 434.574125
 L 344.614103 373.067702 
 L 316.601875 373.067702 
 z
-" clip-path="url(#p75c6e57096)" style="fill: #9ece6a; opacity: 0.9"/>
+" clip-path="url(#pb2c9d13032)" style="fill: #9ece6a; opacity: 0.9"/>
    </g>
    <g id="patch_21">
     <path d="M 424.341215 434.574125 
@@ -4500,7 +4500,7 @@ L 452.353444 434.574125
 L 452.353444 373.434879 
 L 424.341215 373.434879 
 z
-" clip-path="url(#p75c6e57096)" style="fill: #9ece6a; opacity: 0.9"/>
+" clip-path="url(#pb2c9d13032)" style="fill: #9ece6a; opacity: 0.9"/>
    </g>
    <g id="patch_22">
     <path d="M 532.080556 434.574125 
@@ -4508,13 +4508,13 @@ L 560.092784 434.574125
 L 560.092784 373.801124 
 L 532.080556 373.801124 
 z
-" clip-path="url(#p75c6e57096)" style="fill: #9ece6a; opacity: 0.9"/>
+" clip-path="url(#pb2c9d13032)" style="fill: #9ece6a; opacity: 0.9"/>
    </g>
    <g id="matplotlib.axis_5">
     <g id="xtick_14">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m8777f8dc6c" x="115.129309" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="115.129309" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_39">
@@ -4534,7 +4534,7 @@ z
     <g id="xtick_15">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m8777f8dc6c" x="222.868649" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="222.868649" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_40">
@@ -4554,7 +4554,7 @@ z
     <g id="xtick_16">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m8777f8dc6c" x="330.607989" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="330.607989" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_41">
@@ -4579,7 +4579,7 @@ z
     <g id="xtick_17">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m8777f8dc6c" x="438.34733" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="438.34733" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_42">
@@ -4611,7 +4611,7 @@ z
     <g id="xtick_18">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m8777f8dc6c" x="546.08667" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#mefa7869d34" x="546.08667" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_43">
@@ -4637,11 +4637,11 @@ z
      <g id="line2d_52">
       <path d="M 48.761875 434.574125 
 L 584.441875 434.574125 
-" clip-path="url(#p75c6e57096)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pb2c9d13032)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m05b190d6fa" x="48.761875" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me988d85cd5" x="48.761875" y="434.574125" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_44">
@@ -4655,11 +4655,11 @@ L 584.441875 434.574125
      <g id="line2d_54">
       <path d="M 48.761875 409.643644 
 L 584.441875 409.643644 
-" clip-path="url(#p75c6e57096)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pb2c9d13032)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_55">
       <g>
-       <use xlink:href="#m05b190d6fa" x="48.761875" y="409.643644" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me988d85cd5" x="48.761875" y="409.643644" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_45">
@@ -4674,11 +4674,11 @@ L 584.441875 409.643644
      <g id="line2d_56">
       <path d="M 48.761875 384.713162 
 L 584.441875 384.713162 
-" clip-path="url(#p75c6e57096)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pb2c9d13032)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_57">
       <g>
-       <use xlink:href="#m05b190d6fa" x="48.761875" y="384.713162" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me988d85cd5" x="48.761875" y="384.713162" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_46">
@@ -4693,11 +4693,11 @@ L 584.441875 384.713162
      <g id="line2d_58">
       <path d="M 48.761875 359.782681 
 L 584.441875 359.782681 
-" clip-path="url(#p75c6e57096)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pb2c9d13032)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_59">
       <g>
-       <use xlink:href="#m05b190d6fa" x="48.761875" y="359.782681" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me988d85cd5" x="48.761875" y="359.782681" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_47">
@@ -4712,11 +4712,11 @@ L 584.441875 359.782681
      <g id="line2d_60">
       <path d="M 48.761875 334.8522 
 L 584.441875 334.8522 
-" clip-path="url(#p75c6e57096)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
+" clip-path="url(#pb2c9d13032)" style="fill: none; stroke: #565f89; stroke-opacity: 0.25; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_61">
       <g>
-       <use xlink:href="#m05b190d6fa" x="48.761875" y="334.8522" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
+       <use xlink:href="#me988d85cd5" x="48.761875" y="334.8522" style="fill: #565f89; stroke: #565f89; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_48">
@@ -5084,13 +5084,13 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pca0bb86289">
+  <clipPath id="p0e05e55de8">
    <rect x="48.761875" y="24.318125" width="516.9312" height="239.33262"/>
   </clipPath>
-  <clipPath id="p514828ed03">
+  <clipPath id="p4b783f7d70">
    <rect x="571.049875" y="24.318125" width="11.966631" height="239.33262"/>
   </clipPath>
-  <clipPath id="p75c6e57096">
+  <clipPath id="pb2c9d13032">
    <rect x="48.761875" y="334.8522" width="535.68" height="99.721925"/>
   </clipPath>
  </defs>

--- a/scripts/plot_survey.py
+++ b/scripts/plot_survey.py
@@ -8,8 +8,10 @@ types don't match — so the Rust and Python sides stay in lock-step (bump
 SCHEMA_VERSION on both when the contract changes).
 
 Usage:
-    python3 scripts/plot_survey.py [DATA_JSON] [OUT_SVG]
+    python3 scripts/plot_survey.py [DATA_JSON] [OUT_SVG] [--theme dark|standard]
 Defaults: crates/p9-survey/p9_survey_data.json -> crates/p9-survey/p9_survey_sky.svg
+          --theme dark  (the Tokyo-Night palette used throughout this tooling;
+          "standard" is the conventional light/matplotlib scheme).
 """
 import json
 import sys
@@ -20,16 +22,49 @@ import numpy as np
 
 SCHEMA_VERSION = 2  # must equal p9_survey::schema::SCHEMA_VERSION
 
-# Tokyo-Night palette (portal dark background #1a1b26)
-FG, MUTE = "#c0caf5", "#565f89"
-STUDY_COLORS = {  # by substring of study name, oldest->newest
-    "2016 Batygin & Brown (nominal)": "#7dcfff",
-    "2016 Batygin & Brown (inclined-TNO variant)": "#7aa2f7",
-    "2019 Batygin et al.": "#9ece6a",
-    "2021 Brown & Batygin": "#f7768e",
-    "2024 Siraj": "#e0af68",
+# Two palettes. "dark" is the Tokyo-Night scheme this tooling uses on the
+# portal's #1a1b26 background; "standard" is a conventional light/matplotlib
+# (tab10) scheme for slides, print, or anywhere a white background is wanted.
+THEMES = {
+    "dark": {
+        "fg": "#c0caf5", "mute": "#565f89", "bg": None, "transparent": True,
+        "study": {
+            "2016 Batygin & Brown (nominal)": "#7dcfff",
+            "2016 Batygin & Brown (inclined-TNO variant)": "#7aa2f7",
+            "2019 Batygin et al.": "#9ece6a",
+            "2021 Brown & Batygin": "#f7768e",
+            "2024 Siraj": "#e0af68",
+        },
+        "tele": {"Rubin": "#7dcfff", "JBT": "#9ece6a"},
+        "arc": "#bb9af7", "rubin_line": "#c0caf5",
+        "galplane": "#9aa5ce", "ecliptic": "#c0caf5",
+        "cloud": [(0.0, (0, 0, 0, 0.0)), (0.35, (0.50, 0.52, 0.60, 0.55)),
+                  (1.0, (0.90, 0.92, 0.99, 1.0))],
+        "outline_bg": "#1a1b26", "star_edge": "white",
+    },
+    "standard": {
+        "fg": "#222222", "mute": "#555555", "bg": "white", "transparent": False,
+        "study": {
+            "2016 Batygin & Brown (nominal)": "#1f77b4",
+            "2016 Batygin & Brown (inclined-TNO variant)": "#17becf",
+            "2019 Batygin et al.": "#2ca02c",
+            "2021 Brown & Batygin": "#d62728",
+            "2024 Siraj": "#ff7f0e",
+        },
+        "tele": {"Rubin": "#1f77b4", "JBT": "#2ca02c"},
+        "arc": "#9467bd", "rubin_line": "#333333",
+        "galplane": "#888888", "ecliptic": "#aaaaaa",
+        "cloud": [(0.0, (1, 1, 1, 0.0)), (0.35, (0.55, 0.70, 0.88, 0.55)),
+                  (1.0, (0.11, 0.30, 0.55, 1.0))],
+        "outline_bg": "white", "star_edge": "black",
+    },
 }
-TELE_COLORS = {"Rubin": "#7dcfff", "JBT": "#9ece6a"}
+
+# Module globals set per-theme in main(); default to dark so the helpers below
+# (study_color) have a palette before main() runs.
+FG, MUTE = THEMES["dark"]["fg"], THEMES["dark"]["mute"]
+STUDY_COLORS = THEMES["dark"]["study"]
+TELE_COLORS = THEMES["dark"]["tele"]
 
 
 # ---- tight typed schema (mirror of crates/p9-survey/src/schema.rs) ----
@@ -182,8 +217,23 @@ def levels_68_95(h: np.ndarray) -> list:
 
 
 def main() -> None:
-    data_path = sys.argv[1] if len(sys.argv) > 1 else "crates/p9-survey/p9_survey_data.json"
-    out_path = sys.argv[2] if len(sys.argv) > 2 else "crates/p9-survey/p9_survey_sky.svg"
+    global FG, MUTE, STUDY_COLORS, TELE_COLORS
+    argv = sys.argv[1:]
+    theme_name = "dark"
+    if "--theme" in argv:
+        i = argv.index("--theme")
+        if i + 1 >= len(argv):
+            raise SystemExit("--theme needs a value (dark|standard)")
+        theme_name = argv[i + 1]
+        del argv[i:i + 2]
+    if theme_name not in THEMES:
+        raise SystemExit(f"--theme must be one of {list(THEMES)}, got {theme_name!r}")
+    th = THEMES[theme_name]
+    FG, MUTE = th["fg"], th["mute"]
+    STUDY_COLORS, TELE_COLORS = th["study"], th["tele"]
+
+    data_path = argv[0] if len(argv) > 0 else "crates/p9-survey/p9_survey_data.json"
+    out_path = argv[1] if len(argv) > 1 else "crates/p9-survey/p9_survey_sky.svg"
     d = load(data_path)
 
     import matplotlib
@@ -194,25 +244,24 @@ def main() -> None:
     from matplotlib.colors import LinearSegmentedColormap
     import matplotlib.patheffects as pe
 
-    # Neutral grey "probability cloud" so the coloured overlays read clearly on
-    # the dark background (the warm magma map fought the orange/red overlays).
-    p9_cloud = LinearSegmentedColormap.from_list(
-        "p9cloud",
-        [(0.0, (0, 0, 0, 0.0)), (0.35, (0.50, 0.52, 0.60, 0.55)),
-         (1.0, (0.90, 0.92, 0.99, 1.0))],
-    )
-    outline = [pe.Stroke(linewidth=4.0, foreground="#1a1b26"), pe.Normal()]
+    # Transparent-low "probability cloud" in the theme's hue so the coloured
+    # overlays read clearly against the background.
+    p9_cloud = LinearSegmentedColormap.from_list("p9cloud", th["cloud"])
+    outline = [pe.Stroke(linewidth=4.0, foreground=th["outline_bg"]), pe.Normal()]
 
     g = d.grid
     extent = [g.ra_min_deg, g.ra_max_deg, g.dec_min_deg, g.dec_max_deg]
     primary = next(s for s in d.studies if "2021 Brown" in s.solution.name)
 
     fig = plt.figure(figsize=(9.6, 7.4))
-    fig.patch.set_alpha(0)
+    if th["transparent"]:
+        fig.patch.set_alpha(0)
+    else:
+        fig.patch.set_facecolor(th["bg"])
     gs = GridSpec(2, 1, height_ratios=[2.4, 1.0], hspace=0.42)
 
     # ---- panel 1: sky heatmap ----
-    ax = fig.add_subplot(gs[0]); ax.set_facecolor("none")
+    ax = fig.add_subplot(gs[0]); ax.set_facecolor(th["bg"] or "none")
     H = gaussian_filter(grid_2d(primary, g), 1.2)
     im = ax.imshow(H / H.max(), origin="lower", extent=extent, aspect="auto",
                    cmap=p9_cloud, vmin=0.02, zorder=2)
@@ -224,22 +273,22 @@ def main() -> None:
             Hs = gaussian_filter(grid_2d(s, g), 1.4)
             ax.contour(xc, yc, Hs, levels=levels_68_95(Hs), colors=col,
                        linewidths=[0.9, 1.6], alpha=0.95, zorder=4)
-        ax.plot(s.peak_ra_deg, s.peak_dec_deg, "*", ms=14, mfc=col, mec="white",
+        ax.plot(s.peak_ra_deg, s.peak_dec_deg, "*", ms=14, mfc=col, mec=th["star_edge"],
                 mew=0.5, zorder=6)
         ax.plot([], [], color=col, lw=2.2,
                 label=f"{s.solution.name.split('(')[0].strip()} — V≈{s.v_median:.1f}, {s.dist_median_au:.0f} AU")
 
     gp = np.array(d.overlays.galactic_plane); ec = np.array(d.overlays.ecliptic)
-    op = np.argsort(gp[:, 0]); ax.plot(gp[op, 0], gp[op, 1], ls="--", color="#9aa5ce", lw=1.8,
+    op = np.argsort(gp[:, 0]); ax.plot(gp[op, 0], gp[op, 1], ls="--", color=th["galplane"], lw=1.8,
                                        alpha=0.9, zorder=3, path_effects=outline,
                                        label="Galactic plane (crowded zone)")
-    oe = np.argsort(ec[:, 0]); ax.plot(ec[oe, 0], ec[oe, 1], ls=":", color=FG, lw=0.9,
-                                       alpha=0.5, zorder=3, label="Ecliptic")
+    oe = np.argsort(ec[:, 0]); ax.plot(ec[oe, 0], ec[oe, 1], ls=":", color=th["ecliptic"], lw=0.9,
+                                       alpha=0.7, zorder=3, label="Ecliptic")
 
     # Search-narrowing overlays: Rubin cede line + Cassini favored-ν arc.
     c = d.constraints
     ax.axhspan(g.dec_min_deg, c.rubin_dec_max_deg, color=MUTE, alpha=0.16, zorder=1)
-    ax.axhline(c.rubin_dec_max_deg, color="#c0caf5", ls=(0, (6, 3)), lw=1.4, alpha=0.9,
+    ax.axhline(c.rubin_dec_max_deg, color=th["rubin_line"], ls=(0, (6, 3)), lw=1.4, alpha=0.9,
                zorder=5, label=f"Rubin reach (Dec < +{c.rubin_dec_max_deg:.0f}°)")
     # The favored-ν arc is a compact curve that can cross RA = 0/360; draw it as
     # connected segments (split on wrap) in a high-contrast colour with a dark
@@ -250,10 +299,10 @@ def main() -> None:
     for k in range(1, len(ra_a) + 1):
         if k == len(ra_a) or abs(ra_a[k] - ra_a[k - 1]) > 180:
             sl = slice(start, k)
-            ax.plot(ra_a[sl], dec_a[sl], color="#bb9af7", lw=2.8, zorder=8,
+            ax.plot(ra_a[sl], dec_a[sl], color=th["arc"], lw=2.8, zorder=8,
                     path_effects=outline)
             start = k
-    ax.plot([], [], color="#bb9af7", lw=2.8,
+    ax.plot([], [], color=th["arc"], lw=2.8,
             label=f"Cassini favoured-ν arc (ν {c.favored_nu_lo_deg:.0f}–{c.favored_nu_hi_deg:.0f}°, B&B orbit)")
 
     ax.set_xlim(g.ra_min_deg, g.ra_max_deg); ax.set_ylim(g.dec_min_deg, g.dec_max_deg)
@@ -273,7 +322,7 @@ def main() -> None:
     cb.ax.tick_params(colors=MUTE); plt.setp(cb.ax.get_yticklabels(), color=FG, fontsize=7)
 
     # ---- panel 2: detection probability per telescope across studies ----
-    ax2 = fig.add_subplot(gs[1]); ax2.set_facecolor("none")
+    ax2 = fig.add_subplot(gs[1]); ax2.set_facecolor(th["bg"] or "none")
     studies = [s.solution.name.split("(")[0].strip() for s in d.studies]
     x = np.arange(len(studies)); w = 0.26
     for j, t in enumerate(d.telescopes):
@@ -295,8 +344,9 @@ def main() -> None:
     ax2.legend(loc="upper right", fontsize=7.2, framealpha=0.0, labelcolor=FG)
     ax2.grid(axis="y", color=MUTE, alpha=0.25, lw=0.5)
 
-    fig.savefig(out_path, transparent=True, bbox_inches="tight")
-    print(f"wrote {out_path}  (schema v{d.schema_version}, "
+    fig.savefig(out_path, transparent=th["transparent"],
+                facecolor=("none" if th["transparent"] else th["bg"]), bbox_inches="tight")
+    print(f"wrote {out_path}  (theme={theme_name}, schema v{d.schema_version}, "
           f"{d.samples_per_study} samples/study, {len(d.studies)} studies)")
 
 


### PR DESCRIPTION
`scripts/plot_survey.py` now takes `--theme dark|standard` (default `dark`). `dark` is the Tokyo-Night palette this tooling uses on the portal's dark background (transparent SVG); `standard` is a conventional light/matplotlib (tab10) scheme on a white background for slides/print. Colours, background, transparency, cloud-cmap hue, marker edges, and overlay outlines are all driven from a `THEMES` table; unknown themes error cleanly. Committed figure regenerated with the default dark theme.