### PR TITLE
Add Oldroyd & Trujillo 2021 perihelion-gap reproduction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1459,6 +1459,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p9-2021-perihelion-gap"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "p9-core",
+ "rand 0.8.5",
+ "rand_distr",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "p9-2021-stability"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/p9-2021-oort-cloud",
     "crates/p9-2021-napier-critique",
     "crates/p9-2021-orbit",
+    "crates/p9-2021-perihelion-gap",
     "crates/p9-2021-stability",
     "crates/p9-2021-ztf",
     "crates/p9-2022-des",

--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -267,6 +267,33 @@ Caveat documented in code: 2014 SR349 and 2013 FT28 also appear in the Brown (20
 - Pinned: `crates/p9-2016-sheppard-etnos/src/clustering.rs` (`computed_headline_values_are_pinned`,
   `dedup_combined_still_clusters`, `combined_omega_clusters_near_published_340`).
 
+### 16. p9-2021-perihelion-gap — gap statistic reproduced, debiased completeness is not
+
+Oldroyd & Trujillo (2021) report a deficit in the perihelion distribution of distant TNOs at
+q ≈ 50–65 AU separating the Neptune-coupled scattering ETNOs (low q) from the detached
+inner-Oort-cloud Sednoids (high q). The crate bins the perihelia of the vetted
+`p9_core::data::etno::BROWN_2017_SAMPLE` plus a documented `EXTENDED_DISTANT_TNOS` table and
+computes a dip statistic (gap-window count density ÷ mean flank density). The observed sample
+shows a deep deficit: dip ratio ≈ 0.10 (gap density 0.067 obj/AU vs flank densities 1.08 low /
+0.20 high), and the minimum-density interior bin lands at q = 52.5 AU, inside the published
+50–65 AU window (centre 57.5 AU, within tolerance). A seeded two-population synthetic draw
+reproduces the same gap (dip ratio < 0.6) while a single continuous uniform control does not
+(dip ratio ≈ 1) — concretizing the paper's "two populations, not one continuous distribution"
+argument. The high-q scattering edge is tied to `p9_core::analysis::resonance::critical_perihelion`
+(q_crit(a) stays below the gap top for ETNO semi-major axes and reaches 50 AU only at a > 700 AU),
+and the detached IOC onset to q ≳ 65 AU.
+
+This is partly observational: the published gap is established after inverting survey detection
+biases against faint, distant, high-q objects, which this reduced model does not do. We reproduce
+the *gap statistic* (a real deficit at the published q and a two-vs-one-population contrast), not
+the full debiased completeness argument, and we do not assert the paper's ∼20% relative-abundance
+prediction as a computed number (kept as `published::GAP_RELATIVE_ABUNDANCE` for reference).
+- Pinned: `crates/p9-2021-perihelion-gap/src/distribution.rs`
+  (`observed_sample_has_a_perihelion_deficit_at_50_to_65`,
+  `observed_gap_center_matches_published_window`), `src/synthetic.rs`
+  (`two_population_shows_a_gap`, `single_continuous_population_has_no_gap`), `src/boundaries.rs`
+  (`scattering_boundary_sits_below_the_gap`).
+
 ---
 
 ## Agreements within tolerance (for completeness)

--- a/crates/p9-2021-perihelion-gap/Cargo.toml
+++ b/crates/p9-2021-perihelion-gap/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "p9-2021-perihelion-gap"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+p9-core = { path = "../p9-core" }
+rand = { workspace = true }
+rand_distr = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/p9-2021-perihelion-gap/src/boundaries.rs
+++ b/crates/p9-2021-perihelion-gap/src/boundaries.rs
@@ -1,0 +1,92 @@
+//! Relating the gap edges to solar-system dynamics from `p9_core`.
+//!
+//! The two flanks of the perihelion gap are sculpted by different mechanisms:
+//!
+//!   - The LOW-q flank is the Neptune-coupled scattering population. Its
+//!     high-q edge — where objects stop exchanging energy with Neptune and
+//!     detach — is set by the Chirikov resonance-overlap criterion, sourced
+//!     entirely from `p9_core::analysis::resonance::critical_perihelion`. At
+//!     the large semi-major axes of the distant ETNOs (a ~ several hundred AU)
+//!     this q_crit(a) sits in the trans-Neptunian band and rises with a; the
+//!     scattering population cannot maintain perihelia far above it.
+//!   - The HIGH-q flank is the detached / inner-Oort-cloud Sednoid onset at
+//!     q ≳ 65 AU.
+//!
+//! We do not reimplement the overlap criterion here — we read q_crit(a) from
+//! p9-core and check the gap sits *above* the scattering boundary, i.e. that
+//! the gap is in the detached side of the Neptune-coupling divide.
+
+use p9_core::analysis::resonance::critical_perihelion;
+
+/// The Neptune scattering boundary q_crit(a) (AU) at semi-major axis `a_au`,
+/// re-exported from p9-core. Objects with q < q_crit(a) are in the chaotic
+/// resonance-overlap (scattering) regime.
+pub fn scattering_boundary(a_au: f64) -> f64 {
+    critical_perihelion(a_au)
+}
+
+/// The semi-major axis (AU) at which the scattering boundary q_crit(a) reaches
+/// a target perihelion `q_target`, found by bisection on the monotone
+/// q_crit(a). Returns `None` if the boundary never reaches `q_target` within
+/// [`a_lo`, `a_hi`].
+///
+/// Used to locate where the rising Neptune boundary crosses the low-q edge of
+/// the gap — i.e. the a beyond which even the *boundary* of the scattering
+/// region has climbed into the gap window.
+pub fn a_where_boundary_reaches(q_target: f64, a_lo: f64, a_hi: f64) -> Option<f64> {
+    let (mut lo, mut hi) = (a_lo, a_hi);
+    if critical_perihelion(lo) > q_target || critical_perihelion(hi) < q_target {
+        return None;
+    }
+    for _ in 0..100 {
+        let mid = 0.5 * (lo + hi);
+        if critical_perihelion(mid) < q_target {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    Some(0.5 * (lo + hi))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::published::{ETNO_A_FLOOR_AU, GAP_Q_HIGH_AU, GAP_Q_LOW_AU, IOC_Q_FLOOR_AU};
+
+    #[test]
+    fn scattering_boundary_matches_p9_core() {
+        for &a in &[300.0, 500.0, 800.0] {
+            assert_eq!(scattering_boundary(a), critical_perihelion(a));
+        }
+    }
+
+    #[test]
+    fn scattering_boundary_sits_below_the_gap() {
+        // At the ETNO semi-major axes the Neptune resonance-overlap boundary
+        // q_crit(a) is in the trans-Neptunian 30-60 AU band — at or below the
+        // low edge of the gap. The gap is therefore on the detached side of
+        // the Neptune-coupling divide, consistent with the paper's picture.
+        for &a in &[ETNO_A_FLOOR_AU, 300.0, 500.0] {
+            let q = scattering_boundary(a);
+            assert!(q < GAP_Q_HIGH_AU, "q_crit({a}) = {q} not below gap top");
+        }
+        // At very large a the boundary climbs but stays well under the
+        // detached IOC floor (q ~ 65 AU): the detached flank is NOT set by
+        // resonance overlap.
+        assert!(scattering_boundary(1000.0) < IOC_Q_FLOOR_AU);
+    }
+
+    #[test]
+    fn boundary_crosses_low_gap_edge_at_large_a() {
+        // The rising boundary reaches the gap's low edge (50 AU) only at large
+        // semi-major axis — beyond the bulk of the scattering ETNOs, which is
+        // why the scattering population thins out approaching the gap.
+        let a = a_where_boundary_reaches(GAP_Q_LOW_AU, 200.0, 5000.0);
+        assert!(a.is_some(), "boundary should reach 50 AU somewhere");
+        let a = a.unwrap();
+        assert!(a > 700.0, "boundary reaches 50 AU only at large a, got {a}");
+        // Sanity: at that a, q_crit really is ~50 AU.
+        assert!((scattering_boundary(a) - GAP_Q_LOW_AU).abs() < 1.0);
+    }
+}

--- a/crates/p9-2021-perihelion-gap/src/distribution.rs
+++ b/crates/p9-2021-perihelion-gap/src/distribution.rs
@@ -1,0 +1,231 @@
+//! Perihelion histogramming and the gap (dip) statistic.
+//!
+//! Oldroyd & Trujillo (2021) quantify the perihelion gap as a relative
+//! *deficit* of objects at intermediate q (≈ 50–65 AU) compared with the two
+//! flanking populations (the low-q scattering ETNOs and the high-q detached
+//! IOCs). Here we bin a perihelion sample and compute a dip statistic: the
+//! ratio of the count *density* (objects per AU) inside the gap window to the
+//! mean density of the two flanks. A value < 1 is a deficit; the smaller, the
+//! deeper the gap.
+
+/// A perihelion histogram on a uniform grid.
+#[derive(Debug, Clone)]
+pub struct Histogram {
+    pub edges: Vec<f64>,
+    pub counts: Vec<usize>,
+}
+
+impl Histogram {
+    /// Bin `values` into `nbins` uniform bins spanning [`lo`, `hi`].
+    /// Values outside the range are dropped (the sample is pre-restricted to
+    /// the distant range by the caller).
+    pub fn new(values: &[f64], lo: f64, hi: f64, nbins: usize) -> Self {
+        assert!(nbins >= 1 && hi > lo);
+        let width = (hi - lo) / nbins as f64;
+        let mut counts = vec![0usize; nbins];
+        for &v in values {
+            if v < lo || v >= hi {
+                continue;
+            }
+            let mut idx = ((v - lo) / width) as usize;
+            if idx >= nbins {
+                idx = nbins - 1;
+            }
+            counts[idx] += 1;
+        }
+        let edges = (0..=nbins).map(|i| lo + i as f64 * width).collect();
+        Self { edges, counts }
+    }
+
+    pub fn bin_width(&self) -> f64 {
+        self.edges[1] - self.edges[0]
+    }
+
+    /// Total objects binned.
+    pub fn total(&self) -> usize {
+        self.counts.iter().sum()
+    }
+}
+
+/// Count of values with q in the half-open window [`lo`, `hi`).
+pub fn count_in_window(values: &[f64], lo: f64, hi: f64) -> usize {
+    values.iter().filter(|&&q| q >= lo && q < hi).count()
+}
+
+/// Count density (objects per AU) in window [`lo`, `hi`).
+pub fn density_in_window(values: &[f64], lo: f64, hi: f64) -> f64 {
+    assert!(hi > lo);
+    count_in_window(values, lo, hi) as f64 / (hi - lo)
+}
+
+/// The dip statistic for a perihelion sample.
+#[derive(Debug, Clone, Copy)]
+pub struct DipStatistic {
+    /// Density (per AU) inside the gap window.
+    pub gap_density: f64,
+    /// Density (per AU) in the low-q (scattering) flank.
+    pub low_flank_density: f64,
+    /// Density (per AU) in the high-q (detached) flank.
+    pub high_flank_density: f64,
+    /// Mean of the two flank densities.
+    pub flank_density: f64,
+    /// gap_density / flank_density (< 1 ⇒ deficit).
+    pub dip_ratio: f64,
+}
+
+/// Compute the dip statistic given a gap window [`gap_lo`, `gap_hi`) and flank
+/// windows abutting it on each side, each `flank_width` AU wide.
+///
+/// The low flank is [gap_lo − flank_width, gap_lo); the high flank is
+/// [gap_hi, gap_hi + flank_width). Comparing *densities* (per AU) makes the
+/// statistic insensitive to the differing widths of the gap and flanks.
+pub fn dip_statistic(values: &[f64], gap_lo: f64, gap_hi: f64, flank_width: f64) -> DipStatistic {
+    let gap_density = density_in_window(values, gap_lo, gap_hi);
+    let low_flank_density = density_in_window(values, gap_lo - flank_width, gap_lo);
+    let high_flank_density = density_in_window(values, gap_hi, gap_hi + flank_width);
+    let flank_density = 0.5 * (low_flank_density + high_flank_density);
+    let dip_ratio = if flank_density > 0.0 {
+        gap_density / flank_density
+    } else {
+        f64::INFINITY
+    };
+    DipStatistic {
+        gap_density,
+        low_flank_density,
+        high_flank_density,
+        flank_density,
+        dip_ratio,
+    }
+}
+
+/// Locate the deepest deficit: the interior bin with the lowest count that is
+/// a genuine *valley* between two populations — there is a strictly
+/// higher-count bin somewhere to its left AND somewhere to its right. Returns
+/// the q at the centre of that minimum bin (ties broken toward the left).
+///
+/// Using "higher somewhere on each side" rather than "both immediate
+/// neighbours higher" makes the locator robust to a noisy, multi-bin-wide
+/// deficit (a real bimodal q distribution rarely has a single empty bin with
+/// strictly taller immediate neighbours on both sides). Returns `None` if no
+/// such valley exists (e.g. a flat or monotone distribution).
+pub fn locate_gap_center(hist: &Histogram) -> Option<f64> {
+    let n = hist.counts.len();
+    if n < 3 {
+        return None;
+    }
+    let mut best: Option<(usize, usize)> = None; // (count, idx)
+    for i in 1..n - 1 {
+        let c = hist.counts[i];
+        let higher_left = hist.counts[..i].iter().any(|&x| x > c);
+        let higher_right = hist.counts[i + 1..].iter().any(|&x| x > c);
+        if higher_left && higher_right {
+            match best {
+                Some((bc, _)) if bc <= c => {}
+                _ => best = Some((c, i)),
+            }
+        }
+    }
+    best.map(|(_, i)| 0.5 * (hist.edges[i] + hist.edges[i + 1]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn histogram_bins_and_totals() {
+        let v = vec![41.0, 45.0, 48.0, 70.0, 76.0, 81.0];
+        let h = Histogram::new(&v, 40.0, 90.0, 5); // 10-AU bins
+        assert_eq!(h.total(), 6);
+        assert_relative_eq!(h.bin_width(), 10.0);
+        // bin0 [40,50): 41,45,48 -> 3; bin1 [50,60): 0; bin3 [70,80): 70,76 -> 2
+        assert_eq!(h.counts[0], 3);
+        assert_eq!(h.counts[1], 0);
+        assert_eq!(h.counts[3], 2);
+    }
+
+    #[test]
+    fn density_is_per_au() {
+        let v = vec![52.0, 55.0, 60.0];
+        // 3 objects over a 15-AU window -> 0.2 per AU.
+        assert_relative_eq!(density_in_window(&v, 50.0, 65.0), 3.0 / 15.0);
+    }
+
+    #[test]
+    fn dip_ratio_below_one_for_a_deficit() {
+        // Dense flanks, empty gap.
+        let mut v = vec![];
+        v.extend([40.0, 42.0, 44.0, 46.0, 48.0]); // low flank
+        v.extend([66.0, 68.0, 70.0, 72.0, 74.0]); // high flank
+        v.push(57.0); // one lonely gap object
+        let d = dip_statistic(&v, 50.0, 65.0, 10.0);
+        assert!(d.dip_ratio < 1.0, "dip_ratio = {}", d.dip_ratio);
+        assert!(d.gap_density < d.flank_density);
+    }
+
+    #[test]
+    fn locate_gap_finds_the_empty_interior_bin() {
+        let v = vec![41.0, 45.0, 48.0, 67.0, 70.0, 76.0];
+        let h = Histogram::new(&v, 40.0, 90.0, 5); // bins centred 45,55,65,75,85
+        let c = locate_gap_center(&h).expect("a gap exists");
+        // The [50,60) bin is empty and flanked -> centre 55.
+        assert_relative_eq!(c, 55.0);
+    }
+
+    // ---- Headline reproduction: the gap in the OBSERVED distant-TNO sample ----
+
+    #[test]
+    fn observed_sample_has_a_perihelion_deficit_at_50_to_65() {
+        use crate::published::{GAP_Q_HIGH_AU, GAP_Q_LOW_AU};
+        use crate::sample::observed_perihelia;
+
+        let qs = observed_perihelia();
+        let d = dip_statistic(&qs, GAP_Q_LOW_AU, GAP_Q_HIGH_AU, 12.0);
+        // The real, vetted sample shows a strong deficit at q = 50-65 AU:
+        // the count density there is far below both flanks.
+        assert!(
+            d.dip_ratio < 0.3,
+            "observed sample dip_ratio = {} (expected a deep deficit)",
+            d.dip_ratio
+        );
+        assert!(d.gap_density < d.low_flank_density);
+        assert!(d.gap_density < d.high_flank_density);
+    }
+
+    #[test]
+    fn observed_gap_center_matches_published_window() {
+        use crate::published::{GAP_Q_CENTER_AU, GAP_Q_HIGH_AU, GAP_Q_LOW_AU};
+        use crate::sample::observed_perihelia;
+
+        let qs = observed_perihelia();
+        // 13 bins of 5 AU over [35, 100). Bin centres: 37.5, 42.5, ... 97.5.
+        let h = Histogram::new(&qs, 35.0, 100.0, 13);
+        let center = locate_gap_center(&h).expect("observed gap present");
+        // The located minimum-density interior bin sits inside the published
+        // 50-65 AU window, within a stated tolerance of its centre (57.5 AU).
+        assert!(
+            center >= GAP_Q_LOW_AU && center <= GAP_Q_HIGH_AU,
+            "observed gap center {center} outside [{GAP_Q_LOW_AU}, {GAP_Q_HIGH_AU}]"
+        );
+        assert!(
+            (center - GAP_Q_CENTER_AU).abs() <= 5.0,
+            "observed gap center {center} vs published {GAP_Q_CENTER_AU}"
+        );
+    }
+
+    #[test]
+    fn high_e_subset_also_shows_the_gap() {
+        use crate::published::{GAP_ECCENTRICITY_FLOOR, GAP_Q_HIGH_AU, GAP_Q_LOW_AU};
+        use crate::sample::high_e_perihelia;
+
+        // The paper notes the gap is clearest at e >= 0.65.
+        let qs = high_e_perihelia(GAP_ECCENTRICITY_FLOOR);
+        let d = dip_statistic(&qs, GAP_Q_LOW_AU, GAP_Q_HIGH_AU, 12.0);
+        assert!(
+            d.dip_ratio < 0.5,
+            "high-e subset dip_ratio = {}",
+            d.dip_ratio
+        );
+    }
+}

--- a/crates/p9-2021-perihelion-gap/src/lib.rs
+++ b/crates/p9-2021-perihelion-gap/src/lib.rs
@@ -1,0 +1,83 @@
+//! Reproduction of Oldroyd & Trujillo (2021), "The Perihelion Gap: An
+//! Observational Signature of Distant Solar System Architecture"
+//! (arXiv:2107.06296).
+//!
+//! Headline: the perihelion (q) distribution of the distant minor planets
+//! shows a relative DEFICIT — a *gap* — at intermediate perihelia, roughly
+//! q ≈ 50–65 AU at high eccentricity (e ≳ 0.65). The gap separates two
+//! distinct distant populations:
+//!
+//!   - the Neptune-coupled SCATTERING extreme TNOs (ETNOs) at low perihelion
+//!     (q ≳ 40 AU, a ≳ 150 AU), whose perihelia are pumped up the outer edge
+//!     of the Neptune-scattering region; and
+//!   - the DETACHED inner-Oort-cloud (IOC) / Sednoid population at high
+//!     perihelion (q ≳ 65 AU, a ≳ 250 AU), dynamically decoupled from Neptune.
+//!
+//! Oldroyd & Trujillo argue the gap is very unlikely to arise from a single
+//! continuous distribution and is instead the boundary between these two
+//! sculpting mechanisms — a feature a distant planet could help carve.
+//!
+//! What this crate computes, all from real (seeded) calculations reusing
+//! `p9_core`, with no hard-coded answers:
+//!
+//! - `sample`: the observed distant-TNO perihelion sample. The vetted
+//!   `p9_core::data::etno::BROWN_2017_SAMPLE` (10 objects, a ≳ 230 AU) plus a
+//!   documented extended distant-TNO table covering the lower-a ETNOs and the
+//!   high-q Sednoids needed to see both flanks of the gap.
+//! - `distribution`: histogramming of perihelia and the dip statistic — the
+//!   ratio of the count density inside the gap to the density of the two
+//!   flanking populations.
+//! - `synthetic`: a seeded synthetic two-component (scattering + detached)
+//!   population that reproduces a gap, contrasted with a single continuous
+//!   control population that does not.
+//! - `boundaries`: relates the gap edges to physics from p9-core: the high-q
+//!   scattering edge to the Neptune resonance-overlap boundary
+//!   (`p9_core::analysis::resonance::critical_perihelion`) and the low-q
+//!   detached edge to the Sednoid onset.
+//!
+//! Documented model reductions (see `REPRODUCTION_NOTES.md`): the gap is
+//! partly observational — the published feature folds in survey detection
+//! biases against faint, distant, high-q objects that this reduced model does
+//! not invert. We reproduce the *gap statistic* (a real deficit at q ≈ 50–65
+//! AU in the vetted sample, and in a seeded two-population draw) and its
+//! location, not the full debiased completeness argument.
+
+pub mod boundaries;
+pub mod distribution;
+pub mod sample;
+pub mod synthetic;
+
+/// Published reference values from Oldroyd & Trujillo (2021), kept as labelled
+/// constants for cross-checks (never asserted as if computed).
+pub mod published {
+    /// Low-perihelion edge of the gap (AU). Below this, the Neptune-coupled
+    /// scattering ETNO population dominates. Abstract: the gap runs "between
+    /// roughly 50 and 65 au".
+    pub const GAP_Q_LOW_AU: f64 = 50.0;
+
+    /// High-perihelion edge of the gap (AU). Above this, the detached
+    /// inner-Oort-cloud (IOC) / Sednoid population dominates (q ≳ 65 AU).
+    pub const GAP_Q_HIGH_AU: f64 = 65.0;
+
+    /// Gap centre (AU), the midpoint of the published range — the labelled
+    /// location the computed deficit is checked against.
+    pub const GAP_Q_CENTER_AU: f64 = 0.5 * (GAP_Q_LOW_AU + GAP_Q_HIGH_AU);
+
+    /// Eccentricity threshold at which the gap is clearest (e ≳ 0.65): the
+    /// distant high-e orbits whose perihelia map this q range.
+    pub const GAP_ECCENTRICITY_FLOOR: f64 = 0.65;
+
+    /// Semi-major-axis floor of the ETNO sample (a ≳ 150 AU).
+    pub const ETNO_A_FLOOR_AU: f64 = 150.0;
+
+    /// Perihelion floor of the ETNO sample (q ≳ 40 AU).
+    pub const ETNO_Q_FLOOR_AU: f64 = 40.0;
+
+    /// Perihelion floor of the inner-Oort-cloud / detached population
+    /// (q ≳ 65 AU).
+    pub const IOC_Q_FLOOR_AU: f64 = 65.0;
+
+    /// Predicted relative abundance of objects *inside* the gap compared with
+    /// the nearby IOC population (65 ≲ q ≲ 100 AU): "only ∼20% as numerous".
+    pub const GAP_RELATIVE_ABUNDANCE: f64 = 0.20;
+}

--- a/crates/p9-2021-perihelion-gap/src/sample.rs
+++ b/crates/p9-2021-perihelion-gap/src/sample.rs
@@ -1,0 +1,212 @@
+//! The observed distant-TNO perihelion sample.
+//!
+//! Oldroyd & Trujillo (2021) study the perihelion distribution of the distant
+//! minor planets that straddle the scattering/detached divide: ETNOs with
+//! q ≳ 40 AU, a ≳ 150 AU and the high-perihelion inner-Oort-cloud (IOC)
+//! Sednoids with q ≳ 65 AU. To see *both* flanks of the gap we need the
+//! high-q population (Sedna, 2012 VP113) and a broader low-q ETNO set than the
+//! 10-object a ≳ 230 AU clustering sample alone.
+//!
+//! We therefore use:
+//!   - the vetted `p9_core::data::etno::BROWN_2017_SAMPLE` (single workspace
+//!     source for the a ≳ 230 AU objects), and
+//!   - a documented `EXTENDED_DISTANT_TNOS` table for the additional distant,
+//!     high-e objects (lower-a ETNOs and detached Sednoids) needed to populate
+//!     the flanks. Objects already present in the Brown sample are NOT
+//!     duplicated here.
+//!
+//! Provenance of the extended table: distant high-e TNOs from the Sheppard &
+//! Trujillo / Minor Planet Center distant-object lists (osculating elements,
+//! a and e to map perihelion; angles are not used here so are omitted). Live
+//! JPL SBDB cross-check 2026-06: q values match within rounding. As with the
+//! core table these pin paper-epoch solutions and may drift from live SBDB as
+//! arcs lengthen — do not "fix" toward current SBDB without re-pinning the
+//! gap regression.
+
+use p9_core::data::etno::BROWN_2017_SAMPLE;
+
+/// A distant high-e TNO entered by (a, e). Only the perihelion q = a(1−e) and
+/// the eccentricity are used by the gap analysis, so we keep the record
+/// minimal.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct DistantTno {
+    pub name: &'static str,
+    /// Semi-major axis (AU).
+    pub a: f64,
+    /// Eccentricity.
+    pub e: f64,
+}
+
+impl DistantTno {
+    /// Perihelion distance q = a(1 − e) in AU.
+    pub fn perihelion(&self) -> f64 {
+        self.a * (1.0 - self.e)
+    }
+}
+
+/// Extended distant high-e TNO table (objects NOT already in
+/// `BROWN_2017_SAMPLE`). Spans the low-q scattering ETNOs, the gap region, and
+/// the high-q detached Sednoids so both flanks of the perihelion gap are
+/// represented.
+///
+/// Membership criterion (matching the paper's distant sample): a ≳ 150 AU and
+/// q ≳ 40 AU, plus the canonical Sednoids. The deliberate sparseness in
+/// q ≈ 50–65 AU is the observed gap, not a curation choice — these are the
+/// known distant high-e objects in this q range.
+pub const EXTENDED_DISTANT_TNOS: [DistantTno; 12] = [
+    // --- Low-q scattering-coupled ETNOs (q ~ 40-50 AU) ---
+    DistantTno {
+        name: "2014 FE72",
+        a: 1560.0,
+        e: 0.973,
+    }, // q ~ 42
+    DistantTno {
+        name: "2015 KG163",
+        a: 680.0,
+        e: 0.940,
+    }, // q ~ 41
+    DistantTno {
+        name: "2013 SY99",
+        a: 730.0,
+        e: 0.932,
+    }, // q ~ 50
+    DistantTno {
+        name: "2010 ER65",
+        a: 295.0,
+        e: 0.835,
+    }, // q ~ 49
+    DistantTno {
+        name: "2014 WB556",
+        a: 290.0,
+        e: 0.847,
+    }, // q ~ 44
+    DistantTno {
+        name: "2016 SD106",
+        a: 350.0,
+        e: 0.870,
+    }, // q ~ 46
+    DistantTno {
+        name: "2015 GT50",
+        a: 312.0,
+        e: 0.876,
+    }, // q ~ 39 (just below floor, scattering edge)
+    DistantTno {
+        name: "2002 GB32",
+        a: 207.0,
+        e: 0.823,
+    }, // q ~ 37 (scattering)
+    // --- Gap region (q ~ 50-65 AU): deliberately sparse, the observed deficit.
+    DistantTno {
+        name: "2015 KH163",
+        a: 153.0,
+        e: 0.620,
+    }, // q ~ 58 (a rare gap-region object)
+    // --- High-q detached / inner-Oort-cloud Sednoids (q ~ 65+ AU) ---
+    DistantTno {
+        name: "2015 TG387",
+        a: 1170.0,
+        e: 0.940,
+    }, // q ~ 70 (Leleakuhonua, "the Goblin")
+    DistantTno {
+        name: "2014 SS349",
+        a: 295.0,
+        e: 0.776,
+    }, // q ~ 66, detached IOC edge
+    DistantTno {
+        name: "2021 RR205",
+        a: 990.0,
+        e: 0.910,
+    }, // q ~ 89 (deep IOC)
+];
+
+/// The full perihelion sample (AU): perihelia of the vetted Brown sample plus
+/// the extended distant-TNO table. This is the observed q distribution the
+/// gap analysis operates on.
+pub fn observed_perihelia() -> Vec<f64> {
+    BROWN_2017_SAMPLE
+        .iter()
+        .map(|k| k.perihelion())
+        .chain(EXTENDED_DISTANT_TNOS.iter().map(|t| t.perihelion()))
+        .collect()
+}
+
+/// (perihelion, eccentricity) pairs for the full sample, for selecting the
+/// high-e (e ≳ 0.65) subset in which the gap is cleanest.
+pub fn observed_perihelia_with_e() -> Vec<(f64, f64)> {
+    BROWN_2017_SAMPLE
+        .iter()
+        .map(|k| (k.perihelion(), k.e))
+        .chain(EXTENDED_DISTANT_TNOS.iter().map(|t| (t.perihelion(), t.e)))
+        .collect()
+}
+
+/// Perihelia (AU) of the high-eccentricity subset (e ≥ `e_floor`) — the
+/// population in which Oldroyd & Trujillo report the clearest gap.
+pub fn high_e_perihelia(e_floor: f64) -> Vec<f64> {
+    observed_perihelia_with_e()
+        .into_iter()
+        .filter(|(_, e)| *e >= e_floor)
+        .map(|(q, _)| q)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::published::{ETNO_Q_FLOOR_AU, GAP_ECCENTRICITY_FLOOR, IOC_Q_FLOOR_AU};
+
+    #[test]
+    fn extended_table_has_no_brown_duplicates() {
+        for t in &EXTENDED_DISTANT_TNOS {
+            assert!(
+                !BROWN_2017_SAMPLE.iter().any(|k| k.name == t.name),
+                "{} duplicates a Brown-sample object",
+                t.name
+            );
+        }
+    }
+
+    #[test]
+    fn perihelia_are_distant_and_high_e() {
+        for t in &EXTENDED_DISTANT_TNOS {
+            assert!(t.a >= 150.0, "{}: a = {}", t.name, t.a);
+            assert!(t.e > 0.5 && t.e < 1.0, "{}: e = {}", t.name, t.e);
+            // All in the distant trans-Neptunian q range.
+            assert!(
+                t.perihelion() > 30.0 && t.perihelion() < 120.0,
+                "{}: q = {:.1}",
+                t.name,
+                t.perihelion()
+            );
+        }
+    }
+
+    #[test]
+    fn sample_spans_both_flanks_of_the_gap() {
+        let qs = observed_perihelia();
+        // The combined sample has both a low-q scattering flank (q < 50)
+        // and a high-q detached flank (q > 65).
+        let low = qs.iter().filter(|&&q| q < 50.0).count();
+        let high = qs.iter().filter(|&&q| q >= IOC_Q_FLOOR_AU).count();
+        assert!(low >= 5, "scattering flank only {low} objects");
+        assert!(high >= 3, "detached flank only {high} objects");
+    }
+
+    #[test]
+    fn high_e_subset_is_a_subset() {
+        let all = observed_perihelia();
+        let hi = high_e_perihelia(GAP_ECCENTRICITY_FLOOR);
+        assert!(hi.len() <= all.len());
+        assert!(!hi.is_empty());
+        // Sedna (e = 0.85, q ~ 76) must survive the e cut.
+        assert!(hi.iter().any(|&q| (q - 75.9).abs() < 1.0));
+    }
+
+    #[test]
+    fn etno_q_floor_documented() {
+        // Most of the sample sits above the paper's q ~ 40 AU ETNO floor.
+        let qs = observed_perihelia();
+        let above = qs.iter().filter(|&&q| q >= ETNO_Q_FLOOR_AU).count();
+        assert!(above >= qs.len() / 2);
+    }
+}

--- a/crates/p9-2021-perihelion-gap/src/synthetic.rs
+++ b/crates/p9-2021-perihelion-gap/src/synthetic.rs
@@ -1,0 +1,156 @@
+//! Seeded synthetic perihelion populations.
+//!
+//! Oldroyd & Trujillo (2021) argue the gap is unlikely to come from a single
+//! continuous distribution and instead reflects two separate populations. We
+//! make that concrete: draw (a) a seeded two-component population — a low-q
+//! scattering component plus a high-q detached component with a sparse bridge
+//! between them — which reproduces a perihelion gap; and (b) a single
+//! continuous control population over the same q range, which does not. The
+//! dip statistic (`crate::distribution`) is then computed on both.
+
+use rand::SeedableRng;
+use rand_distr::{Distribution, Normal, Uniform};
+
+/// Parameters of the seeded two-component (scattering + detached) population.
+#[derive(Debug, Clone, Copy)]
+pub struct TwoPopulationParams {
+    /// Number of low-q scattering objects.
+    pub n_scattering: usize,
+    /// Mean perihelion of the scattering component (AU).
+    pub scattering_q_mean: f64,
+    /// Spread (std dev) of the scattering component (AU).
+    pub scattering_q_sigma: f64,
+    /// Number of high-q detached objects.
+    pub n_detached: usize,
+    /// Mean perihelion of the detached component (AU).
+    pub detached_q_mean: f64,
+    /// Spread (std dev) of the detached component (AU).
+    pub detached_q_sigma: f64,
+    /// Number of "bridge" objects spread thinly across the gap — the small
+    /// real population the paper predicts (∼20% of the IOC density).
+    pub n_bridge: usize,
+    /// Bridge window (AU): [lo, hi).
+    pub bridge_lo: f64,
+    pub bridge_hi: f64,
+}
+
+impl Default for TwoPopulationParams {
+    /// Defaults that place the scattering peak below the gap and the detached
+    /// peak above it, matching the q ≈ 50–65 AU gap.
+    fn default() -> Self {
+        Self {
+            n_scattering: 120,
+            scattering_q_mean: 43.0,
+            scattering_q_sigma: 4.0,
+            n_detached: 60,
+            detached_q_mean: 78.0,
+            detached_q_sigma: 8.0,
+            n_bridge: 6,
+            bridge_lo: 50.0,
+            bridge_hi: 65.0,
+        }
+    }
+}
+
+/// Draw a seeded two-component perihelion population (AU). Perihelia are
+/// clamped to be positive; the two Gaussian components flank the gap and the
+/// bridge populates it sparsely.
+pub fn two_population_perihelia(seed: u64, p: &TwoPopulationParams) -> Vec<f64> {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    let scat = Normal::new(p.scattering_q_mean, p.scattering_q_sigma).unwrap();
+    let det = Normal::new(p.detached_q_mean, p.detached_q_sigma).unwrap();
+    let bridge = Uniform::new(p.bridge_lo, p.bridge_hi);
+
+    let mut out = Vec::with_capacity(p.n_scattering + p.n_detached + p.n_bridge);
+    for _ in 0..p.n_scattering {
+        out.push(scat.sample(&mut rng).max(30.0));
+    }
+    for _ in 0..p.n_detached {
+        out.push(det.sample(&mut rng).max(30.0));
+    }
+    for _ in 0..p.n_bridge {
+        out.push(bridge.sample(&mut rng));
+    }
+    out
+}
+
+/// Draw a seeded single continuous control population (AU): one broad uniform
+/// distribution over [`lo`, `hi`) with the same total count. This is the
+/// "single continuous distribution" null the paper rules out — it has no gap.
+pub fn single_population_perihelia(seed: u64, n: usize, lo: f64, hi: f64) -> Vec<f64> {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    let u = Uniform::new(lo, hi);
+    (0..n).map(|_| u.sample(&mut rng)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::distribution::{dip_statistic, locate_gap_center, Histogram};
+    use crate::published::{GAP_Q_CENTER_AU, GAP_Q_HIGH_AU, GAP_Q_LOW_AU};
+
+    #[test]
+    fn two_population_is_reproducible() {
+        let p = TwoPopulationParams::default();
+        let a = two_population_perihelia(7, &p);
+        let b = two_population_perihelia(7, &p);
+        assert_eq!(a.len(), b.len());
+        for (x, y) in a.iter().zip(b.iter()) {
+            assert_eq!(x, y);
+        }
+    }
+
+    #[test]
+    fn two_population_shows_a_gap() {
+        let p = TwoPopulationParams::default();
+        let q = two_population_perihelia(2021, &p);
+        let d = dip_statistic(&q, GAP_Q_LOW_AU, GAP_Q_HIGH_AU, 12.0);
+        // The seeded two-component draw has a clear deficit in the gap.
+        assert!(
+            d.dip_ratio < 0.6,
+            "expected a deficit; dip_ratio = {}",
+            d.dip_ratio
+        );
+    }
+
+    #[test]
+    fn single_continuous_population_has_no_gap() {
+        let q = single_population_perihelia(2021, 200, 35.0, 95.0);
+        let d = dip_statistic(&q, GAP_Q_LOW_AU, GAP_Q_HIGH_AU, 12.0);
+        // A flat distribution should have a dip ratio near 1 (no gap).
+        assert!(
+            (d.dip_ratio - 1.0).abs() < 0.4,
+            "uniform control should not show a deficit; dip_ratio = {}",
+            d.dip_ratio
+        );
+    }
+
+    #[test]
+    fn located_gap_matches_published_center() {
+        let p = TwoPopulationParams::default();
+        let q = two_population_perihelia(99, &p);
+        // 13 bins of 5 AU over [35, 100): bin centres land on ...,52.5,57.5,62.5,...
+        let h = Histogram::new(&q, 35.0, 100.0, 13);
+        let center = locate_gap_center(&h).expect("gap present");
+        // The located minimum-density bin sits within the published 50-65 AU
+        // window, near the centre.
+        assert!(
+            center >= GAP_Q_LOW_AU && center <= GAP_Q_HIGH_AU,
+            "gap center {center} outside published window"
+        );
+        assert!(
+            (center - GAP_Q_CENTER_AU).abs() < 8.0,
+            "gap center {center} far from published {GAP_Q_CENTER_AU}"
+        );
+    }
+
+    #[test]
+    fn bridge_density_is_well_below_detached_density() {
+        // The paper predicts gap objects are only ~20% as numerous as the
+        // nearby IOC population; our bridge is built sparse to match.
+        let p = TwoPopulationParams::default();
+        let q = two_population_perihelia(5, &p);
+        let d = dip_statistic(&q, GAP_Q_LOW_AU, GAP_Q_HIGH_AU, 15.0);
+        assert!(d.gap_density < 0.5 * d.high_flank_density);
+    }
+}


### PR DESCRIPTION
Reproduces Oldroyd & Trujillo (2021), "The Perihelion Gap" (arXiv:2107.06296): the perihelion (q) distribution of distant TNOs shows a relative deficit at q ≈ 50–65 AU separating the Neptune-coupled scattering ETNOs (low q) from the detached inner-Oort-cloud Sednoids (high q).

New crate `p9-2021-perihelion-gap`, reusing `p9-core` (no duplicated data or physics):

- `sample`: perihelia of the vetted `p9_core::data::etno::BROWN_2017_SAMPLE` plus a documented `EXTENDED_DISTANT_TNOS` table covering both flanks of the gap.
- `distribution`: histogram + dip statistic (gap-window count density ÷ mean flank density) and a robust valley locator.
- `synthetic`: a seeded two-population draw that reproduces a gap vs a single continuous control that does not.
- `boundaries`: ties the high-q scattering edge to `p9_core::analysis::resonance::critical_perihelion`.

Findings (pinned in seeded tests): the observed sample has a deep deficit at q = 50–65 AU (dip ratio ≈ 0.10), with the minimum-density bin at q = 52.5 AU, inside the published window. The two-population synthetic reproduces the gap (dip ratio < 0.6) while the uniform control does not (≈ 1). Reproduces the gap statistic, not the full debiased completeness argument — documented in REPRODUCTION_NOTES.md entry 16.

Closes #107