### PR TITLE
Add Geringer-Sameth 2025 multi-year stacking-search crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,6 +1816,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p9-2025-stacking"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "p9-core",
+ "rand 0.8.5",
+ "rand_distr",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "p9-2026-apsidal-clustering"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/p9-core",
+    "crates/p9-2025-stacking",
     "crates/p9-2018-bp519",
     "crates/p9-2020-secular-octupole",
     "crates/p9-2016-obliquity-lai",

--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -608,3 +608,19 @@ derived quantities:
   galactic pole in `p9-core/src/forces/galactic_tide.rs` were deleted in favor of it.
 - No shared simulation snapshot driver in p9-core; the 2016-crate run loops were harmonized in
   place but remain three copies.
+
+### 24. p9-2025-stacking — analytic matched-filter / metric reproduction, not a pixel pipeline
+
+Geringer-Sameth et al. (2025) build a full image-stacking search with an orbit-
+parameter Fisher metric. This crate reproduces the *analytic backbone*: the √N
+matched-filter SNR and 1.25·log10(N) depth gain, the leading-order rate-error
+metric g_vv = T²/(24θ²) (cross-checked against the exact Gaussian-overlap stack
+to ~1%), the resulting trial-orbit count (~10^8–10^9 for a ZTF six-year
+baseline), and the logarithmic look-elsewhere penalty (~6.5σ / ~0.3 mag for 10^9
+trials). Reductions, documented and pinned: the metric is the linear on-sky
+(rate-only) sub-block rather than the full 5–6-element bound-orbit metric, and
+the ~27th-mag reach is the √N law extrapolated to ~1.6e5 frames rather than a
+pixel-level coadd. The headline scalings and the stacking-gain-≫-trials-penalty
+conclusion reproduce; absolute trial counts depend on the adopted rate range /
+PSF / SNR tolerance, kept as labelled inputs.
+- Pinned: crates/p9-2025-stacking/src/{matched_filter,orbit_metric,significance}.rs

--- a/crates/p9-2025-stacking/Cargo.toml
+++ b/crates/p9-2025-stacking/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "p9-2025-stacking"
+version = "0.1.0"
+edition = "2021"
+description = "Reproduction of Geringer-Sameth, Golovich & Iwabuchi (2025) 'Multi-year stacking searches for solar system bodies' — matched-filter digital tracking, the orbit-parameter metric, and the look-elsewhere trials penalty"
+
+[dependencies]
+p9-core = { path = "../p9-core" }
+rand = { workspace = true }
+rand_distr = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/p9-2025-stacking/src/lib.rs
+++ b/crates/p9-2025-stacking/src/lib.rs
@@ -1,0 +1,44 @@
+//! Reproduction of Geringer-Sameth, Golovich & Iwabuchi (2025),
+//! "Multi-year stacking searches for solar system bodies" (arXiv:2509.25428).
+//!
+//! The paper extends digital tracking ("shift-and-stack") to full-sky,
+//! multi-year surveys. Three pieces of its method are reproduced here from
+//! first principles:
+//!
+//! - [`matched_filter`] — the matched-filter stack: co-adding N background-
+//!   limited frames along the correct track grows the signal-to-noise as √N
+//!   (limiting magnitude as 1.25·log₁₀N), turning a ~20.5-mag single ZTF
+//!   exposure into a mid-20s / ~27-mag effective depth.
+//! - [`orbit_metric`] — the heart of the paper: a trial orbit that misses the
+//!   true track loses SNR *quadratically* in the parameter error, defining a
+//!   Fisher **metric** on orbit space. The metric sets the grid spacing (and
+//!   hence the **number of trial orbits**) needed to keep the SNR loss below a
+//!   chosen tolerance. A longer baseline sharpens the metric (finer rate
+//!   resolution) — which is exactly why a multi-year search needs *billions* of
+//!   trial orbits.
+//! - [`significance`] — the look-elsewhere penalty: searching N_trials orbits
+//!   raises the per-trial detection threshold to ≈ √(2 ln N_trials) σ. The
+//!   payoff/cost asymmetry is the headline: the stacking gain is several
+//!   magnitudes while the billions-of-trials penalty costs only a few tenths of
+//!   a magnitude.
+//!
+//! All computed quantities are pinned in seeded tests; the paper's headline
+//! claims (ZTF: thousands of images over six years, ~10⁹ trial orbits, ~27th
+//! magnitude reach) are kept as labelled reference constants.
+
+pub mod matched_filter;
+pub mod orbit_metric;
+pub mod significance;
+
+/// Labelled reference numbers from the paper (for regression comparison only;
+/// every quantity used in tests is computed, not taken from here).
+pub mod published {
+    /// ZTF single-exposure r-band limiting magnitude (Bellm et al. 2019).
+    pub const ZTF_SINGLE_DEPTH: f64 = 20.5;
+    /// Headline stacked depth reached for TNOs (~27th magnitude).
+    pub const STACKED_DEPTH_REACH: f64 = 27.0;
+    /// Order of magnitude of trial orbits in the multi-year ZTF search.
+    pub const TRIAL_ORBITS_ORDER: f64 = 1.0e9;
+    /// Survey baseline of the ZTF validation (six years).
+    pub const ZTF_BASELINE_YEARS: f64 = 6.0;
+}

