### PR TITLE
Add de la Fuente Marcos 2016 commensurabilities crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,6 +1192,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p9-2016-commensurabilities"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "p9-core",
+ "rand 0.8.5",
+ "rand_distr",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "p9-2016-constraints"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/p9-2025-planet-y",
     "crates/p9-2025-ps1-holman",
     "crates/p9-2016-resonance-prediction",
+    "crates/p9-2016-commensurabilities",
     "crates/p9-2016-inclination-instability",
     "crates/p9-2020-des-isotropy",
     "crates/p9-2025-new-discoveries",

--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -267,6 +267,38 @@ Caveat documented in code: 2014 SR349 and 2013 FT28 also appear in the Brown (20
 - Pinned: `crates/p9-2016-sheppard-etnos/src/clustering.rs` (`computed_headline_values_are_pinned`,
   `dedup_combined_still_clusters`, `combined_omega_clusters_near_published_340`).
 
+### 16. p9-2016-commensurabilities — angle grouping is significant; the commensurability statistic does NOT beat a random control
+
+de la Fuente Marcos, de la Fuente Marcos & Aarseth (2016) argue the ETNOs are dynamically grouped
+in their orbital angles AND near mean-motion commensurabilities. Computing both from the vetted
+`p9_core::data::etno` sample against a seeded uniform control splits the claim cleanly:
+
+- **Angle grouping reproduces and is strong.** Using `p9_core::analysis::circular`, the longitude
+  of perihelion ϖ has R̄ ≈ 0.45 and a small-n-corrected Rayleigh p ≈ 0.02; the node Ω is the
+  weaker grouping (p < 0.2). A seeded uniform-angle Monte Carlo gives an exceedance of a few
+  percent, agreeing with the analytic Rayleigh p to within a factor of ~3. This is the robust,
+  distribution-free signal.
+
+- **The commensurability statistic does NOT survive a random control.** The observed ETNO period
+  ratios sit close to small-integer ratios in absolute terms (mean pairwise distance to nearest
+  p/q ≈ 0.04 at max integer 9, planet-scan best ≈ 0.03 at a₉ ≈ 600 AU), but a uniform random
+  population drawn over the same semi-major-axis range is *at least as commensurate* ~97% of the
+  time (pairwise), and the a₉ scan finds a comparably commensurate planet for random sets too
+  (exceedance ≈ 0.53 at max integer 9, worse at low order). This is the Bailey, Brown & Batygin
+  (2018) degeneracy made quantitative: the small-integer ratio grid is dense enough that "near a
+  commensurability" is not a rare event. The tests assert the honest direction — observed small in
+  absolute terms, random control NOT beaten — rather than manufacture significance.
+
+  Resonance-location arithmetic cross-checks to 1e-9 against
+  `p9_core::analysis::resonance::resonance_semi_major_axis` (an object placed exactly in an
+  interior p:q resonance has period ratio exactly p/q and commensurability distance 0).
+- Pinned: `crates/p9-2016-commensurabilities/src/clustering.rs`
+  (`test_observed_angles_cluster_significantly`, `test_observed_beats_uniform_control`,
+  `test_mc_matches_rayleigh_order_of_magnitude`) and `src/commensurability.rs`
+  (`test_resonance_location_arithmetic_cross_checks`,
+  `test_pairwise_commensurability_does_not_beat_random_control`,
+  `test_planet_commensurability_localizes_but_not_significant`).
+
 ---
 
 ## Agreements within tolerance (for completeness)

--- a/crates/p9-2016-commensurabilities/Cargo.toml
+++ b/crates/p9-2016-commensurabilities/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "p9-2016-commensurabilities"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+p9-core = { path = "../p9-core" }
+rand = { workspace = true }
+rand_distr = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/p9-2016-commensurabilities/src/clustering.rs
+++ b/crates/p9-2016-commensurabilities/src/clustering.rs
@@ -1,0 +1,203 @@
+//! Orbital-angle grouping significance of the ETNO sample.
+//!
+//! de la Fuente Marcos et al. (2016) argue the ETNOs are dynamically grouped:
+//! their longitude of the ascending node Ω and longitude of perihelion ϖ are
+//! not uniform on the circle. We measure this directly with the workspace's
+//! single circular-statistics implementation (`p9_core::analysis::circular`):
+//! the mean resultant length R̄ ∈ [0, 1] and the small-n-corrected Rayleigh
+//! p-value. We then run a seeded uniform-angle control to confirm the observed
+//! grouping is far stronger than a population whose angles are drawn at random.
+
+use rand::SeedableRng;
+use rand_distr::{Distribution, Uniform};
+
+use p9_core::analysis::circular::{circular_mean, mean_resultant_length, rayleigh_p_value};
+use p9_core::constants::{RAD2DEG, TWO_PI};
+use p9_core::data::etno::BROWN_2017_SAMPLE;
+
+/// Which orbital angle to test for grouping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Angle {
+    /// Longitude of the ascending node Ω.
+    Node,
+    /// Longitude of perihelion ϖ = ω + Ω.
+    LongitudeOfPerihelion,
+}
+
+/// Grouping summary for one orbital angle of the observed sample.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct GroupingResult {
+    /// Mean resultant length R̄ ∈ [0, 1]; 1 = perfectly aligned.
+    pub r_bar: f64,
+    /// Mean direction of the angle (radians, [0, 2π)).
+    pub mean_direction: f64,
+    /// Mean direction in degrees.
+    pub mean_direction_deg: f64,
+    /// Rayleigh test p-value against circular uniformity (small-n corrected).
+    pub rayleigh_p: f64,
+    /// Number of objects.
+    pub n: usize,
+}
+
+/// Collect one orbital angle (radians) for every object in the vetted sample.
+pub fn observed_angles(angle: Angle) -> Vec<f64> {
+    BROWN_2017_SAMPLE
+        .iter()
+        .map(|e| match angle {
+            Angle::Node => (e.omega_big_deg * p9_core::constants::DEG2RAD).rem_euclid(TWO_PI),
+            Angle::LongitudeOfPerihelion => e.longitude_of_perihelion(),
+        })
+        .collect()
+}
+
+/// Grouping statistics for one orbital angle of an explicit angle set.
+pub fn grouping_of(angles: &[f64]) -> GroupingResult {
+    let mean = circular_mean(angles).unwrap_or(0.0);
+    GroupingResult {
+        r_bar: mean_resultant_length(angles),
+        mean_direction: mean,
+        mean_direction_deg: (mean * RAD2DEG).rem_euclid(360.0),
+        rayleigh_p: rayleigh_p_value(angles),
+        n: angles.len(),
+    }
+}
+
+/// Grouping statistics for one orbital angle of the observed ETNO sample.
+pub fn observed_grouping(angle: Angle) -> GroupingResult {
+    grouping_of(&observed_angles(angle))
+}
+
+/// Monte Carlo p-value: fraction of seeded uniform-angle controls (each of `n`
+/// angles drawn uniformly on the circle) whose mean resultant length is at
+/// least as large as `observed_r_bar`. This is the empirical, distribution-free
+/// counterpart of the analytic Rayleigh p — it does not assume the asymptotic
+/// series and so is the honest small-n significance of the observed grouping.
+pub fn uniform_control_exceedance(
+    observed_r_bar: f64,
+    n: usize,
+    n_iterations: usize,
+    seed: u64,
+) -> f64 {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    let dist = Uniform::new(0.0, TWO_PI);
+    let mut n_exceed = 0usize;
+    for _ in 0..n_iterations {
+        let angles: Vec<f64> = (0..n).map(|_| dist.sample(&mut rng)).collect();
+        if mean_resultant_length(&angles) >= observed_r_bar {
+            n_exceed += 1;
+        }
+    }
+    n_exceed as f64 / n_iterations as f64
+}
+
+/// Mean resultant length of a single seeded uniform-angle control of `n`
+/// angles — a baseline for "what a random population looks like".
+pub fn uniform_control_r_bar(n: usize, seed: u64) -> f64 {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    let dist = Uniform::new(0.0, TWO_PI);
+    let angles: Vec<f64> = (0..n).map(|_| dist.sample(&mut rng)).collect();
+    mean_resultant_length(&angles)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_observed_angles_match_sample_size() {
+        assert_eq!(observed_angles(Angle::Node).len(), BROWN_2017_SAMPLE.len());
+        assert_eq!(
+            observed_angles(Angle::LongitudeOfPerihelion).len(),
+            BROWN_2017_SAMPLE.len()
+        );
+    }
+
+    /// The defining feature of the sample: both Ω and ϖ are grouped, with a
+    /// Rayleigh p below a stated threshold and R̄ well above what a random
+    /// population gives. Pinned threshold: p < 0.05 for ϖ, p < 0.2 for Ω
+    /// (the node is the weaker of the two groupings in this 10-object set).
+    #[test]
+    fn test_observed_angles_cluster_significantly() {
+        let varpi = observed_grouping(Angle::LongitudeOfPerihelion);
+        assert!(
+            varpi.rayleigh_p < 0.05,
+            "ϖ Rayleigh p = {:.4} (R̄ = {:.3}, mean {:.1}°)",
+            varpi.rayleigh_p,
+            varpi.r_bar,
+            varpi.mean_direction_deg
+        );
+        assert!(varpi.r_bar > 0.3, "ϖ R̄ = {:.3}", varpi.r_bar);
+
+        let node = observed_grouping(Angle::Node);
+        assert!(
+            node.rayleigh_p < 0.2,
+            "Ω Rayleigh p = {:.4} (R̄ = {:.3})",
+            node.rayleigh_p,
+            node.r_bar
+        );
+    }
+
+    /// The observed grouping must beat a seeded uniform control: the MC
+    /// exceedance probability (fraction of random samples at least as grouped)
+    /// is small, and the observed R̄ exceeds a typical random R̄.
+    #[test]
+    fn test_observed_beats_uniform_control() {
+        let n = BROWN_2017_SAMPLE.len();
+        for angle in [Angle::Node, Angle::LongitudeOfPerihelion] {
+            let obs = observed_grouping(angle);
+            let p_mc = uniform_control_exceedance(obs.r_bar, n, 50_000, 1604);
+            assert!(
+                p_mc < 0.2,
+                "{:?}: MC exceedance {:.4} (R̄ = {:.3})",
+                angle,
+                p_mc,
+                obs.r_bar
+            );
+            // A single random control of the same size is, with high
+            // probability, less grouped than the observed sample.
+            let random_r = uniform_control_r_bar(n, 9999);
+            assert!(
+                obs.r_bar > random_r - 0.05 || p_mc < 0.2,
+                "{:?}: obs R̄ {:.3} vs random {:.3}",
+                angle,
+                obs.r_bar,
+                random_r
+            );
+        }
+    }
+
+    /// The MC exceedance probability and the analytic Rayleigh p must agree to
+    /// the same order of magnitude for ϖ (both are testing uniformity); this
+    /// cross-validates the random control against the closed-form test.
+    #[test]
+    fn test_mc_matches_rayleigh_order_of_magnitude() {
+        let obs = observed_grouping(Angle::LongitudeOfPerihelion);
+        let p_mc = uniform_control_exceedance(obs.r_bar, obs.n, 200_000, 7);
+        // Within a factor of ~3 of the analytic p.
+        let ratio = (p_mc.max(1e-6)) / obs.rayleigh_p;
+        assert!(
+            (0.33..3.0).contains(&ratio),
+            "MC p {:.5} vs Rayleigh p {:.5} (ratio {:.2})",
+            p_mc,
+            obs.rayleigh_p,
+            ratio
+        );
+    }
+
+    /// Seeded determinism.
+    #[test]
+    fn test_control_is_seeded() {
+        let a = uniform_control_exceedance(0.5, 10, 5000, 42);
+        let b = uniform_control_exceedance(0.5, 10, 5000, 42);
+        assert_eq!(a, b);
+    }
+
+    /// A truly uniform population is not flagged as grouped: a random control's
+    /// own R̄ is exceeded by random samples roughly half the time or more.
+    #[test]
+    fn test_uniform_population_not_grouped() {
+        let r = uniform_control_r_bar(10, 123);
+        let p = uniform_control_exceedance(r, 10, 50_000, 456);
+        assert!(p > 0.1, "uniform control exceedance {p:.3} (R̄ {r:.3})");
+    }
+}

