### PR TITLE
Anderson & Kaib 2021: detached Kuiper belt inclination forcing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,6 +1420,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "p9-2021-detached-inclinations"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "nalgebra",
+ "p9-core",
+ "rand 0.8.5",
+ "rand_distr",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "p9-2021-napier-critique"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/p9-2021-oort-cloud",
     "crates/p9-2021-napier-critique",
     "crates/p9-2021-orbit",
+    "crates/p9-2021-detached-inclinations",
     "crates/p9-2021-stability",
     "crates/p9-2021-ztf",
     "crates/p9-2022-des",

--- a/crates/p9-2021-detached-inclinations/Cargo.toml
+++ b/crates/p9-2021-detached-inclinations/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "p9-2021-detached-inclinations"
+version = "0.1.0"
+edition = "2021"
+description = "Reproduction of Anderson & Kaib (2021) 'The effect of Planet Nine on the inclinations of the detached Kuiper belt'"
+
+[dependencies]
+p9-core = { path = "../p9-core" }
+nalgebra = { workspace = true }
+rand = { workspace = true }
+rand_distr = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/p9-2021-detached-inclinations/src/forcing.rs
+++ b/crates/p9-2021-detached-inclinations/src/forcing.rs
@@ -1,0 +1,261 @@
+//! Secular inclination forcing of a detached test particle by an inclined
+//! Planet Nine, in linear Laplace-Lagrange theory.
+//!
+//! A detached object (q decoupled from Neptune, a ≳ 250 AU) feels two secular
+//! torques on its orbital plane:
+//!
+//!   * the **giant planets**, which define (with the Sun) a near-ecliptic
+//!     reference plane and make the particle's node regress at a rate `B_gp`;
+//!   * **Planet Nine**, an inclined massive body, which tries to align the
+//!     particle's plane with *its* plane at a rate `B_p9`.
+//!
+//! In the linear (small mutual-inclination) secular problem the particle's
+//! inclination vector (p, q) = (sin i sin Ω, sin i cos Ω) precesses about a
+//! **forced inclination** that is the mass/coupling-weighted mean of the two
+//! driving planes. With the giant-planet plane taken as the reference
+//! (≈ invariable plane), the forced inclination measured from that plane is
+//!
+//!   i_forced = B_p9 / (B_gp + B_p9) · sin(i9)               (linearized)
+//!
+//! where `i9` is Planet Nine's inclination to the same reference plane. The
+//! free inclination — the particle's intrinsic tilt — precesses on a cone of
+//! this opening about the forced pole, so over secular time the *observed*
+//! inclination spreads between |i_forced − i_free| and (i_forced + i_free).
+//!
+//! This is the linear backbone of Anderson & Kaib (2021): an inclined Planet
+//! Nine forces detached objects onto an inclined Laplace plane, broadening the
+//! inclination distribution relative to a Planet-Nine-free Solar System. The
+//! coupling `B_p9` reuses p9-core's orbit-averaged quadrupole secular
+//! constant; `B_gp` reuses p9-core's giant-planet nodal-precession rate.
+//!
+//! References: Murray & Dermott (1999) §7 (Laplace-Lagrange secular theory);
+//! Anderson & Kaib (2021), arXiv:2109.13307.
+
+use p9_core::analysis::secular::quadrupole_hamiltonian;
+use p9_core::constants::GM_SUN;
+use p9_core::initial_conditions::planets::giant_planets_j2000;
+use p9_core::types::{cartesian_to_elements, P9Params};
+
+/// Giant-planet nodal precession frequency `B_gp` for a particle at (a, e, i),
+/// in rad/yr. This is the secular self-frequency that anchors the particle to
+/// the invariable plane in the absence of Planet Nine:
+///
+///   |Ω̇| = (3/4) n cos i /(1−e²)² Σ_j (m_j/M_⊙)(a_j/a)²,
+///
+/// with the giant-planet masses and semi-major axes read from p9-core's J2000
+/// DE-ephemeris states (no local planet table). This is the identical closed
+/// form used by p9-2025-clustering's `orbital_poles::nodal_precession_rate`;
+/// inlined here because that lives in a sibling paper crate, not p9-core.
+///
+/// Returned as a positive magnitude (a precession *rate*); the forced-
+/// inclination ratio only depends on the relative strengths.
+pub fn giant_planet_frequency(a: f64, e: f64, i: f64) -> f64 {
+    let n = (GM_SUN / (a * a * a)).sqrt(); // rad/day
+    let eta_sq = (1.0 - e * e) * (1.0 - e * e);
+    let sum: f64 = giant_planets_j2000()
+        .iter()
+        .map(|body| {
+            let a_j = cartesian_to_elements(&body.state, GM_SUN).a;
+            body.mass * (a_j / a).powi(2)
+        })
+        .sum();
+    let rate_day = 0.75 * n * i.cos() / eta_sq * sum;
+    (rate_day * 365.25).abs() // rad/yr
+}
+
+/// Planet Nine secular inclination-coupling frequency `B_p9` for a test
+/// particle at (a, e), in rad/yr.
+///
+/// The orbit-averaged quadrupole Hamiltonian (p9-core) is
+/// H = −(C/4)[(2+3e²)(3cos²I − 1) + ...], with the inclination-restoring
+/// coupling constant C = GM₉ α²/(4 a₉ (1−e₉²)^{3/2}). The nodal precession
+/// frequency a particle's plane acquires about Planet Nine's plane is the
+/// second derivative of H with respect to the inclination action; to leading
+/// order in I it reduces to
+///
+///   B_p9 = (3/4) · GM₉/(a₉³) · (a/a₉)^{1/2} ... — but the cleanest, and the
+///
+/// way that stays consistent with the giant-planet expression above, is to use
+/// the *same* disturbing-function coefficient form: treating Planet Nine as one
+/// more (outer, eccentric, massive) perturber,
+///
+///   B_p9 = (3/4) n (m₉/M_⊙) (a/a₉)² · 1/(1−e₉²)^{3/2}
+///
+/// with n = √(GM_⊙/a³) the particle mean motion. The α² = (a/a₉)² scaling makes
+/// the coupling *strengthen with semi-major axis*, the central prediction. We
+/// cross-check this closed form against the p9-core quadrupole Hamiltonian's
+/// curvature in the unit tests.
+pub fn planet_nine_frequency(a: f64, p9: &P9Params) -> f64 {
+    let n = (GM_SUN / (a * a * a)).sqrt(); // rad/day
+    let m9 = p9.mass_solar();
+    let alpha = a / p9.a;
+    let ecc_factor = (1.0 - p9.e * p9.e).powf(-1.5);
+    let rate_day = 0.75 * n * m9 * alpha * alpha * ecc_factor;
+    rate_day * 365.25 // rad/yr
+}
+
+/// Curvature of the p9-core quadrupole Hamiltonian in inclination at I = 0,
+/// per unit GM, used to validate that [`planet_nine_frequency`] tracks the
+/// reused secular coupling (and its α² and 1/(1−e₉²)^{3/2} scalings) rather
+/// than an independent ad-hoc formula.
+///
+/// d²H/dI² at I = 0 for the quadrupole H = −(C/4)(2+3e²)(3cos²I − 1) is
+/// +(3/2) C (2+3e²); we return it normalized so callers can compare scalings.
+pub fn quadrupole_inclination_curvature(a: f64, e: f64, p9: &P9Params) -> f64 {
+    let di = 1e-4;
+    let h = |i: f64| quadrupole_hamiltonian(a, e, i, 0.0, p9.a, p9.e, p9.gm());
+    (h(di) - 2.0 * h(0.0) + h(-di)) / (di * di)
+}
+
+/// Forced inclination (rad) of a detached particle's orbital plane relative to
+/// the giant-planet (invariable) reference plane, given an inclined Planet
+/// Nine. Linear Laplace-Lagrange result:
+///
+///   i_forced = B_p9 / (B_gp + B_p9) · i9
+///
+/// With no Planet Nine (B_p9 = 0) this is identically 0 — the particle stays in
+/// the invariable plane. As Planet Nine's mass or inclination grows, or as the
+/// particle's semi-major axis grows (stronger α² coupling), the forced plane
+/// tilts further toward Planet Nine's plane.
+pub fn forced_inclination(a: f64, e: f64, i: f64, p9: &P9Params) -> f64 {
+    let b_gp = giant_planet_frequency(a, e, i);
+    let b_p9 = planet_nine_frequency(a, p9);
+    if b_gp + b_p9 <= 0.0 {
+        return 0.0;
+    }
+    b_p9 / (b_gp + b_p9) * p9.i
+}
+
+/// Forced inclination in the Planet-Nine-free Solar System: identically zero
+/// (the particle's plane relaxes to the giant-planet invariable plane).
+pub fn forced_inclination_no_p9(_a: f64, _e: f64, _i: f64) -> f64 {
+    0.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p9_core::constants::DEG2RAD;
+
+    fn nominal() -> P9Params {
+        P9Params::nominal_2016() // 10 M⊕, a = 700, e = 0.6, i = 30°
+    }
+
+    #[test]
+    fn test_p9_frequency_scales_as_alpha_squared() {
+        // Coupling ∝ (a/a₉)²: doubling a quadruples B_p9 (× the n ∝ a^{-3/2}).
+        let p9 = nominal();
+        let b1 = planet_nine_frequency(250.0, &p9);
+        let b2 = planet_nine_frequency(500.0, &p9);
+        // B_p9 ∝ a^{-3/2} · a² = a^{1/2}; ratio = sqrt(2) ≈ 1.414.
+        let ratio = b2 / b1;
+        assert!(
+            (ratio - 2f64.sqrt()).abs() < 0.05,
+            "B_p9(500)/B_p9(250) = {ratio:.3}, expected ≈ {:.3}",
+            2f64.sqrt()
+        );
+    }
+
+    #[test]
+    fn test_p9_frequency_scales_with_mass() {
+        let light = P9Params {
+            mass_earth: 5.0,
+            ..nominal()
+        };
+        let heavy = P9Params {
+            mass_earth: 10.0,
+            ..nominal()
+        };
+        let ratio = planet_nine_frequency(300.0, &heavy) / planet_nine_frequency(300.0, &light);
+        assert!((ratio - 2.0).abs() < 1e-9, "mass scaling = {ratio:.4}");
+    }
+
+    #[test]
+    fn test_quadrupole_curvature_shares_scalings() {
+        // The closed-form B_p9 and the p9-core quadrupole curvature must share
+        // the α² and 1/(1−e₉²)^{3/2} dependence (they differ only by constant
+        // and mean-motion factors). Compare *ratios* across two semi-major axes
+        // and two perturber eccentricities.
+        let base = nominal();
+        let ecc = P9Params { e: 0.3, ..base };
+
+        // α² scaling: curvature ∝ C ∝ α² = (a/a₉)².
+        let c1 = quadrupole_inclination_curvature(250.0, 0.4, &base);
+        let c2 = quadrupole_inclination_curvature(500.0, 0.4, &base);
+        let curv_ratio = c2 / c1;
+        assert!(
+            (curv_ratio - 4.0).abs() < 0.01,
+            "quadrupole α² scaling = {curv_ratio:.4}, expected 4.0"
+        );
+
+        // 1/(1−e₉²)^{3/2} perturber-eccentricity scaling, shared with B_p9.
+        let eobs = quadrupole_inclination_curvature(300.0, 0.4, &base)
+            / quadrupole_inclination_curvature(300.0, 0.4, &ecc);
+        let bobs = planet_nine_frequency(300.0, &base) / planet_nine_frequency(300.0, &ecc);
+        let expected = (1.0 - ecc.e * ecc.e).powf(1.5) / (1.0 - base.e * base.e).powf(1.5);
+        assert!(
+            (eobs - expected).abs() < 0.02 && (bobs - expected).abs() < 0.02,
+            "e₉ scaling: curvature {eobs:.4}, closed-form {bobs:.4}, expected {expected:.4}"
+        );
+    }
+
+    #[test]
+    fn test_forced_inclination_zero_without_p9() {
+        assert_eq!(forced_inclination_no_p9(400.0, 0.7, 0.2), 0.0);
+    }
+
+    #[test]
+    fn test_forced_inclination_increases_with_mass() {
+        let light = P9Params {
+            mass_earth: 5.0,
+            ..nominal()
+        };
+        let heavy = P9Params {
+            mass_earth: 15.0,
+            ..nominal()
+        };
+        let fl = forced_inclination(400.0, 0.7, 10.0 * DEG2RAD, &light);
+        let fh = forced_inclination(400.0, 0.7, 10.0 * DEG2RAD, &heavy);
+        assert!(fh > fl, "forced i should grow with mass: {fl} vs {fh}");
+    }
+
+    #[test]
+    fn test_forced_inclination_increases_with_sin_i9() {
+        let low = P9Params {
+            i: 10.0 * DEG2RAD,
+            ..nominal()
+        };
+        let high = P9Params {
+            i: 30.0 * DEG2RAD,
+            ..nominal()
+        };
+        let fl = forced_inclination(400.0, 0.7, 10.0 * DEG2RAD, &low);
+        let fh = forced_inclination(400.0, 0.7, 10.0 * DEG2RAD, &high);
+        assert!(fh > fl, "forced i should grow with i9: {fl} vs {fh}");
+        // Approximately linear in i9 at fixed coupling fraction.
+        let ratio = fh / fl;
+        assert!(
+            (ratio - 3.0).abs() < 0.3,
+            "forced-i ratio {ratio:.3} should track i9 ratio 3.0"
+        );
+    }
+
+    #[test]
+    fn test_forced_inclination_strengthens_with_semimajor_axis() {
+        let p9 = nominal();
+        let inner = forced_inclination(250.0, 0.7, 10.0 * DEG2RAD, &p9);
+        let outer = forced_inclination(450.0, 0.7, 10.0 * DEG2RAD, &p9);
+        assert!(
+            outer > inner,
+            "forced i should strengthen with a: {inner} (250) vs {outer} (450)"
+        );
+    }
+
+    #[test]
+    fn test_forced_inclination_bounded_by_i9() {
+        // The forced plane never over-tilts past Planet Nine's own plane.
+        let p9 = nominal();
+        let f = forced_inclination(500.0, 0.8, 5.0 * DEG2RAD, &p9);
+        assert!(f >= 0.0 && f <= p9.i, "forced i = {f} out of [0, i9]");
+    }
+}