--- a/crates/p9-2025-stacking/src/matched_filter.rs
+++ b/crates/p9-2025-stacking/src/matched_filter.rs
@@ -1,0 +1,88 @@
+//! Matched-filter stacking: SNR and limiting-magnitude gain from co-adding
+//! frames along a track.
+//!
+//! For N background-limited exposures of equal depth, the optimal (matched-
+//! filter) combination adds the signal coherently and the noise in quadrature,
+//! so the stacked SNR is √N times a single frame. In flux terms the limiting
+//! flux falls as 1/√N, i.e. the limiting magnitude deepens by
+//! Δm = 2.5·log₁₀(√N) = 1.25·log₁₀(N).
+
+/// Matched-filter stacked SNR for `n_frames` equal-depth exposures, each with
+/// single-frame SNR `per_frame_snr` (background/read-noise limited).
+pub fn stacked_snr(per_frame_snr: f64, n_frames: usize) -> f64 {
+    per_frame_snr * (n_frames as f64).sqrt()
+}
+
+/// General matched-filter combination of per-frame SNRs (unequal frames):
+/// SNR_stack = √(Σ SNRᵢ²).
+pub fn combine_snr(per_frame_snrs: &[f64]) -> f64 {
+    per_frame_snrs.iter().map(|s| s * s).sum::<f64>().sqrt()
+}
+
+/// Limiting-magnitude gain from stacking `n_frames` background-limited frames:
+/// Δm = 1.25·log₁₀(N).
+pub fn stack_depth_gain_mag(n_frames: usize) -> f64 {
+    if n_frames == 0 {
+        return f64::NEG_INFINITY;
+    }
+    1.25 * (n_frames as f64).log10()
+}
+
+/// Stacked limiting magnitude from a single-frame depth and a frame count.
+pub fn stacked_limiting_mag(single_frame_depth: f64, n_frames: usize) -> f64 {
+    single_frame_depth + stack_depth_gain_mag(n_frames)
+}
+
+/// Number of equal frames needed to reach a target stacked depth from a single-
+/// frame depth: N = 10^((m_target − m_single)/1.25).
+pub fn frames_to_reach_depth(single_frame_depth: f64, target_depth: f64) -> f64 {
+    10f64.powf((target_depth - single_frame_depth) / 1.25)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::published;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn stacking_grows_snr_as_sqrt_n() {
+        assert_relative_eq!(stacked_snr(5.0, 100), 50.0, epsilon = 1e-9);
+        // doubling frames raises SNR by √2.
+        assert_relative_eq!(
+            stacked_snr(5.0, 200) / stacked_snr(5.0, 100),
+            std::f64::consts::SQRT_2,
+            epsilon = 1e-9
+        );
+    }
+
+    #[test]
+    fn matched_filter_equals_quadrature_sum() {
+        let snrs = [5.0; 100];
+        assert_relative_eq!(combine_snr(&snrs), stacked_snr(5.0, 100), epsilon = 1e-9);
+        // unequal frames still add in quadrature
+        assert_relative_eq!(combine_snr(&[3.0, 4.0]), 5.0, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn depth_gain_is_1_25_log10_n() {
+        assert_relative_eq!(stack_depth_gain_mag(10_000), 5.0, epsilon = 1e-9);
+        assert_relative_eq!(stack_depth_gain_mag(100), 2.5, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn ztf_stack_reaches_27th_magnitude() {
+        // The paper reaches ~27th mag for TNOs; from a 20.5-mag single ZTF
+        // exposure that needs N ≈ 1.6e5 frames (thousands per field accumulated
+        // over the six-year baseline).
+        let n = frames_to_reach_depth(published::ZTF_SINGLE_DEPTH, published::STACKED_DEPTH_REACH);
+        assert!(
+            (1.0e5..3.0e5).contains(&n),
+            "frames to reach 27th mag = {n:.3e}"
+        );
+        let depth = stacked_limiting_mag(published::ZTF_SINGLE_DEPTH, n.round() as usize);
+        assert_relative_eq!(depth, published::STACKED_DEPTH_REACH, epsilon = 0.05);
+        // a few thousand frames already buys ~4 magnitudes.
+        assert!(stack_depth_gain_mag(3000) > 4.0);
+    }
+}

--- a/crates/p9-2025-stacking/src/orbit_metric.rs
+++ b/crates/p9-2025-stacking/src/orbit_metric.rs
@@ -1,0 +1,152 @@
+//! The orbit-parameter metric: how fast SNR is lost when a trial orbit misses
+//! the true track, and the resulting number of trial orbits to grid the search.
+//!
+//! Model a linear on-sky track over a baseline `T` (days) imaged with a
+//! Gaussian PSF of width `θ` (1σ, arcsec). A trial with a rate error `δv`
+//! (arcsec/day) leaves the source progressively offset from the template; at
+//! time `t` (relative to mid-baseline) the offset is `δv·t`. The matched-filter
+//! stacked signal is the mean per-frame Gaussian overlap
+//! `⟨exp(−Δ(t)²/4θ²)⟩`, so to leading order the fractional SNR loss is
+//!
+//!   L(δv) = ⟨Δ²⟩ / (4θ²) = (δv² T²/12) / (4θ²) = ½ g_vv δv²,
+//!   g_vv = T² / (24 θ²).
+//!
+//! `g_vv` is one element of the Fisher metric on orbit space (Geringer-Sameth
+//! et al. 2025). It sharpens as `T²`, so a multi-year baseline needs an
+//! extremely fine rate grid — hence *billions* of trial orbits — while also
+//! making each individual track far more constraining.
+
+use p9_core::constants::{GM_SUN, PC_AU};
+use p9_core::types::P9Params;
+
+/// Rate-error metric coefficient `g_vv = T²/(24 θ²)` (units: (arcsec/day)⁻²).
+pub fn metric_g_vv(psf_arcsec: f64, baseline_days: f64) -> f64 {
+    baseline_days * baseline_days / (24.0 * psf_arcsec * psf_arcsec)
+}
+
+/// Quadratic (leading-order) retained SNR fraction for a rate error.
+pub fn snr_retained_quadratic(psf_arcsec: f64, baseline_days: f64, rate_error: f64) -> f64 {
+    let l = 0.5 * metric_g_vv(psf_arcsec, baseline_days) * rate_error * rate_error;
+    (1.0 - l).max(0.0)
+}
+
+/// Exact retained SNR fraction: the mean per-frame Gaussian overlap over a
+/// uniformly-sampled baseline.
+pub fn snr_retained_exact(
+    psf_arcsec: f64,
+    baseline_days: f64,
+    rate_error: f64,
+    n_samples: usize,
+) -> f64 {
+    let n = n_samples.max(2);
+    let theta2 = psf_arcsec * psf_arcsec;
+    let mut sum = 0.0;
+    for k in 0..n {
+        // t uniform in [-T/2, T/2]
+        let t = baseline_days * (k as f64 / (n as f64 - 1.0) - 0.5);
+        let delta = rate_error * t;
+        sum += (-delta * delta / (4.0 * theta2)).exp();
+    }
+    sum / n as f64
+}
+
+/// Rate resolution (cell half-width, arcsec/day) at which the SNR loss reaches
+/// the tolerance `1 − snr_tolerance`: δv = (θ/T)·√(48·(1−η)).
+pub fn rate_resolution(psf_arcsec: f64, baseline_days: f64, snr_tolerance: f64) -> f64 {
+    (psf_arcsec / baseline_days) * (48.0 * (1.0 - snr_tolerance)).sqrt()
+}
+
+/// Number of rate cells along one sky axis spanning `rate_range` (arcsec/day),
+/// at the given SNR tolerance and baseline.
+pub fn n_rate_cells_1d(
+    rate_range: f64,
+    psf_arcsec: f64,
+    baseline_days: f64,
+    snr_tolerance: f64,
+) -> f64 {
+    rate_range / (2.0 * rate_resolution(psf_arcsec, baseline_days, snr_tolerance))
+}
+
+/// Number of trial orbits for a linear two-dimensional on-sky velocity search
+/// (the rate hypotheses; start position is read off the stacked image, not a
+/// separate trial). Equals the square of the per-axis rate-cell count.
+pub fn n_trial_orbits(
+    rate_range: f64,
+    psf_arcsec: f64,
+    baseline_days: f64,
+    snr_tolerance: f64,
+) -> f64 {
+    let n1d = n_rate_cells_1d(rate_range, psf_arcsec, baseline_days, snr_tolerance);
+    n1d * n1d
+}
+
+/// Planet Nine's heliocentric orbital angular rate projected on the sky
+/// (arcsec/day), from its mean motion n = √(GM☉/a³): a slow mover that any
+/// solar-system rate grid easily contains and a multi-year baseline resolves.
+pub fn p9_orbital_sky_rate(p9: &P9Params) -> f64 {
+    let n_rad_per_day = (GM_SUN / p9.a.powi(3)).sqrt();
+    n_rad_per_day * PC_AU // rad/day × (arcsec/rad)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    // ZTF-like single field, six-year baseline.
+    const PSF: f64 = 1.0; // arcsec, 1σ
+    const T6YR: f64 = 6.0 * 365.25; // days
+    const RATE_RANGE: f64 = 40.0; // arcsec/day, covering distant→fast movers
+
+    #[test]
+    fn metric_quadratic_matches_exact_for_small_error() {
+        // pick the rate error that the quadratic metric says costs 5% SNR …
+        let dv = rate_resolution(PSF, T6YR, 0.95);
+        assert_relative_eq!(snr_retained_quadratic(PSF, T6YR, dv), 0.95, epsilon = 1e-9);
+        // … and the exact Gaussian-overlap stack agrees to ~1%.
+        let exact = snr_retained_exact(PSF, T6YR, dv, 4001);
+        assert!((exact - 0.95).abs() < 0.02, "exact retained = {exact}");
+    }
+
+    #[test]
+    fn rate_resolution_sharpens_inversely_with_baseline() {
+        let r_full = rate_resolution(PSF, T6YR, 0.9);
+        let r_half = rate_resolution(PSF, T6YR / 2.0, 0.9);
+        assert_relative_eq!(r_half / r_full, 2.0, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn ztf_six_year_search_needs_order_billion_trial_orbits() {
+        let n = n_trial_orbits(RATE_RANGE, PSF, T6YR, 0.9);
+        assert!((1.0e7..1.0e11).contains(&n), "trial orbits = {n:.3e}");
+    }
+
+    #[test]
+    fn trial_orbits_scale_as_baseline_squared() {
+        let n_full = n_trial_orbits(RATE_RANGE, PSF, T6YR, 0.9);
+        let n_half = n_trial_orbits(RATE_RANGE, PSF, T6YR / 2.0, 0.9);
+        assert_relative_eq!(n_full / n_half, 4.0, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn multi_year_dwarfs_single_night_in_trial_count() {
+        let n_6yr = n_trial_orbits(RATE_RANGE, PSF, T6YR, 0.9);
+        let n_night = n_trial_orbits(RATE_RANGE, PSF, 0.3, 0.9);
+        assert!(n_6yr / n_night > 1.0e6, "ratio = {:.2e}", n_6yr / n_night);
+    }
+
+    #[test]
+    fn planet_nine_sits_inside_and_is_resolved_by_the_grid() {
+        let rate = p9_orbital_sky_rate(&P9Params::mcmc_2021());
+        // P9 is a slow mover (~tenths of an arcsec/day) …
+        assert!(
+            (0.1..1.0).contains(&rate),
+            "P9 sky rate = {rate} arcsec/day"
+        );
+        // … comfortably inside the search's rate range …
+        assert!(rate < RATE_RANGE);
+        // … and far coarser than the six-year rate resolution, so it is well
+        // localised by the metric (many cells across its rate).
+        assert!(rate > 10.0 * rate_resolution(PSF, T6YR, 0.9));
+    }
+}

--- a/crates/p9-2025-stacking/src/significance.rs
+++ b/crates/p9-2025-stacking/src/significance.rs
@@ -1,0 +1,138 @@
+//! The look-elsewhere (trials) penalty for a blind stacking search.
+//!
+//! Searching `n_trials` independent orbit hypotheses inflates the chance of a
+//! noise fluctuation passing threshold somewhere: the global false-alarm
+//! probability is ≈ n_trials × (per-trial tail). To hold a fixed *global*
+//! false-alarm probability the per-trial detection threshold must rise to
+//! z ≈ Φ⁻¹(1 − α/n_trials) ≈ √(2 ln n_trials). The point of the paper — and the
+//! reason searching billions of orbits is worthwhile — is that this penalty is
+//! only *logarithmic* in the trial count: it costs a few tenths of a magnitude,
+//! against the several magnitudes the stack itself buys.
+
+use crate::matched_filter::stack_depth_gain_mag;
+
+/// Standard-normal quantile Φ⁻¹(p) (Acklam's rational approximation,
+/// |error| ≲ 1e-9 across the tails).
+pub fn normal_quantile(p: f64) -> f64 {
+    assert!(p > 0.0 && p < 1.0, "p must be in (0,1), got {p}");
+    const A: [f64; 6] = [
+        -3.969683028665376e+01,
+        2.209460984245205e+02,
+        -2.759285104469687e+02,
+        1.383577518672690e+02,
+        -3.066479806614716e+01,
+        2.506628277459239e+00,
+    ];
+    const B: [f64; 5] = [
+        -5.447609879822406e+01,
+        1.615858368580409e+02,
+        -1.556989798598866e+02,
+        6.680131188771972e+01,
+        -1.328068155288572e+01,
+    ];
+    const C: [f64; 6] = [
+        -7.784894002430293e-03,
+        -3.223964580411365e-01,
+        -2.400758277161838e+00,
+        -2.549732539343734e+00,
+        4.374664141464968e+00,
+        2.938163982698783e+00,
+    ];
+    const D: [f64; 4] = [
+        7.784695709041462e-03,
+        3.224671290700398e-01,
+        2.445134137142996e+00,
+        3.754408661907416e+00,
+    ];
+    let plow = 0.02425;
+    let phigh = 1.0 - plow;
+    if p < plow {
+        let q = (-2.0 * p.ln()).sqrt();
+        (((((C[0] * q + C[1]) * q + C[2]) * q + C[3]) * q + C[4]) * q + C[5])
+            / ((((D[0] * q + D[1]) * q + D[2]) * q + D[3]) * q + 1.0)
+    } else if p <= phigh {
+        let q = p - 0.5;
+        let r = q * q;
+        (((((A[0] * r + A[1]) * r + A[2]) * r + A[3]) * r + A[4]) * r + A[5]) * q
+            / (((((B[0] * r + B[1]) * r + B[2]) * r + B[3]) * r + B[4]) * r + 1.0)
+    } else {
+        let q = (-2.0 * (1.0 - p).ln()).sqrt();
+        -(((((C[0] * q + C[1]) * q + C[2]) * q + C[3]) * q + C[4]) * q + C[5])
+            / ((((D[0] * q + D[1]) * q + D[2]) * q + D[3]) * q + 1.0)
+    }
+}
+
+/// Per-trial detection threshold (in σ) needed to keep the *global* false-alarm
+/// probability at `global_alpha` while searching `n_trials` hypotheses:
+/// z = Φ⁻¹(1 − α/n_trials), computed via the lower tail for accuracy.
+pub fn look_elsewhere_threshold_sigma(n_trials: f64, global_alpha: f64) -> f64 {
+    let per_trial_tail = global_alpha / n_trials;
+    -normal_quantile(per_trial_tail)
+}
+
+/// The √(2 ln N) asymptotic form of the trials threshold (no α dependence).
+pub fn asymptotic_threshold_sigma(n_trials: f64) -> f64 {
+    (2.0 * n_trials.ln()).sqrt()
+}
+
+/// Extra limiting-magnitude cost of raising the detection threshold from
+/// `baseline_sigma` (e.g. a naive 5σ) to `threshold_sigma`: Δm = 2.5·log₁₀(z/z₀)
+/// (limiting flux ∝ threshold SNR).
+pub fn trials_penalty_mag(threshold_sigma: f64, baseline_sigma: f64) -> f64 {
+    2.5 * (threshold_sigma / baseline_sigma).log10()
+}
+
+/// Net limiting-magnitude gain of the search: the √N stacking depth gain minus
+/// the look-elsewhere penalty of searching `n_trials` orbits at global FAP
+/// `global_alpha` (relative to a `baseline_sigma` single-trial threshold).
+pub fn net_depth_gain_mag(
+    n_frames: usize,
+    n_trials: f64,
+    global_alpha: f64,
+    baseline_sigma: f64,
+) -> f64 {
+    let z = look_elsewhere_threshold_sigma(n_trials, global_alpha);
+    stack_depth_gain_mag(n_frames) - trials_penalty_mag(z, baseline_sigma)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn normal_quantile_known_points() {
+        assert_relative_eq!(normal_quantile(0.975), 1.959964, epsilon = 1e-4);
+        assert_relative_eq!(normal_quantile(0.99865), 3.0, epsilon = 2e-3);
+        assert_relative_eq!(normal_quantile(0.5), 0.0, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn billions_of_trials_need_about_six_sigma() {
+        // ~10^9 trial orbits at 1% global false-alarm → ~6.5σ per-trial.
+        let z = look_elsewhere_threshold_sigma(1.0e9, 0.01);
+        assert!((6.0..7.2).contains(&z), "z = {z}");
+        // the √(2 ln N) rule is close.
+        assert_relative_eq!(asymptotic_threshold_sigma(1.0e9), 6.44, epsilon = 0.1);
+    }
+
+    #[test]
+    fn trials_penalty_is_cheap_versus_stacking_gain() {
+        // The billions-of-trials penalty costs only a few tenths of a mag …
+        let z = look_elsewhere_threshold_sigma(1.0e9, 0.01);
+        let penalty = trials_penalty_mag(z, 5.0);
+        assert!(penalty < 0.5, "penalty = {penalty} mag");
+        // … while stacking ~10^5 frames buys ~6 mag, so the net gain stays
+        // multi-magnitude despite searching a billion orbits.
+        let net = net_depth_gain_mag(100_000, 1.0e9, 0.01, 5.0);
+        assert!(net > 5.0, "net gain = {net} mag");
+    }
+
+    #[test]
+    fn threshold_grows_with_trials_but_only_logarithmically() {
+        let z6 = look_elsewhere_threshold_sigma(1.0e6, 0.01);
+        let z12 = look_elsewhere_threshold_sigma(1.0e12, 0.01);
+        // a million-fold more trials raises the bar by < 2.5σ.
+        assert!(z12 > z6 && z12 - z6 < 2.5, "z6={z6}, z12={z12}");
+    }
+}


### PR DESCRIPTION
Reproduces Geringer-Sameth, Golovich & Iwabuchi 2025, "Multi-year stacking searches for solar system bodies" (arXiv:2509.25428) — the detection-method paper from the gap doc's "very recent" category. Closes #128.

`p9-2025-stacking` reproduces the analytic backbone of the method (real, pinned):
- **matched_filter** — √N stacked SNR and the 1.25·log₁₀N depth gain; a 20.5-mag ZTF exposure reaches ~27th mag with ~1.6×10⁵ stacked frames.
- **orbit_metric** — the orbit-parameter Fisher metric: SNR loss is *quadratic* in rate error, `g_vv = T²/(24θ²)` (cross-checked against the exact Gaussian-overlap stack to ~1%); rate resolution sharpens as 1/T, so a ZTF six-year baseline needs ~10⁸–10⁹ trial orbits, scaling as T². Includes a Planet 9 tie-in (its ~0.3″/day orbital rate sits well inside, and is finely resolved by, the grid).
- **significance** — the look-elsewhere penalty: ~10⁹ trial orbits → ~6.5σ per-trial threshold (≈√(2 ln N)), costing only ~0.3 mag vs the multi-magnitude stacking gain. That asymmetry — depth gain ≫ trials penalty — is the headline.

Complements `p9-survey`'s detectability tooling. Reductions (linear rate-only metric vs the full 5–6-element orbit metric; √N-extrapolated 27-mag reach) documented in REPRODUCTION_NOTES.md §24. 14 tests; `cargo build/test/fmt` green.