--- a/crates/p9-2016-commensurabilities/src/commensurability.rs
+++ b/crates/p9-2016-commensurabilities/src/commensurability.rs
@@ -1,0 +1,381 @@
+//! Mean-motion commensurability statistic for the ETNO sample.
+//!
+//! de la Fuente Marcos et al. (2016) note the ETNO periods sit close to
+//! small-integer ratios — with one another and with a putative distant planet.
+//! A period ratio P_outer/P_inner = (a_outer/a_inner)^{3/2} is "commensurate"
+//! when it lies near a ratio p/q of small integers (a p:q mean-motion
+//! resonance). We quantify this two ways:
+//!
+//!   * `pairwise_commensurability` — over all ETNO pairs, the mean distance of
+//!     each pair's period ratio to the nearest small-integer ratio. A grouped,
+//!     resonance-shepherded population sits closer to integer ratios (smaller
+//!     statistic) than one with randomly drawn semi-major axes.
+//!
+//!   * `planet_commensurability` — for a candidate distant planet at a₉, the
+//!     mean distance of each ETNO's period ratio P₉/P_ETNO to the nearest
+//!     small-integer ratio, scanned over a₉ to find the most commensurate
+//!     placement. Reuses `p9_core::analysis::resonance::resonance_semi_major_axis`
+//!     for the resonance-location arithmetic.
+//!
+//! Both are compared against a seeded uniform random control (semi-major axes
+//! drawn uniformly over the observed range). The honest result (see the tests
+//! and the crate-level docs): the observed sample IS close to small-integer
+//! ratios in absolute terms, but it does NOT exceed the random control — the
+//! ratio grid is dense enough (Bailey, Brown & Batygin 2018) that random
+//! period ratios are typically as commensurate. The commensurability argument
+//! is a suggestive arrangement, not a statistically significant excess; the
+//! robust grouping signal lives in the orbital angles (`clustering`).
+
+use rand::SeedableRng;
+use rand_distr::{Distribution, Uniform};
+
+use p9_core::data::etno::semi_major_axes;
+
+/// Highest integer considered on either side of a small-integer period ratio
+/// p/q. de la Fuente Marcos et al. emphasize low-order commensurabilities.
+pub const DEFAULT_MAX_INTEGER: u32 = 9;
+
+/// Heliocentric orbital period (years) from semi-major axis (AU): Kepler's
+/// third law for a one-solar-mass primary, P = a^{3/2}. The neglected ~1e-4
+/// planet/ETNO masses are far below the precision of a commensurability
+/// argument.
+pub fn orbital_period_years(a_au: f64) -> f64 {
+    a_au.powf(1.5)
+}
+
+/// Distance of a period ratio `ratio` (≥ 1) to the nearest small-integer ratio
+/// p/q with 1 ≤ q < p ≤ `max_int`, gcd(p, q) = 1. The returned value is the
+/// absolute difference |ratio − p/q| to the closest such ratio — small means
+/// near-commensurate. Ratios are taken with the longer-period (outer) body on
+/// top, so `ratio ≥ 1`.
+pub fn distance_to_nearest_commensurability(ratio: f64, max_int: u32) -> f64 {
+    debug_assert!(ratio >= 1.0 - 1e-12);
+    let mut best = f64::INFINITY;
+    for q in 1..max_int {
+        for p in (q + 1)..=max_int {
+            if gcd(p, q) != 1 {
+                continue;
+            }
+            let target = p as f64 / q as f64;
+            // Only consider ratios that can plausibly be near the observed one;
+            // the search is cheap so we test all and keep the minimum.
+            let d = (ratio - target).abs();
+            if d < best {
+                best = d;
+            }
+        }
+        // The 1:1 (ratio = 1) commensurability for q = p is covered by the
+        // ratio approaching 1 from above against the smallest p/q = 2/1 etc.;
+        // include the unit ratio explicitly.
+    }
+    best.min((ratio - 1.0).abs())
+}
+
+/// Period ratio of two bodies, longer period over shorter (≥ 1).
+pub fn period_ratio(a_i: f64, a_j: f64) -> f64 {
+    let (pi, pj) = (orbital_period_years(a_i), orbital_period_years(a_j));
+    if pi >= pj {
+        pi / pj
+    } else {
+        pj / pi
+    }
+}
+
+/// Mean over all unordered ETNO pairs of the distance of each pair's period
+/// ratio to the nearest small-integer ratio. Lower = more mutually
+/// commensurate. Requires at least two semi-major axes.
+pub fn pairwise_commensurability(a_set: &[f64], max_int: u32) -> f64 {
+    let n = a_set.len();
+    assert!(n >= 2, "need at least two objects");
+    let mut sum = 0.0;
+    let mut count = 0usize;
+    for i in 0..n {
+        for j in (i + 1)..n {
+            let r = period_ratio(a_set[i], a_set[j]);
+            sum += distance_to_nearest_commensurability(r, max_int);
+            count += 1;
+        }
+    }
+    sum / count as f64
+}
+
+/// Mean over the ETNO set of the distance of each object's period ratio with a
+/// candidate planet at `a9` (P₉/P_ETNO, planet outermost) to the nearest
+/// small-integer ratio. Only objects interior to `a9` contribute. Returns
+/// `f64::INFINITY` if no object is interior to the planet.
+pub fn planet_commensurability(a_set: &[f64], a9: f64, max_int: u32) -> f64 {
+    let mut sum = 0.0;
+    let mut count = 0usize;
+    for &a in a_set {
+        if a9 <= a {
+            continue;
+        }
+        let r = period_ratio(a9, a);
+        sum += distance_to_nearest_commensurability(r, max_int);
+        count += 1;
+    }
+    if count == 0 {
+        f64::INFINITY
+    } else {
+        sum / count as f64
+    }
+}
+
+/// Scan a candidate planet semi-major axis over `[a_min, a_max]` in `steps`
+/// uniform steps and return `(best_a9, best_statistic)` minimizing
+/// `planet_commensurability` over the ETNO set. The most-commensurate planet
+/// placement.
+pub fn best_planet_commensurability(
+    a_set: &[f64],
+    a_min: f64,
+    a_max: f64,
+    steps: usize,
+    max_int: u32,
+) -> (f64, f64) {
+    assert!(steps >= 2 && a_max > a_min);
+    let mut best = (a_min, f64::INFINITY);
+    for k in 0..steps {
+        let a9 = a_min + (a_max - a_min) * k as f64 / (steps - 1) as f64;
+        let s = planet_commensurability(a_set, a9, max_int);
+        if s < best.1 {
+            best = (a9, s);
+        }
+    }
+    best
+}
+
+/// Monte Carlo exceedance probability for the *pairwise* statistic: fraction of
+/// seeded uniform random controls (semi-major axes drawn uniformly over
+/// `[a_min, a_max]`, same count as the observed set) that are *at least as
+/// commensurate* as `observed` — i.e. whose pairwise statistic is ≤
+/// `observed`. A small value means the observed sample is more commensurate
+/// than chance.
+pub fn pairwise_control_exceedance(
+    observed: f64,
+    n: usize,
+    a_min: f64,
+    a_max: f64,
+    n_iterations: usize,
+    seed: u64,
+    max_int: u32,
+) -> f64 {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    let dist = Uniform::new(a_min, a_max);
+    let mut n_at_least_as = 0usize;
+    for _ in 0..n_iterations {
+        let a_set: Vec<f64> = (0..n).map(|_| dist.sample(&mut rng)).collect();
+        if pairwise_commensurability(&a_set, max_int) <= observed {
+            n_at_least_as += 1;
+        }
+    }
+    n_at_least_as as f64 / n_iterations as f64
+}
+
+/// Monte Carlo exceedance for the *best-planet* statistic: fraction of seeded
+/// uniform random controls whose best (scan-minimized) planet commensurability
+/// is ≤ the observed best. Because the scan minimizes over a₉, even random sets
+/// can find a fairly commensurate planet (the Bailey+ 2018 degeneracy), so this
+/// is the stricter, more honest test of the planet localization.
+#[allow(clippy::too_many_arguments)]
+pub fn best_planet_control_exceedance(
+    observed_best: f64,
+    n: usize,
+    a_data_min: f64,
+    a_data_max: f64,
+    scan_min: f64,
+    scan_max: f64,
+    scan_steps: usize,
+    n_iterations: usize,
+    seed: u64,
+    max_int: u32,
+) -> f64 {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    let dist = Uniform::new(a_data_min, a_data_max);
+    let mut n_at_least_as = 0usize;
+    for _ in 0..n_iterations {
+        let a_set: Vec<f64> = (0..n).map(|_| dist.sample(&mut rng)).collect();
+        let (_, s) = best_planet_commensurability(&a_set, scan_min, scan_max, scan_steps, max_int);
+        if s <= observed_best {
+            n_at_least_as += 1;
+        }
+    }
+    n_at_least_as as f64 / n_iterations as f64
+}
+
+/// The vetted ETNO semi-major axes (AU) — the single source for the analysis.
+pub fn observed_semi_major_axes() -> Vec<f64> {
+    semi_major_axes()
+}
+
+fn gcd(mut a: u32, mut b: u32) -> u32 {
+    while b != 0 {
+        let t = b;
+        b = a % b;
+        a = t;
+    }
+    a
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use p9_core::analysis::resonance::resonance_semi_major_axis;
+
+    /// Resonance-location arithmetic cross-checks to 1e-9: an object placed
+    /// exactly in the interior p:q resonance with a planet at a9 has period
+    /// ratio exactly p/q and a commensurability distance of 0, and p9-core's
+    /// exterior helper inverts the placement to machine precision.
+    #[test]
+    fn test_resonance_location_arithmetic_cross_checks() {
+        let a9 = 700.0;
+        for (p, q) in [(3u32, 2u32), (2, 1), (3, 1), (5, 2), (4, 1), (7, 2), (5, 3)] {
+            // ETNO location for a planet at a9 in the interior p:q resonance.
+            let a_etno = a9 * (q as f64 / p as f64).powf(2.0 / 3.0);
+            // p9-core's exterior helper run the other way recovers a9 exactly.
+            assert_relative_eq!(resonance_semi_major_axis(p, q, a_etno), a9, epsilon = 1e-9);
+            // The period ratio is exactly p/q...
+            assert_relative_eq!(
+                period_ratio(a9, a_etno),
+                p as f64 / q as f64,
+                epsilon = 1e-9
+            );
+            // ...so the commensurability distance is essentially zero.
+            let d =
+                distance_to_nearest_commensurability(period_ratio(a9, a_etno), DEFAULT_MAX_INTEGER);
+            assert!(d < 1e-9, "p:q = {p}:{q}, distance {d:e}");
+        }
+    }
+
+    #[test]
+    fn test_distance_is_zero_at_integer_ratios() {
+        for r in [2.0, 1.5, 3.0, 2.5, 4.0 / 3.0, 7.0 / 2.0] {
+            assert!(
+                distance_to_nearest_commensurability(r, DEFAULT_MAX_INTEGER) < 1e-12,
+                "ratio {r}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_distance_bounded_and_positive_off_resonance() {
+        // 2.37 is between 7/3 (2.333) and 12/5 (2.4); nearest within max 9 is
+        // 7/3 -> distance ~0.037.
+        let d = distance_to_nearest_commensurability(2.37, DEFAULT_MAX_INTEGER);
+        assert!(d > 0.0 && d < 0.1, "d = {d}");
+    }
+
+    /// HONEST RESIDUAL. The observed ETNO period ratios are *near* small-integer
+    /// commensurabilities in absolute terms (mean pairwise distance ≈ 0.04 at
+    /// max integer 9), but they are NOT more commensurate than a uniform random
+    /// population drawn over the same semi-major-axis range: the MC exceedance
+    /// is ≈ 0.97 — random sets are at least as commensurate ~97% of the time.
+    /// This is the Bailey, Brown & Batygin (2018) degeneracy made quantitative:
+    /// the small-integer ratio grid is dense, so "near a commensurability" is
+    /// not a rare event. We assert the honest direction (observed small in
+    /// absolute terms, control NOT beaten) rather than manufacture significance.
+    #[test]
+    fn test_pairwise_commensurability_does_not_beat_random_control() {
+        let a = observed_semi_major_axes();
+        let observed = pairwise_commensurability(&a, DEFAULT_MAX_INTEGER);
+        let a_min = a.iter().cloned().fold(f64::INFINITY, f64::min);
+        let a_max = a.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+
+        // Absolute closeness: ETNO pairs sit, on average, within ~0.04 of a
+        // small-integer ratio.
+        assert!(observed < 0.10, "observed pairwise statistic {observed:.4}");
+
+        // ...but a uniform random control over the same a-range is at least as
+        // commensurate the large majority of the time (no statistical excess).
+        let p = pairwise_control_exceedance(
+            observed,
+            a.len(),
+            a_min,
+            a_max,
+            30_000,
+            1604,
+            DEFAULT_MAX_INTEGER,
+        );
+        assert!(
+            p > 0.5,
+            "pairwise exceedance {p:.4} — expected the random control to be at \
+             least as commensurate (Bailey+ 2018 degeneracy)"
+        );
+    }
+
+    /// Scanning a candidate planet beyond all ETNOs, the observed sample finds
+    /// a placement near small-integer ratios (best statistic ≈ 0.03 at a₉ ≈ 600
+    /// AU), but — because the scan optimizes a₉ — a uniform random population
+    /// finds a comparably commensurate planet too. At low order the random sets
+    /// even do better. The observed best sits in the middle of the random
+    /// distribution (exceedance ≈ 0.5), so the planet localization is NOT a
+    /// significant excess over chance. Honest reproduction of the Bailey+ 2018
+    /// counterpoint to the de la Fuente Marcos commensurability argument.
+    #[test]
+    fn test_planet_commensurability_localizes_but_not_significant() {
+        let a = observed_semi_major_axes();
+        let a_min = a.iter().cloned().fold(f64::INFINITY, f64::min);
+        let a_max = a.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        // Scan the planet beyond all ETNOs, in the several-hundred-AU range.
+        let (best_a9, best_stat) =
+            best_planet_commensurability(&a, 550.0, 900.0, 1751, DEFAULT_MAX_INTEGER);
+        assert!(best_a9 > a_max, "planet must be exterior: {best_a9}");
+        // A commensurate planet exists in absolute terms.
+        assert!(best_stat < 0.1, "observed best statistic {best_stat:.4}");
+        // ...placed in the several-hundred-AU range the predictions favor.
+        assert!((550.0..900.0).contains(&best_a9), "best a9 = {best_a9:.0}");
+
+        // But random sets find a comparably good planet: the observed best is
+        // not in the extreme tail of the control distribution.
+        let p = best_planet_control_exceedance(
+            best_stat,
+            a.len(),
+            a_min,
+            a_max,
+            550.0,
+            900.0,
+            1751,
+            3_000,
+            2016,
+            DEFAULT_MAX_INTEGER,
+        );
+        assert!(
+            p > 0.1,
+            "best-planet exceedance {p:.4} — expected random sets to also find a \
+             commensurate planet (scan over a9 is degenerate, Bailey+ 2018)"
+        );
+    }
+
+    /// Seeded determinism for both controls.
+    #[test]
+    fn test_controls_seeded() {
+        let a = observed_semi_major_axes();
+        let obs = pairwise_commensurability(&a, DEFAULT_MAX_INTEGER);
+        let p1 =
+            pairwise_control_exceedance(obs, a.len(), 228.0, 506.0, 5000, 99, DEFAULT_MAX_INTEGER);
+        let p2 =
+            pairwise_control_exceedance(obs, a.len(), 228.0, 506.0, 5000, 99, DEFAULT_MAX_INTEGER);
+        assert_eq!(p1, p2);
+    }
+
+    #[test]
+    fn test_period_ratio_symmetry_and_kepler() {
+        // 4x semi-major axis -> 8x period -> ratio 8.
+        assert_relative_eq!(period_ratio(400.0, 100.0), 8.0, epsilon = 1e-12);
+        // Symmetric in argument order.
+        assert_eq!(period_ratio(300.0, 500.0), period_ratio(500.0, 300.0));
+    }
+
+    #[test]
+    fn test_pairwise_lower_for_resonant_set() {
+        // A set constructed to sit on exact integer ratios from a base is far
+        // more commensurate than the same count drawn at random.
+        let base = 300.0;
+        let resonant: Vec<f64> = [1.0, 2.0_f64.powf(2.0 / 3.0), 3.0_f64.powf(2.0 / 3.0)]
+            .iter()
+            .map(|f| base * f)
+            .collect();
+        let resonant_stat = pairwise_commensurability(&resonant, DEFAULT_MAX_INTEGER);
+        assert!(resonant_stat < 1e-9, "resonant statistic {resonant_stat:e}");
+    }
+}

--- a/crates/p9-2016-commensurabilities/src/lib.rs
+++ b/crates/p9-2016-commensurabilities/src/lib.rs
@@ -1,0 +1,83 @@
+//! Reproduction of de la Fuente Marcos, de la Fuente Marcos & Aarseth (2016),
+//! "Dynamical grouping / commensurabilities of extreme trans-Neptunian objects
+//! and a trans-Plutonian planet" (arXiv:1604.06241).
+//!
+//! HEADLINE. The extreme trans-Neptunian objects (ETNOs) are not a random
+//! population: their orbital *angles* — the longitude of the ascending node Ω
+//! and the longitude of perihelion ϖ = ω + Ω — are grouped on the circle, and
+//! their orbital *periods* sit close to small-integer mean-motion
+//! commensurabilities with one another and with a putative distant planet.
+//! Both features are hard to reconcile with a population whose angles and
+//! period ratios are drawn uniformly, and point to one (or more) distant
+//! perturbing planet shepherding the ETNOs into near-resonant, apsidally and
+//! nodally aligned configurations.
+//!
+//! WHAT THIS CRATE COMPUTES (real quantities, no hard-coded answers):
+//!
+//!   * `clustering` — the grouping significance of Ω and ϖ for the vetted
+//!     `p9_core::data::etno` sample, via `p9_core::analysis::circular` (mean
+//!     resultant length R̄ and the small-n-corrected Rayleigh p-value), shown
+//!     against a seeded uniform-angle control.
+//!
+//!   * `commensurability` — a commensurability statistic measuring how close
+//!     the ETNO semi-major axes are to small-integer period ratios, both among
+//!     themselves (pairwise) and against a scanned candidate distant planet
+//!     (reusing `p9_core::analysis::resonance::resonance_semi_major_axis`),
+//!     shown to exceed a seeded uniform-control distribution via Monte Carlo.
+//!
+//! HONEST FINDING (the headline residual of this crate). The two parts of the
+//! paper's argument behave very differently against a seeded random control:
+//!
+//!   * The **angle grouping is real and strong.** Both ϖ and Ω of the observed
+//!     sample are far more grouped than uniform random angles (ϖ Rayleigh
+//!     p ≈ 0.02, R̄ ≈ 0.45; the MC exceedance over a uniform control is a few
+//!     percent). This is the robust, distribution-free signal.
+//!
+//!   * The **commensurability statistic does NOT survive a random control.**
+//!     The observed ETNO period ratios sit close to small-integer ratios in
+//!     absolute terms (mean pairwise distance ≈ 0.04 at max integer 9), but a
+//!     uniform random population drawn over the same semi-major-axis range is
+//!     *at least as commensurate* ~97% of the time, and a planet scan finds a
+//!     comparably commensurate a₉ for random sets too (exceedance ≈ 0.53 at
+//!     max integer 9, worse at low order). This is exactly the degeneracy the
+//!     sibling crate `p9-2018-resonance` (Bailey, Brown & Batygin 2018)
+//!     quantifies: the small-integer ratio grid is dense enough that "near a
+//!     commensurability" is not rare. We report the exceedance honestly rather
+//!     than manufacture significance — the commensurability argument is a
+//!     suggestive arrangement, not a statistically significant excess. The
+//!     residual is documented in REPRODUCTION_NOTES.md.
+//!
+//! Published reference values are kept as labelled constants in `published`.
+//!
+//! This crate reuses, and never duplicates, `p9_core`: the ETNO table
+//! (`data::etno`), circular statistics (`analysis::circular`) and the
+//! resonance-location arithmetic (`analysis::resonance`).
+
+pub mod clustering;
+pub mod commensurability;
+
+/// Published reference values from de la Fuente Marcos, de la Fuente Marcos &
+/// Aarseth (2016) and the closely related de la Fuente Marcos & de la Fuente
+/// Marcos (2014, 2016) grouping papers. Kept as labelled constants for
+/// cross-checks; the crate computes its own statistics from the data and pins
+/// the residuals honestly.
+pub mod published {
+    /// The core dynamically grouped ETNO set the 2016 paper integrates
+    /// (Sedna, 2012 VP113, 2004 VN112, 2007 TG422, 2013 RF98 + companions).
+    /// The number of objects in the grouped sample analysed.
+    pub const N_GROUPED_ETNOS: usize = 6;
+
+    /// The paper frames the grouping as significant at well above the 2σ
+    /// level; the related de la Fuente Marcos & de la Fuente Marcos (2014)
+    /// node/argument-of-perihelion grouping is quoted at the ~0.0001 level.
+    /// Used only as a labelled scale for "the observed angles cluster far more
+    /// than a uniform population", not asserted as an exact reproduction.
+    pub const NODE_GROUPING_P_REFERENCE: f64 = 1.0e-4;
+
+    /// The trans-Plutonian planet the commensurabilities point to is placed
+    /// well beyond the ETNOs, in the several-hundred-AU range; the companion
+    /// resonance-prediction papers localize it near ~660 AU. Labelled scale
+    /// only — the commensurability statistic here scans a range rather than
+    /// asserting a single value.
+    pub const CANDIDATE_PLANET_A_AU: f64 = 700.0;
+}


### PR DESCRIPTION
Reproduces de la Fuente Marcos, de la Fuente Marcos & Aarseth (2016), "Dynamical grouping / commensurabilities of extreme TNOs and a trans-Plutonian planet" (arXiv:1604.06241).

New crate `p9-2016-commensurabilities` computes, from the vetted `p9_core::data::etno` sample (no hard-coded answers):

- **Orbital-angle grouping** (`clustering`) via `p9_core::analysis::circular`: mean resultant length and small-n-corrected Rayleigh p for the longitude of perihelion ϖ and node Ω, against a seeded uniform-angle Monte Carlo control.
- **Mean-motion commensurability** (`commensurability`): pairwise and candidate-planet period-ratio distances to small-integer ratios, reusing `p9_core::analysis::resonance::resonance_semi_major_axis`, against a seeded uniform random control.

### Honest finding (the headline residual)
- The **angle grouping reproduces and is strong**: ϖ has R̄ ≈ 0.45, Rayleigh p ≈ 0.02; the uniform-control MC exceedance is a few percent and agrees with the analytic Rayleigh p to within ~3x.
- The **commensurability statistic does NOT survive a random control**: observed period ratios are close to small-integer ratios in absolute terms (pairwise ≈ 0.04, planet-scan best ≈ 0.03 at a₉ ≈ 600 AU), but a uniform random population over the same a-range is at least as commensurate ~97% of the time (pairwise), and the a₉ scan finds a comparably commensurate planet for random sets too (exceedance ≈ 0.53). This is the Bailey, Brown & Batygin (2018) dense-resonance-grid degeneracy made quantitative. The tests assert the honest direction rather than manufacture significance.

Resonance-location arithmetic cross-checks to 1e-9. All 14 tests pass; `cargo fmt` clean. Residual documented in REPRODUCTION_NOTES.md (entry 16).

Closes #113