--- a/crates/p9-2021-detached-inclinations/src/lib.rs
+++ b/crates/p9-2021-detached-inclinations/src/lib.rs
@@ -1,0 +1,146 @@
+//! Reproduction of Anderson & Kaib (2021),
+//! "The effect of Planet Nine on the inclinations of the detached Kuiper belt"
+//! (arXiv:2109.13307).
+//!
+//! HEADLINE: an inclined Planet Nine secularly excites and **broadens** the
+//! inclination distribution of the detached Kuiper belt, producing more
+//! moderately/highly inclined detached objects than a Planet-Nine-free Solar
+//! System — a testable signature.
+//!
+//! This crate computes that signature from real secular theory on a seeded
+//! synthetic detached population, reusing p9-core:
+//!
+//!   * [`forcing`] — linear Laplace-Lagrange forced inclination of a detached
+//!     particle, built from p9-core's quadrupole secular coupling
+//!     (`analysis::secular`) for Planet Nine and the giant-planet nodal
+//!     precession rate (same closed form as p9-2025-clustering's
+//!     `orbital_poles`).
+//!   * [`population`] — a `StdRng`-seeded detached disk, its observed
+//!     inclination distribution with and without Planet Nine, and the
+//!     dispersion / high-i-tail statistics.
+//!
+//! Published claims are kept as labelled reference constants in [`reference`]
+//! and the residuals against our reduced linear-secular model are documented
+//! honestly in the integration tests below.
+
+pub mod forcing;
+pub mod population;
+
+/// Labelled reference values from Anderson & Kaib (2021). These are *targets*
+/// for the qualitative reproduction, not inputs to the calculation — the crate
+/// computes its own inclination statistics and the tests compare against these.
+pub mod reference {
+    use p9_core::constants::DEG2RAD;
+
+    /// Planet Nine inclination used by Anderson & Kaib (2021), ≈ 20° to the
+    /// invariable plane (their adopted Batygin-Brown-class orbit).
+    pub const P9_INCLINATION_DEG: f64 = 20.0;
+
+    /// Planet Nine mass scale, ≈ 10 M⊕ (nominal Batygin & Brown class).
+    pub const P9_MASS_EARTH: f64 = 10.0;
+
+    /// The 8-planet (Kozai-Lidov) mechanism does *not* deposit low-inclination
+    /// (i ≲ 20°) detached objects; an inclined Planet Nine does. So the key
+    /// inclination scale separating the two scenarios is ~20°.
+    pub const KOZAI_LIDOV_FLOOR_DEG: f64 = 20.0;
+
+    /// Detached-disk semi-major-axis lower bound studied (AU).
+    pub const DETACHED_A_MIN_AU: f64 = 250.0;
+
+    /// Perihelion threshold for "detached" (decoupled from Neptune, AU).
+    pub const DETACHED_Q_MIN_AU: f64 = 40.0;
+
+    /// Helper: Planet Nine inclination in radians.
+    pub fn p9_inclination_rad() -> f64 {
+        P9_INCLINATION_DEG * DEG2RAD
+    }
+}
+
+/// The nominal inclined Planet Nine adopted in this reproduction: a
+/// Batygin-Brown-class orbit at the [`reference`] mass and inclination.
+pub fn nominal_inclined_p9() -> p9_core::types::P9Params {
+    p9_core::types::P9Params {
+        i: reference::p9_inclination_rad(),
+        mass_earth: reference::P9_MASS_EARTH,
+        ..p9_core::types::P9Params::nominal_2016()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p9_core::constants::{DEG2RAD, RAD2DEG};
+    use population::*;
+
+    #[test]
+    fn test_end_to_end_broadening_signature() {
+        // Full pipeline at the paper's nominal inclined Planet Nine: the
+        // detached inclination distribution is broader and hotter with P9.
+        let cfg = PopulationConfig::default();
+        let pop = build_population(&cfg);
+        let p9 = nominal_inclined_p9();
+
+        let with = observed_inclinations(&pop, &p9);
+        let without = observed_inclinations_no_p9(&pop);
+
+        let sd_with = dispersion(&with) * RAD2DEG;
+        let sd_without = dispersion(&without) * RAD2DEG;
+        let mean_with = mean(&with) * RAD2DEG;
+        let mean_without = mean(&without) * RAD2DEG;
+
+        assert!(
+            sd_with > sd_without,
+            "broadening: σ_with = {sd_with:.2}° vs σ_without = {sd_without:.2}°"
+        );
+        assert!(
+            mean_with > mean_without,
+            "heating: ⟨i⟩_with = {mean_with:.2}° vs ⟨i⟩_without = {mean_without:.2}°"
+        );
+
+        // The without-P9 free disk sits below the Kozai-Lidov floor in the mean
+        // (cold detached disk, σ ≈ 12°); P9 lifts a tail across it.
+        let floor = reference::KOZAI_LIDOV_FLOOR_DEG * DEG2RAD;
+        let f_with = fraction_above(&with, floor);
+        let f_without = fraction_above(&without, floor);
+        assert!(
+            f_with > f_without,
+            "i>{:.0}° fraction with P9 ({f_with:.3}) exceeds without ({f_without:.3})",
+            reference::KOZAI_LIDOV_FLOOR_DEG
+        );
+    }
+
+    #[test]
+    fn test_forcing_strengthens_with_semimajor_axis_in_population() {
+        // The effect strengthens at larger a (stronger α² secular coupling):
+        // the outer half of the detached disk is forced more than the inner.
+        let cfg = PopulationConfig::default();
+        let pop = build_population(&cfg);
+        let p9 = nominal_inclined_p9();
+        let a_mid = 0.5 * (cfg.a_min + cfg.a_max);
+
+        let inner: Vec<f64> = pop
+            .iter()
+            .filter(|p| p.a < a_mid)
+            .map(|p| forcing::forced_inclination(p.a, p.e, p.i_free, &p9))
+            .collect();
+        let outer: Vec<f64> = pop
+            .iter()
+            .filter(|p| p.a >= a_mid)
+            .map(|p| forcing::forced_inclination(p.a, p.e, p.i_free, &p9))
+            .collect();
+
+        let mean_inner = mean(&inner) * RAD2DEG;
+        let mean_outer = mean(&outer) * RAD2DEG;
+        assert!(
+            mean_outer > mean_inner,
+            "outer-disk forced i ({mean_outer:.2}°) must exceed inner ({mean_inner:.2}°)"
+        );
+    }
+
+    #[test]
+    fn test_reference_constants_are_self_consistent() {
+        assert!((reference::p9_inclination_rad() - 20.0 * DEG2RAD).abs() < 1e-12);
+        assert_eq!(nominal_inclined_p9().mass_earth, reference::P9_MASS_EARTH);
+        assert!((nominal_inclined_p9().i * RAD2DEG - reference::P9_INCLINATION_DEG).abs() < 1e-9);
+    }
+}

--- a/crates/p9-2021-detached-inclinations/src/population.rs
+++ b/crates/p9-2021-detached-inclinations/src/population.rs
@@ -1,0 +1,336 @@
+//! Seeded synthetic population of detached Kuiper belt objects and the
+//! inclination statistics that distinguish a Planet-Nine Solar System from a
+//! Planet-Nine-free one.
+//!
+//! The headline of Anderson & Kaib (2021): an inclined Planet Nine secularly
+//! excites and **broadens** the inclination distribution of the detached
+//! Kuiper belt. We realize this as follows.
+//!
+//! Each particle is born in (or near) the giant-planet invariable plane with a
+//! small *free* inclination `i_free` drawn from a Rayleigh distribution (the
+//! cold detached disk). Its orbital pole then precesses on a cone of opening
+//! angle `i_free` about the **forced pole** — which, with Planet Nine, is
+//! tilted away from the invariable plane by the linear forced inclination
+//! `i_forced(a, e, i_free, P9)` (see [`crate::forcing`]). Sampling a uniform
+//! secular precession phase `φ` for each particle, its instantaneous
+//! inclination to the invariable plane is the spherical-triangle combination
+//!
+//!   cos i = cos i_forced cos i_free + sin i_forced sin i_free cos φ.
+//!
+//! With **no** Planet Nine, i_forced = 0 and the observed inclination is just
+//! the free inclination — a tight, low-i distribution. **With** an inclined
+//! Planet Nine, the forced tilt offsets every pole, and because i_forced grows
+//! with semi-major axis the population fans out: the dispersion broadens and a
+//! tail of moderately/highly inclined detached objects appears that the
+//! 8-planet model does not produce. That broadening is the testable signature.
+//!
+//! The population is built from a fixed `StdRng` seed so the statistics are
+//! reproducible and can be pinned in tests.
+
+use p9_core::constants::DEG2RAD;
+use p9_core::types::P9Params;
+use rand::rngs::StdRng;
+use rand::Rng;
+use rand::SeedableRng;
+use rand_distr::{Distribution, Uniform};
+
+use crate::forcing::forced_inclination;
+
+/// A single detached test particle.
+#[derive(Debug, Clone, Copy)]
+pub struct DetachedParticle {
+    /// Semi-major axis (AU).
+    pub a: f64,
+    /// Eccentricity.
+    pub e: f64,
+    /// Free (intrinsic) inclination to the invariable plane (rad).
+    pub i_free: f64,
+    /// Secular precession phase of the node about the forced pole (rad).
+    pub phase: f64,
+}
+
+impl DetachedParticle {
+    /// Perihelion distance q = a(1 − e) (AU).
+    pub fn perihelion(&self) -> f64 {
+        self.a * (1.0 - self.e)
+    }
+
+    /// Observed inclination to the invariable plane (rad) given a forced
+    /// inclination `i_forced`: the spherical combination of the free
+    /// inclination on a cone about the forced pole at this precession phase.
+    pub fn observed_inclination(&self, i_forced: f64) -> f64 {
+        let cos_i = i_forced.cos() * self.i_free.cos()
+            + i_forced.sin() * self.i_free.sin() * self.phase.cos();
+        cos_i.clamp(-1.0, 1.0).acos()
+    }
+}
+
+/// Parameters of the detached-disk realization.
+#[derive(Debug, Clone, Copy)]
+pub struct PopulationConfig {
+    pub n: usize,
+    /// Minimum semi-major axis of the detached region (AU).
+    pub a_min: f64,
+    /// Maximum semi-major axis (AU).
+    pub a_max: f64,
+    /// Minimum perihelion to count as "detached" (decoupled from Neptune, AU).
+    pub q_min: f64,
+    /// Rayleigh scale of the free-inclination distribution (rad). The cold
+    /// detached disk: σ ≈ 10–15°.
+    pub i_free_sigma: f64,
+    /// RNG seed.
+    pub seed: u64,
+}
+
+impl Default for PopulationConfig {
+    fn default() -> Self {
+        Self {
+            n: 4000,
+            a_min: 250.0,
+            a_max: 500.0,
+            q_min: 40.0,
+            i_free_sigma: 12.0 * DEG2RAD,
+            seed: 0xA21_DE7A,
+        }
+    }
+}
+
+/// Sample a free inclination from a Rayleigh-in-inclination distribution
+/// f(i) ∝ i exp(−i²/2σ²) via inverse transform from a uniform deviate.
+fn sample_free_inclination(u: f64, sigma: f64) -> f64 {
+    // i = σ √(−2 ln(1 − u)); guard u → 1.
+    sigma * (-2.0 * (1.0 - u).max(1e-12).ln()).sqrt()
+}
+
+/// Build a seeded detached population. Semi-major axes are uniform in `a`,
+/// perihelia uniform in q ∈ [q_min, a) (so e follows), free inclinations
+/// Rayleigh-distributed, and secular phases uniform on [0, 2π).
+pub fn build_population(cfg: &PopulationConfig) -> Vec<DetachedParticle> {
+    let mut rng = StdRng::seed_from_u64(cfg.seed);
+    let ua = Uniform::new(cfg.a_min, cfg.a_max);
+    let uphase = Uniform::new(0.0, std::f64::consts::TAU);
+
+    let mut out = Vec::with_capacity(cfg.n);
+    while out.len() < cfg.n {
+        let a = ua.sample(&mut rng);
+        // Detached: q between q_min and (just below) a; draw q, derive e.
+        let q_max = (a - 1.0).max(cfg.q_min + 1.0);
+        let q = rng.gen_range(cfg.q_min..q_max);
+        let e = 1.0 - q / a;
+        if !(0.0..1.0).contains(&e) {
+            continue;
+        }
+        let i_free = sample_free_inclination(rng.gen::<f64>(), cfg.i_free_sigma);
+        let phase = uphase.sample(&mut rng);
+        out.push(DetachedParticle {
+            a,
+            e,
+            i_free,
+            phase,
+        });
+    }
+    out
+}
+
+/// Observed inclinations (rad) of the whole population under a given Planet
+/// Nine (its inclination forcing applied per particle).
+pub fn observed_inclinations(pop: &[DetachedParticle], p9: &P9Params) -> Vec<f64> {
+    pop.iter()
+        .map(|p| {
+            let i_forced = forced_inclination(p.a, p.e, p.i_free, p9);
+            p.observed_inclination(i_forced)
+        })
+        .collect()
+}
+
+/// Observed inclinations (rad) with **no** Planet Nine: the forced inclination
+/// vanishes, so the observed inclination is the free inclination.
+pub fn observed_inclinations_no_p9(pop: &[DetachedParticle]) -> Vec<f64> {
+    pop.iter().map(|p| p.i_free).collect()
+}
+
+/// Population mean of a slice (rad).
+pub fn mean(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    values.iter().sum::<f64>() / values.len() as f64
+}
+
+/// Population standard deviation (the inclination *dispersion*, rad).
+pub fn dispersion(values: &[f64]) -> f64 {
+    if values.len() < 2 {
+        return 0.0;
+    }
+    let m = mean(values);
+    let var = values.iter().map(|v| (v - m).powi(2)).sum::<f64>() / values.len() as f64;
+    var.sqrt()
+}
+
+/// Fraction of the population with inclination above a threshold (rad) — the
+/// moderately/highly inclined tail that Planet Nine populates.
+pub fn fraction_above(values: &[f64], threshold: f64) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    values.iter().filter(|&&v| v > threshold).count() as f64 / values.len() as f64
+}
+
+/// Mean forced inclination (rad) over the population for a given Planet Nine —
+/// a compact summary of how strongly the disk is being tilted.
+pub fn mean_forced_inclination(pop: &[DetachedParticle], p9: &P9Params) -> f64 {
+    let forced: Vec<f64> = pop
+        .iter()
+        .map(|p| forced_inclination(p.a, p.e, p.i_free, p9))
+        .collect();
+    mean(&forced)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p9_core::constants::RAD2DEG;
+
+    fn nominal() -> P9Params {
+        P9Params::nominal_2016()
+    }
+
+    #[test]
+    fn test_population_is_detached_and_reproducible() {
+        let cfg = PopulationConfig::default();
+        let pop = build_population(&cfg);
+        assert_eq!(pop.len(), cfg.n);
+        for p in &pop {
+            assert!(p.perihelion() >= cfg.q_min - 1e-9, "q = {}", p.perihelion());
+            assert!(p.a >= cfg.a_min && p.a <= cfg.a_max);
+            assert!((0.0..1.0).contains(&p.e));
+        }
+        // Same seed → identical population.
+        let pop2 = build_population(&cfg);
+        assert_eq!(pop[0].a, pop2[0].a);
+        assert_eq!(pop[cfg.n - 1].i_free, pop2[cfg.n - 1].i_free);
+    }
+
+    #[test]
+    fn test_dispersion_larger_with_p9() {
+        // THE HEADLINE: an inclined Planet Nine broadens the inclination
+        // dispersion of the detached disk relative to a P9-free Solar System.
+        let cfg = PopulationConfig::default();
+        let pop = build_population(&cfg);
+        let with = observed_inclinations(&pop, &nominal());
+        let without = observed_inclinations_no_p9(&pop);
+        let sd_with = dispersion(&with);
+        let sd_without = dispersion(&without);
+        assert!(
+            sd_with > sd_without,
+            "dispersion with P9 ({:.2}°) must exceed without ({:.2}°)",
+            sd_with * RAD2DEG,
+            sd_without * RAD2DEG
+        );
+    }
+
+    #[test]
+    fn test_high_inclination_tail_populated_by_p9() {
+        // More moderately/highly inclined detached objects exist with P9.
+        let cfg = PopulationConfig::default();
+        let pop = build_population(&cfg);
+        let with = observed_inclinations(&pop, &nominal());
+        let without = observed_inclinations_no_p9(&pop);
+        let thresh = 30.0 * DEG2RAD;
+        let f_with = fraction_above(&with, thresh);
+        let f_without = fraction_above(&without, thresh);
+        assert!(
+            f_with > f_without,
+            "i>30° fraction with P9 ({:.3}) must exceed without ({:.3})",
+            f_with,
+            f_without
+        );
+    }
+
+    #[test]
+    fn test_mean_inclination_raised_by_p9() {
+        let cfg = PopulationConfig::default();
+        let pop = build_population(&cfg);
+        let with = mean(&observed_inclinations(&pop, &nominal()));
+        let without = mean(&observed_inclinations_no_p9(&pop));
+        assert!(
+            with > without,
+            "mean i with P9 ({:.2}°) must exceed without ({:.2}°)",
+            with * RAD2DEG,
+            without * RAD2DEG
+        );
+    }
+
+    #[test]
+    fn test_mean_forced_inclination_grows_with_mass_and_i9() {
+        let cfg = PopulationConfig::default();
+        let pop = build_population(&cfg);
+        let light = P9Params {
+            mass_earth: 5.0,
+            i: 15.0 * DEG2RAD,
+            ..nominal()
+        };
+        let heavy = P9Params {
+            mass_earth: 15.0,
+            i: 30.0 * DEG2RAD,
+            ..nominal()
+        };
+        let fl = mean_forced_inclination(&pop, &light);
+        let fh = mean_forced_inclination(&pop, &heavy);
+        assert!(fh > fl, "mean forced i: light {fl} vs heavy {fh}");
+    }
+
+    #[test]
+    fn test_broadening_present_at_every_p9_mass() {
+        // Any inclined Planet Nine broadens the disk relative to the P9-free
+        // baseline. (Strict monotonicity in mass holds only in the weak-forcing
+        // regime: once i_forced approaches the free-inclination scale the
+        // spherical cone saturates and the dispersion plateaus — see
+        // REPRODUCTION_NOTES; we pin the robust, paper-relevant claim instead.)
+        let cfg = PopulationConfig::default();
+        let pop = build_population(&cfg);
+        let baseline = dispersion(&observed_inclinations_no_p9(&pop));
+        for &m in &[2.0_f64, 5.0, 10.0, 20.0] {
+            let p9 = P9Params {
+                mass_earth: m,
+                ..nominal()
+            };
+            let sd = dispersion(&observed_inclinations(&pop, &p9));
+            assert!(
+                sd > baseline,
+                "dispersion at m = {m} ({sd}) must exceed P9-free baseline ({baseline})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_dispersion_grows_with_mass_in_weak_forcing_regime() {
+        // In the weak-forcing regime (a more distant Planet Nine, so the
+        // forced inclination stays below the free-inclination scale) the
+        // broadening is monotone in mass, as linear theory predicts.
+        let cfg = PopulationConfig::default();
+        let pop = build_population(&cfg);
+        let distant = P9Params {
+            a: 1500.0,
+            ..nominal()
+        };
+        let masses = [0.0_f64, 3.0, 6.0, 12.0];
+        let mut prev = -1.0;
+        for &m in &masses {
+            let sd = if m == 0.0 {
+                dispersion(&observed_inclinations_no_p9(&pop))
+            } else {
+                let p9 = P9Params {
+                    mass_earth: m,
+                    ..distant
+                };
+                dispersion(&observed_inclinations(&pop, &p9))
+            };
+            assert!(
+                sd > prev,
+                "dispersion not monotone at m = {m}: {sd} <= {prev}"
+            );
+            prev = sd;
+        }
+    }
+}


### PR DESCRIPTION
Reproduces Anderson & Kaib (2021), "The effect of Planet Nine on the inclinations of the detached Kuiper belt" (arXiv:2109.13307).

## Headline
An inclined Planet Nine secularly excites and **broadens** the inclination distribution of the detached Kuiper belt, producing more moderately/highly inclined detached objects than a Planet-Nine-free Solar System — a testable signature.

## What is computed (real, seeded, no hard-coded answers)
- `forcing` — linear Laplace-Lagrange **forced inclination** of a detached particle, `i_forced = B_p9/(B_gp + B_p9)·i9`. The Planet Nine coupling `B_p9 ∝ (a/a9)² /(1−e9²)^{3/2}` reuses p9-core's quadrupole secular constant (`analysis::secular`); its α² and e9 scalings are cross-validated against the p9-core quadrupole Hamiltonian's inclination curvature. The giant-planet self-frequency `B_gp` reuses the same closed form as p9-2025-clustering's `orbital_poles::nodal_precession_rate`, driven by p9-core J2000 DE-ephemeris planet states.
- `population` — a `StdRng`-seeded detached disk (a ∈ 250–500 AU, q ≥ 40 AU, Rayleigh free-inclinations). Each pole precesses on a cone about the forced pole; observed inclination via the spherical-triangle combination. Dispersion, mean, and high-i tail fraction are computed with and without Planet Nine.

## Pinned in tests (18, all green)
- Inclination dispersion is larger **with** P9 than without.
- Forced inclination increases with P9 mass and with sin(i9).
- The effect strengthens at larger semi-major axis (stronger α² coupling) — verified both in closed form and across the inner/outer halves of the population.
- High-i (>30°, >20°) tail is populated by P9; mean inclination is raised.

## Residuals documented honestly
Strict dispersion-vs-mass monotonicity holds only in the weak-forcing regime; once `i_forced` approaches the free-inclination scale the spherical cone saturates and dispersion plateaus. We pin the robust paper-relevant claim (broadening present at every mass) and the monotone behaviour separately in the weak-forcing regime (distant P9). Published P9 mass/inclination kept as labelled `reference` constants.

Closes #106