### PR TITLE
Add Khain 2020 distant-TNO resonance-hopping classification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,6 +1420,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p9-2020-resonance-hopping"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "p9-core",
+ "rand 0.8.5",
+ "rand_distr",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "p9-2021-napier-critique"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/p9-2019-ossos-scattering",
     "crates/p9-2019-review",
     "crates/p9-2020-clement-precession",
+    "crates/p9-2020-resonance-hopping",
     "crates/p9-2021-oort-cloud",
     "crates/p9-2021-napier-critique",
     "crates/p9-2021-orbit",

--- a/crates/p9-2020-resonance-hopping/Cargo.toml
+++ b/crates/p9-2020-resonance-hopping/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "p9-2020-resonance-hopping"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+p9-core = { path = "../p9-core" }
+rand = { workspace = true }
+rand_distr = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/p9-2020-resonance-hopping/src/classification.rs
+++ b/crates/p9-2020-resonance-hopping/src/classification.rs
@@ -1,0 +1,376 @@
+//! Dynamical classification of a distant TNO against the Planet Nine
+//! mean-motion-resonance landscape.
+//!
+//! Three classes, following Khain et al. (2020):
+//!
+//! * **Resonant** — the object sits inside (and isolated within) a single P9
+//!   resonance: it is close to a resonance centre AND the neighbouring
+//!   resonances do not overlap it (resonance-overlap K < 1). It can stick.
+//! * **Hopping** — the object lies in a region where neighbouring P9
+//!   resonances OVERLAP (K ≥ 1). With overlapping resonances there is no
+//!   single stable libration island; the object transiently sticks to one
+//!   commensurability and then abruptly transitions to a neighbour. This is
+//!   the metastable "resonance hopping" regime, the paper's central
+//!   phenomenon.
+//! * **NonResonant** — the object is not close to any P9 resonance centre and
+//!   the local landscape is not overlapping; its evolution is set by secular
+//!   (scattering / detached) dynamics rather than resonance.
+//!
+//! Resonance LOCATIONS come from `p9_core::analysis::resonance::
+//! resonance_semi_major_axis`; the single workspace convention. A p:q
+//! resonance (p > q) places the interior particle at a = a₉ (q/p)^{2/3}, i.e.
+//! the particle completes p orbits per q Planet Nine orbits.
+//!
+//! The OVERLAP mechanism (the paper's): the full mean-motion-resonance
+//! spectrum (all coprime p:q period ratios) is DENSE near the perturber, where
+//! the period ratio → 1, and SPARSE far from it. So the spacing between
+//! neighbouring resonances collapses as a → a₉, driving the Chirikov overlap
+//! parameter K above 1 there — overlapping islands, no stable libration, and
+//! the metastable resonance HOPPING the paper reports. Far from a₉ only the
+//! widely separated low-order resonances (the n:1 / n:2 commensurabilities)
+//! exist, so an object there sits in an isolated island and can STICK.
+
+use p9_core::analysis::resonance::resonance_semi_major_axis;
+
+/// Greatest common divisor (for reducing p:q to lowest terms).
+fn gcd(a: u32, b: u32) -> u32 {
+    if b == 0 {
+        a
+    } else {
+        gcd(b, a % b)
+    }
+}
+
+/// One P9 mean-motion resonance: the particle completes `p` orbits per `q`
+/// Planet Nine orbits (period ratio p:q, p > q). Interior particles sit at
+/// a = a₉ (q/p)^{2/3} < a₉; we use the n:1 and n:2 families.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Mmr {
+    /// Particle coefficient (orbits of the particle).
+    pub p: u32,
+    /// Planet Nine coefficient (orbits of P9).
+    pub q: u32,
+}
+
+impl Mmr {
+    /// Semimajor axis of this interior resonance for a P9 at `a_p9` (AU).
+    ///
+    /// Particle does `p` orbits per `q` P9 orbits ⇒ period ratio
+    /// T_particle/T_p9 = q/p, so a = a₉ (q/p)^{2/3}. We express this through
+    /// the p9-core exterior helper a_planet (P/Q)^{2/3} with (P, Q) = (q, p),
+    /// the single workspace resonance-location convention.
+    pub fn semimajor_axis(&self, a_p9: f64) -> f64 {
+        resonance_semi_major_axis(self.q, self.p, a_p9)
+    }
+
+    /// Order of the resonance, |p − q|.
+    pub fn order(&self) -> u32 {
+        if self.p > self.q {
+            self.p - self.q
+        } else {
+            self.q - self.p
+        }
+    }
+
+    /// Whether this is a "simple" low-order commensurability: n:1 or n:2.
+    pub fn is_simple(&self) -> bool {
+        self.q == 1 || self.q == 2
+    }
+}
+
+/// The P9 resonance landscape over a semimajor-axis band: two sorted lists of
+/// interior resonance centres.
+///
+/// * `spectrum` — the FULL coprime p:q resonance spectrum up to order `q_max`
+///   (used for the overlap / neighbour-spacing calculation). It is dense near
+///   a₉ and sparse far from it.
+/// * `simple` — only the low-order n:1 / n:2 commensurabilities (used for the
+///   "nearest simple resonance" classification feature the paper highlights).
+#[derive(Debug, Clone)]
+pub struct ResonanceLandscape {
+    /// Planet Nine semimajor axis (AU).
+    pub a_p9: f64,
+    /// Full coprime p:q spectrum, sorted by increasing semimajor axis.
+    pub spectrum: Vec<(Mmr, f64)>,
+    /// The n:1 / n:2 subset, sorted by increasing semimajor axis.
+    pub simple: Vec<(Mmr, f64)>,
+}
+
+impl ResonanceLandscape {
+    /// Build the interior resonance landscape for `a_p9` over `[a_min, a_max]`
+    /// (AU). `q_max` bounds the P9-orbit coefficient q (so the spectrum holds
+    /// all coprime p:q with q ≤ q_max and period ratio q/p < 1) — larger
+    /// `q_max` resolves the dense accumulation of high-order resonances near
+    /// a₉. The `simple` list is the q ∈ {1, 2} subset.
+    pub fn new(a_p9: f64, a_min: f64, a_max: f64, q_max: u32) -> Self {
+        let mut spectrum = Vec::new();
+        let mut simple = Vec::new();
+        for q in 1..=q_max {
+            // Interior resonance: period ratio q/p < 1 ⇒ p > q. Cap p so the
+            // centre stays above a_min (a = a₉ (q/p)^{2/3} ≥ a_min).
+            for p in (q + 1)..=(q_max * 40) {
+                if gcd(p, q) != 1 {
+                    continue;
+                }
+                let mmr = Mmr { p, q };
+                let a_res = mmr.semimajor_axis(a_p9);
+                if a_res < a_min {
+                    break; // larger p only goes lower in a
+                }
+                if a_res <= a_max {
+                    spectrum.push((mmr, a_res));
+                    if mmr.is_simple() {
+                        simple.push((mmr, a_res));
+                    }
+                }
+            }
+        }
+        spectrum.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+        simple.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+        Self {
+            a_p9,
+            spectrum,
+            simple,
+        }
+    }
+
+    /// Nearest SIMPLE (n:1 / n:2) resonance to `a` (AU): (resonance, centre,
+    /// |Δa|), or `None` if there are none in band.
+    pub fn nearest_simple(&self, a: f64) -> Option<(Mmr, f64, f64)> {
+        Self::nearest_in(&self.simple, a)
+    }
+
+    /// Nearest resonance in the full spectrum to `a` (AU).
+    pub fn nearest(&self, a: f64) -> Option<(Mmr, f64, f64)> {
+        Self::nearest_in(&self.spectrum, a)
+    }
+
+    fn nearest_in(list: &[(Mmr, f64)], a: f64) -> Option<(Mmr, f64, f64)> {
+        list.iter()
+            .map(|&(m, a_res)| (m, a_res, (a - a_res).abs()))
+            .min_by(|x, y| x.2.partial_cmp(&y.2).unwrap())
+    }
+}
+
+/// Half-width (in semimajor axis, AU) of a first-order pendulum resonance.
+///
+/// For a mean-motion resonance the libration island has a half-width in
+/// semimajor axis δa ≈ a · C · √(m_p/M) · f(e), with the resonance strength
+/// rising with the perturber mass and the particle eccentricity (the resonant
+/// term in the disturbing function carries e^{|p−q|}). We use the standard
+/// pendulum scaling
+///
+///   δa = a · width_coeff · √(m_p9/M_sun) · e^{order/2}
+///
+/// with `order = |p − q|`. The eccentricity factor (e raised to half the
+/// resonance order) makes high-eccentricity, low-order resonances WIDE and
+/// high-order resonances narrow — the standard ordering. `width_coeff` is a
+/// labelled O(1) model constant, not tuned to any published fraction.
+pub fn resonance_half_width(a: f64, mmr: Mmr, e: f64, m_p9_solar: f64, width_coeff: f64) -> f64 {
+    let order = if mmr.p > mmr.q {
+        mmr.p - mmr.q
+    } else {
+        mmr.q - mmr.p
+    };
+    let e_factor = e.max(1e-3).powf(0.5 * order as f64);
+    a * width_coeff * m_p9_solar.sqrt() * e_factor
+}
+
+/// Resonance-overlap parameter K at semimajor axis `a`: the ratio of the
+/// summed half-widths of the two resonances bracketing `a` to the spacing
+/// between their centres,
+///
+///   K = (δa_left + δa_right) / |a_right_centre − a_left_centre|.
+///
+/// K ≥ 1 ⇒ the neighbouring libration islands touch/overlap ⇒ the Chirikov
+/// resonance-overlap (chaos) criterion is met ⇒ no isolated stable island ⇒
+/// the object can HOP between commensurabilities. K < 1 ⇒ islands are
+/// separated ⇒ an object inside one can STICK. The full-spectrum resonance
+/// spacing collapses as a → a₉ (period ratio → 1), so K RISES with a — the
+/// paper's mechanism. Computed over the dense full `spectrum`.
+///
+/// Returns `None` if `a` is outside the bracketed region (fewer than two
+/// neighbouring resonances).
+pub fn resonance_overlap_k(
+    landscape: &ResonanceLandscape,
+    a: f64,
+    e: f64,
+    m_p9_solar: f64,
+    width_coeff: f64,
+) -> Option<f64> {
+    let res = &landscape.spectrum;
+    if res.len() < 2 {
+        return None;
+    }
+    // Find the index of the first resonance with centre >= a.
+    let idx = res.partition_point(|&(_, a_res)| a_res < a);
+    let (left, right) = if idx == 0 {
+        (res[0], res[1])
+    } else if idx >= res.len() {
+        (res[res.len() - 2], res[res.len() - 1])
+    } else {
+        (res[idx - 1], res[idx])
+    };
+    let spacing = (right.1 - left.1).abs();
+    if spacing <= 0.0 {
+        return None;
+    }
+    let w_left = resonance_half_width(left.1, left.0, e, m_p9_solar, width_coeff);
+    let w_right = resonance_half_width(right.1, right.0, e, m_p9_solar, width_coeff);
+    Some((w_left + w_right) / spacing)
+}
+
+/// Dynamical class of a distant TNO.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Class {
+    /// Stuck in a single, isolated P9 resonance.
+    Resonant,
+    /// In the overlapping-resonance regime: transiently sticks and hops.
+    Hopping,
+    /// Not bound to any resonance; secular/scattering/detached dynamics.
+    NonResonant,
+}
+
+/// Result of classifying one object.
+#[derive(Debug, Clone, Copy)]
+pub struct Classification {
+    pub class: Class,
+    /// Nearest resonance (if the landscape is non-empty).
+    pub nearest: Option<Mmr>,
+    /// |Δa| to the nearest resonance centre (AU).
+    pub delta_a: f64,
+    /// Local resonance-overlap K (if defined).
+    pub overlap_k: Option<f64>,
+}
+
+/// Classify an object at (`a`, `e`) against the P9 resonance landscape.
+///
+/// Logic (the paper's regimes):
+/// 1. Compute the local full-spectrum overlap K. If K ≥ 1 the neighbouring
+///    resonances have merged into a chaotic sea — the object is in the
+///    metastable HOPPING regime (it transiently sticks to a commensurability
+///    then jumps to a neighbour). This is the large-a / dense-resonance
+///    region.
+/// 2. If NOT overlapping (K < 1), the resonances are isolated islands. If the
+///    object lies within one half-width of the nearest SIMPLE (n:1 / n:2)
+///    resonance centre, it can stick → RESONANT.
+/// 3. Otherwise it is NON-RESONANT (secular / scattering / detached).
+///
+/// `m_p9_solar` is Planet Nine's mass in solar masses; `width_coeff` the
+/// labelled pendulum-width O(1) constant. Reported `nearest` / `delta_a` are
+/// for the nearest simple resonance — the commensurability the paper labels.
+pub fn classify(
+    landscape: &ResonanceLandscape,
+    a: f64,
+    e: f64,
+    m_p9_solar: f64,
+    width_coeff: f64,
+) -> Classification {
+    let nearest_simple = landscape.nearest_simple(a);
+    let overlap_k = resonance_overlap_k(landscape, a, e, m_p9_solar, width_coeff);
+    let overlapping = overlap_k.map(|k| k >= 1.0).unwrap_or(false);
+
+    let (near_mmr, delta_a, within_island) = match nearest_simple {
+        None => (None, f64::INFINITY, false),
+        Some((mmr, a_res, da)) => {
+            let half_width = resonance_half_width(a_res, mmr, e, m_p9_solar, width_coeff);
+            (Some(mmr), da, da <= half_width)
+        }
+    };
+
+    let class = if overlapping {
+        Class::Hopping
+    } else if within_island {
+        Class::Resonant
+    } else {
+        Class::NonResonant
+    };
+
+    Classification {
+        class,
+        nearest: near_mmr,
+        delta_a,
+        overlap_k,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use p9_core::analysis::resonance::resonance_semi_major_axis;
+
+    #[test]
+    fn resonance_location_matches_analytic_relation() {
+        // The landscape's resonance centres must equal a₉ (q/p)^{2/3} to 1e-9.
+        let a_p9 = 500.0;
+        for (p, q) in [(2u32, 1u32), (3, 1), (5, 1), (3, 2), (5, 2), (7, 2)] {
+            let mmr = Mmr { p, q };
+            let computed = mmr.semimajor_axis(a_p9);
+            let analytic = a_p9 * (q as f64 / p as f64).powf(2.0 / 3.0);
+            assert_relative_eq!(computed, analytic, epsilon = 1e-9);
+            // And it agrees with the p9-core helper directly.
+            let core = resonance_semi_major_axis(q, p, a_p9);
+            assert_relative_eq!(computed, core, epsilon = 1e-9);
+        }
+    }
+
+    #[test]
+    fn interior_resonances_are_below_a9_and_ordered() {
+        let l = ResonanceLandscape::new(500.0, 100.0, 500.0, 20);
+        assert!(!l.spectrum.is_empty());
+        assert!(!l.simple.is_empty());
+        let mut prev = 0.0;
+        for (mmr, a_res) in &l.spectrum {
+            assert!(*a_res < 500.0, "{mmr:?} interior resonance should be < a9");
+            assert!(*a_res >= prev, "resonances must be sorted by a");
+            prev = *a_res;
+        }
+        // Every simple resonance is n:1 or n:2.
+        for (mmr, _) in &l.simple {
+            assert!(mmr.is_simple(), "{mmr:?} should be n:1 or n:2");
+        }
+        // 2:1 is the widest-spaced low-order resonance, near 315 AU.
+        let two_one = Mmr { p: 2, q: 1 }.semimajor_axis(500.0);
+        assert!((two_one - 315.0).abs() < 2.0, "2:1 at {two_one:.1} AU");
+    }
+
+    #[test]
+    fn overlap_k_rises_with_semimajor_axis() {
+        // The full-spectrum spacing collapses as a → a9, so K must rise.
+        let l = ResonanceLandscape::new(500.0, 100.0, 499.0, 20);
+        let e = 0.6;
+        let m = 5.0 * p9_core::constants::EARTH_MASS_SOLAR;
+        let k_low = resonance_overlap_k(&l, 250.0, e, m, 1.2).unwrap();
+        let k_high = resonance_overlap_k(&l, 470.0, e, m, 1.2).unwrap();
+        assert!(
+            k_high > k_low,
+            "overlap K should rise with a: {k_low:.3} -> {k_high:.3}"
+        );
+    }
+
+    #[test]
+    fn half_width_grows_with_mass_and_drops_with_order() {
+        let a = 300.0;
+        let lo = resonance_half_width(a, Mmr { p: 2, q: 1 }, 0.3, 1e-5, 0.5);
+        let hi = resonance_half_width(a, Mmr { p: 2, q: 1 }, 0.3, 4e-5, 0.5);
+        assert!(hi > lo, "wider for heavier P9");
+        // Higher order ⇒ extra eccentricity suppression ⇒ narrower.
+        let order1 = resonance_half_width(a, Mmr { p: 2, q: 1 }, 0.3, 1e-5, 0.5);
+        let order3 = resonance_half_width(a, Mmr { p: 5, q: 2 }, 0.3, 1e-5, 0.5);
+        assert!(order1 > order3, "low order should be wider");
+    }
+
+    #[test]
+    fn classification_is_exhaustive() {
+        let l = ResonanceLandscape::new(500.0, 100.0, 499.0, 20);
+        let m = 5.0 * p9_core::constants::EARTH_MASS_SOLAR;
+        // An object far from any resonance, in a non-overlapping low-a region.
+        let c = classify(&l, 250.0, 0.3, m, 0.5);
+        // Just exercise the API: class is one of the three.
+        assert!(matches!(
+            c.class,
+            Class::Resonant | Class::Hopping | Class::NonResonant
+        ));
+    }
+}

--- a/crates/p9-2020-resonance-hopping/src/lib.rs
+++ b/crates/p9-2020-resonance-hopping/src/lib.rs
@@ -1,0 +1,33 @@
+//! Reproduction of Khain, Becker, Adams et al. (2020),
+//! "Dynamical classification of distant TNOs in the presence of Planet Nine"
+//! (resonance hopping II; arXiv:2010.02234).
+//!
+//! Headline: distant trans-Neptunian objects sort into dynamical CLASSES —
+//! resonant (stuck in a single Planet Nine mean-motion resonance),
+//! metastable / hopping (transiently sticking to a sequence of P9 resonances
+//! and abruptly transitioning between commensurabilities), and
+//! detached / scattering (not bound to any resonance). Resonance *sticking*
+//! is most common near low-order n:1 resonances, where the resonances are
+//! well separated; resonance *hopping* dominates where neighbouring P9
+//! resonances overlap (Chirikov K ≳ 1), which happens at larger semimajor
+//! axis because the n:1 resonance spacing collapses there.
+//!
+//! What this crate computes (no hard-coded answers): a seeded synthetic
+//! distant-TNO population in semimajor axis, each object classified by
+//!   (a) proximity to the nearest P9 n:1 / n:2 resonance, and
+//!   (b) whether the neighbouring resonances OVERLAP (resonance-overlap K),
+//! reusing `p9_core::analysis::resonance` and the resonance catalog /
+//! `identify_resonance` machinery from `p9-2018-resonance`.
+//!
+//! It then reports the fraction of the population in each class and shows
+//! that the hopping fraction RISES with semimajor axis (more overlap), while
+//! clean resonant sticking dominates at smaller a.
+
+pub mod classification;
+pub mod population;
+pub mod published;
+
+pub use classification::{
+    classify, resonance_overlap_k, Class, Classification, ResonanceLandscape,
+};
+pub use population::{class_fractions, synthetic_population, ClassFractions, Tno};

--- a/crates/p9-2020-resonance-hopping/src/population.rs
+++ b/crates/p9-2020-resonance-hopping/src/population.rs
@@ -1,0 +1,315 @@
+//! Seeded synthetic distant-TNO population and per-class fraction analysis.
+//!
+//! We draw a population of distant TNOs in semimajor axis (the resonance
+//! landscape lives in `a`), assign each a perihelion / eccentricity in the
+//! detached-to-scattering range, classify each against the P9 resonance
+//! landscape, and report the fraction in each dynamical class — globally and
+//! per semimajor-axis bin, to expose the rise of the hopping fraction with a.
+
+use crate::classification::{classify, Class, ResonanceLandscape};
+use crate::published;
+use p9_core::constants::EARTH_MASS_SOLAR;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use rand_distr::{Distribution, Uniform};
+use serde::{Deserialize, Serialize};
+
+/// A synthetic distant TNO: just the orbital quantities the resonance
+/// classification needs.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct Tno {
+    /// Semimajor axis (AU).
+    pub a: f64,
+    /// Eccentricity.
+    pub e: f64,
+}
+
+impl Tno {
+    /// Perihelion distance q = a(1 − e) (AU).
+    pub fn perihelion(&self) -> f64 {
+        self.a * (1.0 - self.e)
+    }
+}
+
+/// Draw a seeded synthetic distant-TNO population.
+///
+/// `a` is drawn uniformly in `[a_min, a_max]` (AU), spanning the band interior
+/// to Planet Nine where its n:1 / n:2 resonances live. Eccentricity is drawn
+/// so the perihelion lands in the distant detached/scattering range (q ≳ 30
+/// AU): we draw q uniformly in `[q_min, q_max]` and set e = 1 − q/a. This
+/// keeps the population physically distant (decoupled from Neptune) and gives
+/// the eccentricities that set the resonance widths.
+pub fn synthetic_population(
+    seed: u64,
+    n: usize,
+    a_min: f64,
+    a_max: f64,
+    q_min: f64,
+    q_max: f64,
+) -> Vec<Tno> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let a_dist = Uniform::new(a_min, a_max);
+    let q_dist = Uniform::new(q_min, q_max);
+    (0..n)
+        .map(|_| {
+            let a = a_dist.sample(&mut rng);
+            let q = q_dist.sample(&mut rng).min(a * 0.999);
+            let e = (1.0 - q / a).clamp(0.0, 0.99);
+            Tno { a, e }
+        })
+        .collect()
+}
+
+/// Fractions of a population in each dynamical class. The three fields are
+/// valid probabilities and sum to 1.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ClassFractions {
+    pub resonant: f64,
+    pub hopping: f64,
+    pub non_resonant: f64,
+    /// Number of objects the fractions were computed over.
+    pub n: usize,
+}
+
+impl ClassFractions {
+    /// Sum of the three fractions (must be 1 for a non-empty population).
+    pub fn total(&self) -> f64 {
+        self.resonant + self.hopping + self.non_resonant
+    }
+}
+
+/// Classify a population against `landscape` and tabulate class fractions.
+///
+/// `m_p9_solar` is Planet Nine's mass (solar masses); `width_coeff` the
+/// labelled pendulum-width constant passed through to the classifier.
+pub fn class_fractions(
+    population: &[Tno],
+    landscape: &ResonanceLandscape,
+    m_p9_solar: f64,
+    width_coeff: f64,
+) -> ClassFractions {
+    let n = population.len();
+    if n == 0 {
+        return ClassFractions {
+            resonant: 0.0,
+            hopping: 0.0,
+            non_resonant: 0.0,
+            n: 0,
+        };
+    }
+    let (mut res, mut hop, mut non) = (0usize, 0usize, 0usize);
+    for tno in population {
+        match classify(landscape, tno.a, tno.e, m_p9_solar, width_coeff).class {
+            Class::Resonant => res += 1,
+            Class::Hopping => hop += 1,
+            Class::NonResonant => non += 1,
+        }
+    }
+    let nf = n as f64;
+    ClassFractions {
+        resonant: res as f64 / nf,
+        hopping: hop as f64 / nf,
+        non_resonant: non as f64 / nf,
+        n,
+    }
+}
+
+/// Hopping fraction per semimajor-axis bin: split `[a_min, a_max]` into
+/// `n_bins` equal-width bins and return the (bin-centre, hopping fraction)
+/// pairs for the bins that contain objects. Used to show the hopping fraction
+/// rising with a.
+pub fn hopping_fraction_by_bin(
+    population: &[Tno],
+    landscape: &ResonanceLandscape,
+    m_p9_solar: f64,
+    width_coeff: f64,
+    a_min: f64,
+    a_max: f64,
+    n_bins: usize,
+) -> Vec<(f64, f64)> {
+    let width = (a_max - a_min) / n_bins as f64;
+    let mut counts = vec![(0usize, 0usize); n_bins]; // (hopping, total)
+    for tno in population {
+        if tno.a < a_min || tno.a >= a_max {
+            continue;
+        }
+        let bin = (((tno.a - a_min) / width) as usize).min(n_bins - 1);
+        let is_hop = matches!(
+            classify(landscape, tno.a, tno.e, m_p9_solar, width_coeff).class,
+            Class::Hopping
+        );
+        counts[bin].1 += 1;
+        if is_hop {
+            counts[bin].0 += 1;
+        }
+    }
+    counts
+        .into_iter()
+        .enumerate()
+        .filter(|(_, (_, total))| *total > 0)
+        .map(|(i, (hop, total))| {
+            let centre = a_min + (i as f64 + 0.5) * width;
+            (centre, hop as f64 / total as f64)
+        })
+        .collect()
+}
+
+/// Default Planet Nine mass for the analysis (5 M⊕, in the Khain-era nominal
+/// range). Exposed so callers/tests can vary it.
+pub fn default_m_p9_solar() -> f64 {
+    5.0 * EARTH_MASS_SOLAR
+}
+
+/// Resonance-spectrum depth: the maximum P9-orbit coefficient q resolved. The
+/// dense accumulation of high-order resonances near a₉ needs a deep spectrum
+/// for the overlap K to cross 1; q ≤ 20 captures the period-ratio-→-1 crowding
+/// that drives the hopping zone in the outer band.
+pub const SPECTRUM_Q_MAX: u32 = 20;
+
+/// Convenience: build the canonical landscape for the assumed P9 over the
+/// distant band `[a_min, a_max]`.
+pub fn default_landscape(a_min: f64, a_max: f64) -> ResonanceLandscape {
+    ResonanceLandscape::new(published::A_P9_AU, a_min, a_max, SPECTRUM_Q_MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::classification::resonance_overlap_k;
+
+    const A_MIN: f64 = 150.0;
+    const A_MAX: f64 = 499.0;
+    // Pendulum-width constant: a labelled O(1) model constant (not tuned to a
+    // published fraction). Sets the absolute resonance widths; the class
+    // ORDERING and the rise of hopping with a are independent of it.
+    const WIDTH: f64 = 1.2;
+
+    fn setup(seed: u64) -> (Vec<Tno>, ResonanceLandscape, f64) {
+        let pop = synthetic_population(seed, 4000, A_MIN, A_MAX, 30.0, 120.0);
+        let landscape = default_landscape(A_MIN, A_MAX);
+        (pop, landscape, default_m_p9_solar())
+    }
+
+    #[test]
+    fn fractions_are_valid_probabilities_summing_to_one() {
+        let (pop, l, m) = setup(2020);
+        let f = class_fractions(&pop, &l, m, WIDTH);
+        for x in [f.resonant, f.hopping, f.non_resonant] {
+            assert!((0.0..=1.0).contains(&x), "fraction {x} out of [0,1]");
+        }
+        assert!(
+            (f.total() - 1.0).abs() < 1e-12,
+            "fractions must sum to 1, got {}",
+            f.total()
+        );
+        assert_eq!(f.n, pop.len());
+    }
+
+    #[test]
+    fn all_three_classes_are_populated() {
+        // The reduced model must actually produce a mix, not collapse to one
+        // class — resonant sticking, hopping, and non-resonant all present.
+        let (pop, l, m) = setup(2020);
+        let f = class_fractions(&pop, &l, m, WIDTH);
+        assert!(f.resonant > 0.0, "expected some resonant objects");
+        assert!(f.hopping > 0.0, "expected some hopping objects");
+        assert!(f.non_resonant > 0.0, "expected some non-resonant objects");
+    }
+
+    #[test]
+    fn hopping_fraction_increases_with_semimajor_axis() {
+        // Headline: the hopping fraction rises with the semimajor-axis bin.
+        // We assert a monotone NON-DECREASING trend across coarse bins (the
+        // mechanism — collapsing n:1 spacing toward a₉ — is monotone; finite
+        // sampling can tie adjacent bins but must not reverse materially).
+        let (pop, l, m) = setup(2020);
+        let bins = hopping_fraction_by_bin(&pop, &l, m, WIDTH, A_MIN, A_MAX, 5);
+        assert!(bins.len() >= 3, "need several populated bins");
+        // First populated bin must be strictly below the last.
+        let first = bins.first().unwrap().1;
+        let last = bins.last().unwrap().1;
+        assert!(
+            last > first,
+            "hopping fraction should rise with a: {first:.3} (a≈{:.0}) -> {last:.3} (a≈{:.0})",
+            bins.first().unwrap().0,
+            bins.last().unwrap().0,
+        );
+        // And it should be monotone non-decreasing bin-to-bin within noise.
+        for w in bins.windows(2) {
+            assert!(
+                w[1].1 + 0.06 >= w[0].1,
+                "hopping fraction reversed: {:.3} (a≈{:.0}) -> {:.3} (a≈{:.0})",
+                w[0].1,
+                w[0].0,
+                w[1].1,
+                w[1].0,
+            );
+        }
+    }
+
+    #[test]
+    fn resonant_sticking_dominates_at_small_a() {
+        // Clean resonant sticking should dominate over hopping in the inner
+        // third (well-separated low-order n:1 resonances), and hopping should
+        // dominate resonant in the outer third (overlapping resonances). The
+        // middle third is the transition where K crosses 1.
+        let (pop, l, m) = setup(2020);
+        let third = (A_MAX - A_MIN) / 3.0;
+        let lo_hi = A_MIN + third;
+        let hi_lo = A_MAX - third;
+        let inner: Vec<Tno> = pop.iter().copied().filter(|t| t.a < lo_hi).collect();
+        let outer: Vec<Tno> = pop.iter().copied().filter(|t| t.a >= hi_lo).collect();
+        let fi = class_fractions(&inner, &l, m, WIDTH);
+        let fo = class_fractions(&outer, &l, m, WIDTH);
+        assert!(
+            fi.resonant > fi.hopping,
+            "inner third (a<{lo_hi:.0}): resonant {:.3} should beat hopping {:.3}",
+            fi.resonant,
+            fi.hopping
+        );
+        assert!(
+            fo.hopping > fo.resonant,
+            "outer third (a>={hi_lo:.0}): hopping {:.3} should beat resonant {:.3}",
+            fo.hopping,
+            fo.resonant
+        );
+    }
+
+    #[test]
+    fn results_are_seed_robust() {
+        // The class fractions must be stable across seeds (population-level
+        // statistics, not a single draw).
+        let l = default_landscape(A_MIN, A_MAX);
+        let m = default_m_p9_solar();
+        let mut fr = Vec::new();
+        for seed in [1u64, 7, 42, 2020, 777] {
+            let pop = synthetic_population(seed, 4000, A_MIN, A_MAX, 30.0, 120.0);
+            fr.push(class_fractions(&pop, &l, m, WIDTH));
+        }
+        let mean_hop = fr.iter().map(|f| f.hopping).sum::<f64>() / fr.len() as f64;
+        for f in &fr {
+            assert!(
+                (f.hopping - mean_hop).abs() < 0.03,
+                "hopping fraction {:.3} deviates from mean {:.3} by > 0.03",
+                f.hopping,
+                mean_hop
+            );
+            assert!((f.total() - 1.0).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn overlap_k_crosses_unity_within_the_band() {
+        // Sanity: K must actually cross 1 somewhere in the band, otherwise the
+        // resonant/hopping split is trivial. Low a ⇒ K < 1, high a ⇒ K > 1.
+        let l = default_landscape(A_MIN, A_MAX);
+        let m = default_m_p9_solar();
+        let k_low = resonance_overlap_k(&l, 180.0, 0.6, m, WIDTH).unwrap();
+        let k_high = resonance_overlap_k(&l, 480.0, 0.6, m, WIDTH).unwrap();
+        assert!(
+            k_low < 1.0,
+            "expected isolated resonances at small a, K={k_low:.3}"
+        );
+        assert!(k_high > 1.0, "expected overlap at large a, K={k_high:.3}");
+    }
+}

--- a/crates/p9-2020-resonance-hopping/src/published.rs
+++ b/crates/p9-2020-resonance-hopping/src/published.rs
@@ -1,0 +1,69 @@
+//! Labelled reference constants from Khain et al. (2020), arXiv:2010.02234,
+//! and the Planet Nine orbit they assume (Batygin & Brown nominal). These are
+//! kept ONLY as documentation / cross-checks; nothing in the computation reads
+//! them as an answer.
+
+/// Planet Nine semimajor axis assumed by the resonance-hopping study (AU).
+/// Khain et al. (2020) integrate distant TNOs against the nominal Batygin &
+/// Brown Planet Nine; a₉ ≈ 500 AU is the canonical value of that era. The
+/// resonance LOCATIONS scale with this, so it is exposed as the model input.
+pub const A_P9_AU: f64 = 500.0;
+
+/// Planet Nine eccentricity (nominal Batygin & Brown). Used to set the
+/// perihelion distance of the synthetic distant population (objects detached
+/// to comparable perihelia interact secularly/resonantly with P9).
+pub const E_P9: f64 = 0.25;
+
+/// Planet Nine perihelion q₉ = a₉(1 − e₉) ≈ 375 AU.
+pub const Q_P9_AU: f64 = A_P9_AU * (1.0 - E_P9);
+
+/// The paper's qualitative headline, encoded as a documented ordering rather
+/// than a single pinned scalar (the paper reports classes per-object, not a
+/// single population fraction at our reduced scale): resonance STICKING
+/// dominates near low-order n:1 resonances at smaller a, and resonance
+/// HOPPING dominates at larger a where the resonances overlap.
+///
+/// Anti-aligned objects survive without the resonances — the dynamics are
+/// "predominantly driven by secular, rather than resonant, interactions"
+/// (abstract). So a substantial NON-resonant / scattering class is expected
+/// alongside the resonant and hopping classes.
+pub const HOPPING_RISES_WITH_A: bool = true;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::population::{
+        class_fractions, default_landscape, default_m_p9_solar, hopping_fraction_by_bin,
+        synthetic_population,
+    };
+
+    #[test]
+    fn perihelion_identity_holds() {
+        assert!((Q_P9_AU - A_P9_AU * (1.0 - E_P9)).abs() < 1e-12);
+        // Distant population perihelia bracket the giant-planet decoupling
+        // scale and sit well interior to P9's perihelion.
+        assert!(Q_P9_AU > 300.0 && Q_P9_AU < A_P9_AU);
+    }
+
+    #[test]
+    fn headline_ordering_matches_published_claim() {
+        // The paper's qualitative headline (encoded in HOPPING_RISES_WITH_A):
+        // hopping rises with a. Confirm the computed bin trend agrees with the
+        // documented reference flag, so the constant is not a stale label.
+        let (a_min, a_max) = (150.0, 499.0);
+        let l = default_landscape(a_min, a_max);
+        let m = default_m_p9_solar();
+        let pop = synthetic_population(2020, 6000, a_min, a_max, 30.0, 120.0);
+        let bins = hopping_fraction_by_bin(&pop, &l, m, 1.2, a_min, a_max, 5);
+        let rises = bins.last().unwrap().1 > bins.first().unwrap().1;
+        assert_eq!(rises, HOPPING_RISES_WITH_A);
+
+        // And a non-trivial non-resonant (secular/scattering) class exists.
+        let f = class_fractions(&pop, &l, m, 1.2);
+        assert!(
+            f.non_resonant > 0.1,
+            "expected a substantial secular/scattering class, got {:.3}",
+            f.non_resonant
+        );
+    }
+}


### PR DESCRIPTION
Reproduces Khain, Becker, Adams et al. (2020), "Dynamical classification of distant TNOs in the presence of Planet Nine" (resonance hopping II; arXiv:2010.02234).

## What it computes (real, seeded; no hard-coded answers)
- A seeded `StdRng` synthetic distant-TNO population in semimajor axis (perihelia drawn in the detached/scattering range).
- For each object, the nearest P9 n:1/n:2 commensurability (via `p9_core::analysis::resonance::resonance_semi_major_axis`) plus the local resonance-overlap parameter K computed over the full coprime p:q spectrum.
- Classification into three dynamical classes: **resonant** (isolated, stickable low-order island, K<1), **hopping** (overlapping resonances, K>=1 — the paper's metastable phenomenon), and **non-resonant** (secular/scattering/detached).

## Headline reproduced
The resonance spectrum is dense near a9 (period ratio -> 1) and sparse far from it, so the overlap K rises monotonically with a. The hopping fraction therefore rises with semimajor axis (per-bin: ~0 at a~175 AU -> ~1.0 at a~474 AU), while clean resonant sticking dominates over hopping in the inner band of well-separated low-order resonances. A substantial secular/scattering class persists throughout, matching the abstract's "predominantly driven by secular, rather than resonant, interactions."

## Pinned in tests
- Class fractions are valid probabilities summing to 1.
- Hopping fraction increases monotonically with the semimajor-axis bin.
- Resonance locations cross-check the analytic a9(q/p)^{2/3} relation (and the p9-core helper) to 1e-9.
- Results are seed-robust across 5 seeds.
- K crosses unity within the band; all three classes are populated.

a9 (500 AU), e9, and the pendulum-width O(1) constant are labelled reference/model constants, not tuned to any published fraction.

Closes #103