### PR TITLE
Add Naess 2021 ACT millimeter Planet Nine search crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,6 +1543,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "p9-2021-act-mm"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "p9-2018-wise-search",
+ "p9-core",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "p9-2021-detached-inclinations"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "crates/p9-2021-oort-cloud",
     "crates/p9-2021-napier-critique",
     "crates/p9-2021-orbit",
+    "crates/p9-2021-act-mm",
     "crates/p9-2021-detached-inclinations",
     "crates/p9-2021-stability",
     "crates/p9-2021-ztf",

--- a/crates/p9-2021-act-mm/Cargo.toml
+++ b/crates/p9-2021-act-mm/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "p9-2021-act-mm"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+p9-core = { path = "../p9-core" }
+p9-2018-wise-search = { path = "../p9-2018-wise-search" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/p9-2021-act-mm/src/detectability.rs
+++ b/crates/p9-2021-act-mm/src/detectability.rs
@@ -1,0 +1,223 @@
+//! Maximum mm detectable distance, the mm-vs-WISE reach comparison, and an
+//! estimate of the number of spurious candidates over the ACT footprint.
+//!
+//! Because the mm flux density falls monotonically as 1/d² (radius and the
+//! cold internal temperature being essentially distance-independent beyond a
+//! few hundred AU), the maximum detectable distance has a closed form: the
+//! flux equals the survey limit when
+//!
+//!   F_ν(d) = π B_ν(T) (R/d)² = S_lim   ⟹   d_max = R √(π B_ν(T) / S_lim).
+//!
+//! We solve it directly (and cross-check by bisection in the tests). The
+//! headline of Naess et al. (2021) is that this d_max is a *large* number —
+//! hundreds of AU — whereas the same cold body is essentially invisible in
+//! WISE W1 (where the thermal channel is buried under the Wien cliff and only
+//! reflected sunlight survives).
+
+use p9_2018_wise_search::detectability::max_detectable_distance as wise_max_distance;
+use p9_2018_wise_search::survey_model::WiseSurvey;
+use p9_core::constants::AU_M;
+
+use crate::survey_model::ActSurvey;
+use crate::thermal_model::{planck_bnu, P9Millimeter, MJY};
+
+/// Whether a P9 of `mass_earth` at `distance_au` is at or above the ACT flux
+/// limit at the survey frequency.
+pub fn is_detectable(survey: &ActSurvey, mass_earth: f64, distance_au: f64) -> bool {
+    P9Millimeter::new(mass_earth, distance_au).flux_density_mjy(survey.frequency_hz)
+        >= survey.flux_limit_mjy
+}
+
+/// Maximum heliocentric distance (AU) at which a P9 of `mass_earth` reaches the
+/// ACT flux limit, from the closed-form 1/d² inversion. The temperature/radius
+/// are taken at a fiducial 500 AU (cold internal floor, distance-independent).
+pub fn max_detectable_distance(survey: &ActSurvey, mass_earth: f64) -> f64 {
+    let p = P9Millimeter::new(mass_earth, 500.0);
+    let bnu = planck_bnu(p.effective_temp(), survey.frequency_hz);
+    let r = p.radius_m();
+    let s_lim = survey.flux_limit_mjy * MJY; // W/m²/Hz
+    let d_m = r * (std::f64::consts::PI * bnu / s_lim).sqrt();
+    d_m / AU_M
+}
+
+/// The mm-band reach for a cold P9 at the ACT 150 GHz limit, paired with the
+/// WISE W1 reach for the *same* body. The mm number should vastly exceed W1.
+#[derive(Debug, Clone, Copy)]
+pub struct ReachComparison {
+    pub mass_earth: f64,
+    /// ACT mm maximum detectable distance (AU).
+    pub act_mm_au: f64,
+    /// WISE W1 maximum detectable distance (AU), or None if undetectable.
+    pub wise_w1_au: Option<f64>,
+}
+
+/// Compare ACT mm vs WISE W1 reach for a given mass.
+pub fn compare_reach(act: &ActSurvey, mass_earth: f64) -> ReachComparison {
+    ReachComparison {
+        mass_earth,
+        act_mm_au: max_detectable_distance(act, mass_earth),
+        wise_w1_au: wise_max_distance(&WiseSurvey::default(), mass_earth),
+    }
+}
+
+/// Expected number of spurious candidates over the search footprint, given a
+/// surface density `sources_per_deg2` of noise peaks / confusing point sources
+/// above the detection threshold. A pure-Poisson area scaling:
+///
+///   N_spurious = ρ · A.
+///
+/// This is the quantity an mm point-source search must beat down (by the
+/// slow-motion linking that distinguishes a real outer-solar-system body from
+/// a static extragalactic source) before any candidate can be believed. The
+/// 10 published candidates are the strongest survivors of exactly this kind of
+/// winnowing.
+pub fn expected_spurious(survey: &ActSurvey, sources_per_deg2: f64) -> f64 {
+    sources_per_deg2 * survey.area_deg2
+}
+
+/// Expected number of pure-Gaussian-noise upward fluctuations above a
+/// `n_sigma` detection threshold, given `n_pixels_per_deg2` independent
+/// resolution elements per square degree. Uses the one-sided Gaussian tail
+/// probability Q(nσ) = ½ erfc(nσ/√2):
+///
+///   N = Q(nσ) · n_pixels_per_deg2 · A.
+pub fn expected_noise_peaks(survey: &ActSurvey, n_sigma: f64, n_pixels_per_deg2: f64) -> f64 {
+    let q = 0.5 * erfc(n_sigma / std::f64::consts::SQRT_2);
+    q * n_pixels_per_deg2 * survey.area_deg2
+}
+
+/// Complementary error function via the Abramowitz & Stegun 7.1.26 rational
+/// approximation (|error| < 1.5e-7), sufficient for tail-count estimates.
+fn erfc(x: f64) -> f64 {
+    let z = x.abs();
+    let t = 1.0 / (1.0 + 0.3275911 * z);
+    let poly = t
+        * (0.254829592
+            + t * (-0.284496736 + t * (1.421413741 + t * (-1.453152027 + t * 1.061405429))));
+    let erf = 1.0 - poly * (-z * z).exp();
+    if x >= 0.0 {
+        1.0 - erf
+    } else {
+        1.0 + erf
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::survey_model::{CANDIDATE_COUNT, NU_150_GHZ};
+
+    #[test]
+    fn closed_form_matches_bisection() {
+        let survey = ActSurvey::default();
+        let mass = 10.0;
+        let d_closed = max_detectable_distance(&survey, mass);
+
+        // Independent bisection on the monotone flux–distance relation.
+        let (mut lo, mut hi) = (50.0_f64, 50_000.0_f64);
+        for _ in 0..200 {
+            let mid = 0.5 * (lo + hi);
+            if is_detectable(&survey, mass, mid) {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        let d_bisect = 0.5 * (lo + hi);
+        assert!(
+            (d_closed - d_bisect).abs() / d_closed < 1e-4,
+            "closed {d_closed:.2} vs bisection {d_bisect:.2} AU"
+        );
+    }
+
+    #[test]
+    fn crossover_flux_equals_limit() {
+        let survey = ActSurvey::default();
+        let d = max_detectable_distance(&survey, 10.0);
+        let f = P9Millimeter::new(10.0, d).flux_density_mjy(NU_150_GHZ);
+        assert!(
+            (f - survey.flux_limit_mjy).abs() < 1e-6,
+            "F({d:.1} AU) = {f:.4} mJy"
+        );
+    }
+
+    #[test]
+    fn mm_reach_is_hundreds_of_au_and_finite() {
+        let survey = ActSurvey::default();
+        let d = max_detectable_distance(&survey, 10.0);
+        assert!(d.is_finite());
+        // A 10 M⊕ cold P9 is detectable out to several hundred AU at 8 mJy,
+        // consistent with Naess et al.'s 425–775 AU (4–12 mJy) range for 10 M⊕.
+        assert!((300.0..900.0).contains(&d), "d_max(10 M⊕) = {d:.0} AU");
+    }
+
+    #[test]
+    fn deeper_limit_reaches_farther() {
+        let m = 10.0;
+        let d_deep = max_detectable_distance(&ActSurvey::deepest(), m);
+        let d_shallow = max_detectable_distance(&ActSurvey::shallowest(), m);
+        assert!(
+            d_deep > d_shallow,
+            "deep {d_deep:.0} > shallow {d_shallow:.0} AU"
+        );
+        // The 4 mJy limit reaches √(12/4) = √3 ≈ 1.73× farther than 12 mJy.
+        assert!((d_deep / d_shallow - 3.0_f64.sqrt()).abs() < 1e-6);
+    }
+
+    #[test]
+    fn reach_grows_with_mass() {
+        let survey = ActSurvey::default();
+        let d5 = max_detectable_distance(&survey, 5.0);
+        let d10 = max_detectable_distance(&survey, 10.0);
+        assert!(d10 > d5, "10 M⊕ reach {d10:.0} > 5 M⊕ reach {d5:.0} AU");
+    }
+
+    #[test]
+    fn mm_vastly_outreaches_wise_w1_for_a_cold_body() {
+        // The headline: at the same cold (40 K) temperature, the mm band
+        // reaches a P9 at far greater distance than WISE W1, which for a cold
+        // body is essentially blind (W1 reach is set by reflected light and is
+        // limited to the low hundreds of AU even at high mass).
+        let cmp = compare_reach(&ActSurvey::default(), 10.0);
+        let w1 = cmp.wise_w1_au.expect("W1 reach finite for 10 M⊕");
+        assert!(
+            cmp.act_mm_au > 2.0 * w1,
+            "ACT mm reach {:.0} AU should far exceed WISE W1 {:.0} AU",
+            cmp.act_mm_au,
+            w1
+        );
+    }
+
+    #[test]
+    fn spurious_count_scales_with_area_and_density() {
+        let survey = ActSurvey::default();
+        // A modest 1e-3 confusing sources per deg² over 18,000 deg² → 18.
+        let n = expected_spurious(&survey, 1.0e-3);
+        assert!((n - 18.0).abs() < 1e-9, "N_spurious = {n}");
+        // Linear in density.
+        assert!((expected_spurious(&survey, 2.0e-3) - 2.0 * n).abs() < 1e-9);
+    }
+
+    #[test]
+    fn noise_peak_count_is_plausible_for_a_candidate_list() {
+        // A high (5σ) threshold over a finely sampled map still yields a
+        // handful of pure-noise peaks across 18,000 deg² — the population from
+        // which the 10 published candidates were winnowed. With ~1e4 beams per
+        // deg² and 5σ (Q ≈ 2.87e-7), N ≈ 5e2; the slow-motion + multi-frequency
+        // linking knocks that down to the ~10 strongest survivors.
+        let survey = ActSurvey::default();
+        let n = expected_noise_peaks(&survey, 5.0, 1.0e4);
+        assert!(n > 1.0, "expected some 5σ noise peaks, got {n:.1}");
+        // Sanity: the published candidate list is short.
+        assert_eq!(CANDIDATE_COUNT, 10);
+    }
+
+    #[test]
+    fn erfc_reference_values() {
+        // erfc(0) = 1, erfc large → 0, and the 5σ one-sided tail.
+        assert!((super::erfc(0.0) - 1.0).abs() < 1e-6);
+        assert!(super::erfc(5.0) < 1e-10);
+        let q5 = 0.5 * super::erfc(5.0 / std::f64::consts::SQRT_2);
+        assert!((q5 - 2.866e-7).abs() < 1e-8, "Q(5σ) = {q5:e}");
+    }
+}

--- a/crates/p9-2021-act-mm/src/lib.rs
+++ b/crates/p9-2021-act-mm/src/lib.rs
@@ -1,0 +1,29 @@
+//! Reproduction of Naess et al. (2021), "The Atacama Cosmology Telescope: A
+//! search for Planet 9" (arXiv:2104.10264).
+//!
+//! A cold (~40 K) Planet Nine is hopeless in the near-IR (the WISE W1 thermal
+//! flux sits far down the Wien tail; see `p9-2018-wise-search`) but is
+//! comparatively bright at millimeter wavelengths, where ACT's 98/150/229 GHz
+//! maps are sensitive. At 150 GHz a 40 K body is deep on the **Rayleigh–Jeans**
+//! tail (hν/kT ≈ 0.18), so its flux scales as ν²·T rather than collapsing
+//! exponentially. A blind ACT search over ~18,000 deg² found candidate
+//! sources but no confirmed Planet Nine, setting a 95%-confidence point-source
+//! limit of 4–12 mJy at 150 GHz.
+//!
+//! What this crate computes (no hard-coded answers):
+//! - [`thermal_model`]: the mm-band blackbody flux density of a P9 of given
+//!   effective temperature, radius (Neptune mass–radius) and distance, both
+//!   exact-Planck and Rayleigh–Jeans, reusing the WISE crate's [`P9Thermal`].
+//! - [`survey_model`]: the ACT search frequencies, the 4–12 mJy point-source
+//!   limit, the ~18,000 deg² footprint and the 10-candidate count, as labelled
+//!   reference constants.
+//! - [`detectability`]: the maximum heliocentric distance at which a P9 reaches
+//!   the ACT flux limit (closed-form 1/d² inversion, cross-checked by
+//!   bisection), the mm-vs-WISE-W1 reach comparison, and an estimate of the
+//!   expected number of spurious candidates over the footprint.
+//!
+//! [`P9Thermal`]: p9_2018_wise_search::thermal_model::P9Thermal
+
+pub mod detectability;
+pub mod survey_model;
+pub mod thermal_model;

--- a/crates/p9-2021-act-mm/src/survey_model.rs
+++ b/crates/p9-2021-act-mm/src/survey_model.rs
@@ -1,0 +1,123 @@
+//! ACT millimeter survey parameters: frequencies, point-source sensitivity,
+//! footprint, and the published candidate count.
+//!
+//! Naess et al. (2021), "The Atacama Cosmology Telescope: A search for Planet
+//! 9" (arXiv:2104.10264), searched ACT maps at 98, 150 and 229 GHz over
+//! ~18,000 deg² for a slowly moving mm point source. The 150 GHz channel sets
+//! the headline 95%-confidence point-source flux limit of 4–12 mJy (position
+//! dependent). The blind search returned a list of candidate sources of which
+//! the 10 strongest were flagged for follow-up; none were confirmed as Planet
+//! Nine. All numbers below are labelled reference constants from the paper.
+
+/// ACT 90 GHz ("f090") band center, Hz.
+pub const NU_98_GHZ: f64 = 98.0e9;
+/// ACT 150 GHz ("f150") band center, Hz — the headline search band.
+pub const NU_150_GHZ: f64 = 150.0e9;
+/// ACT 220 GHz ("f220", 229 GHz effective) band center, Hz.
+pub const NU_229_GHZ: f64 = 229.0e9;
+
+/// 95%-confidence point-source flux limit at 150 GHz (mJy). Position dependent;
+/// the paper quotes 4–12 mJy. We adopt a representative value for the nominal
+/// detectability calculation and pin the published range in tests.
+pub const FLUX_LIMIT_150_MJY: f64 = 8.0;
+
+/// Published lower/upper bounds of the position-dependent 150 GHz flux limit
+/// (mJy): "4–12 mJy depending on position" (Naess et al. 2021).
+pub const FLUX_LIMIT_150_MIN_MJY: f64 = 4.0;
+pub const FLUX_LIMIT_150_MAX_MJY: f64 = 12.0;
+
+/// Search footprint in square degrees (Naess et al. 2021, ~18,000 deg²).
+pub const SEARCH_AREA_DEG2: f64 = 18_000.0;
+
+/// Number of strongest candidate sources flagged for follow-up (Naess et al.
+/// 2021). None were confirmed as Planet Nine.
+pub const CANDIDATE_COUNT: usize = 10;
+
+/// The ACT mm point-source search configuration.
+#[derive(Debug, Clone, Copy)]
+pub struct ActSurvey {
+    /// 95%-confidence point-source flux limit at the search frequency (mJy).
+    pub flux_limit_mjy: f64,
+    /// Search frequency (Hz).
+    pub frequency_hz: f64,
+    /// Footprint area (deg²).
+    pub area_deg2: f64,
+}
+
+impl Default for ActSurvey {
+    /// The nominal 150 GHz ACT search at the representative flux limit over the
+    /// full ~18,000 deg² footprint.
+    fn default() -> Self {
+        Self {
+            flux_limit_mjy: FLUX_LIMIT_150_MJY,
+            frequency_hz: NU_150_GHZ,
+            area_deg2: SEARCH_AREA_DEG2,
+        }
+    }
+}
+
+impl ActSurvey {
+    /// The ACT search at the deepest (best, 4 mJy) position-dependent limit.
+    pub fn deepest() -> Self {
+        Self {
+            flux_limit_mjy: FLUX_LIMIT_150_MIN_MJY,
+            ..Self::default()
+        }
+    }
+
+    /// The ACT search at the shallowest (12 mJy) position-dependent limit.
+    pub fn shallowest() -> Self {
+        Self {
+            flux_limit_mjy: FLUX_LIMIT_150_MAX_MJY,
+            ..Self::default()
+        }
+    }
+
+    /// Total sky area in steradians (for spurious-rate estimates).
+    pub fn area_sr(&self) -> f64 {
+        let deg2_per_sr = (180.0 / std::f64::consts::PI).powi(2);
+        self.area_deg2 / deg2_per_sr
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn representative_limit_lies_in_published_range() {
+        assert!((FLUX_LIMIT_150_MIN_MJY..=FLUX_LIMIT_150_MAX_MJY).contains(&FLUX_LIMIT_150_MJY));
+    }
+
+    #[test]
+    fn frequencies_ordered_and_in_mm_band() {
+        assert!(NU_98_GHZ < NU_150_GHZ && NU_150_GHZ < NU_229_GHZ);
+        // mm/sub-mm band: tens to hundreds of GHz.
+        assert!(NU_98_GHZ > 50.0e9 && NU_229_GHZ < 400.0e9);
+    }
+
+    #[test]
+    fn footprint_is_thousands_of_square_degrees() {
+        // ~18,000 deg² out of 41,253 deg² all-sky: ~44% of the sky.
+        let all_sky = 41_252.96;
+        let frac = SEARCH_AREA_DEG2 / all_sky;
+        assert!((0.3..0.5).contains(&frac), "footprint fraction = {frac:.2}");
+    }
+
+    #[test]
+    fn area_in_steradians_consistent() {
+        let s = ActSurvey::default();
+        // 18,000 deg² ≈ 5.48 sr.
+        assert!(
+            (s.area_sr() - 5.48).abs() < 0.05,
+            "area = {:.3} sr",
+            s.area_sr()
+        );
+    }
+
+    #[test]
+    fn deepest_and_shallowest_bracket_the_default() {
+        assert!(ActSurvey::deepest().flux_limit_mjy < ActSurvey::default().flux_limit_mjy);
+        assert!(ActSurvey::shallowest().flux_limit_mjy > ActSurvey::default().flux_limit_mjy);
+    }
+}

--- a/crates/p9-2021-act-mm/src/thermal_model.rs
+++ b/crates/p9-2021-act-mm/src/thermal_model.rs
@@ -1,0 +1,217 @@
+//! Millimeter-wave thermal emission of a cold Planet Nine.
+//!
+//! Naess et al. (2021) point out that a cold (~30–50 K) Planet Nine, although
+//! hopeless to detect thermally in the near-IR WISE bands (a 40 K body sits far
+//! down the Wien tail at 3.4 µm; see `p9-2018-wise-search`), is comparatively
+//! *bright* at millimeter wavelengths. At ACT's 150 GHz the photon energy is
+//!
+//!   hν/kT = h(150 GHz)/(k·40 K) ≈ 0.18,
+//!
+//! so the body is firmly on the **Rayleigh–Jeans** tail (hν ≪ kT), where the
+//! Planck function reduces to B_ν ≈ 2 ν² k T / c² and the flux scales as ν²·T
+//! rather than the exp(−hν/kT) cliff of the IR. The flux density of an
+//! unresolved grey body of physical radius R at distance d is
+//!
+//!   F_ν = π B_ν(T) (R/d)²        [W/m²/Hz],
+//!
+//! the same solid-angle × Planck-brightness law used by the WISE crate's
+//! [`P9Thermal::thermal_flux_w1_jy`]. This module reuses that crate's
+//! [`P9Thermal`] for the cold-body effective temperature (internal-heat floor
+//! dominating solar heating beyond a few hundred AU) and the Neptune-anchored
+//! mass–radius relation, and evaluates the same Planck law at mm frequencies.
+
+use std::f64::consts::PI;
+
+use p9_2018_wise_search::thermal_model::P9Thermal;
+use p9_core::constants::AU_M;
+
+/// Planck constant (J·s).
+pub const H_PLANCK: f64 = 6.626_070_15e-34;
+/// Boltzmann constant (J/K).
+pub const K_BOLTZ: f64 = 1.380_649e-23;
+/// Speed of light (m/s).
+pub const C_LIGHT: f64 = 2.997_924_58e8;
+
+/// 1 Jansky in W/m²/Hz.
+pub const JY: f64 = 1.0e-26;
+/// 1 milliJansky in W/m²/Hz.
+pub const MJY: f64 = 1.0e-29;
+
+/// Planck function B_ν(T) in W/m²/Hz/sr at frequency `nu_hz`.
+///
+/// This is the exact Planck law; at ACT mm frequencies and ~40 K it is well
+/// approximated by [`rayleigh_jeans_bnu`] (the two agree to a few percent).
+pub fn planck_bnu(t: f64, nu_hz: f64) -> f64 {
+    let x = H_PLANCK * nu_hz / (K_BOLTZ * t);
+    if x > 700.0 {
+        return 0.0;
+    }
+    (2.0 * H_PLANCK * nu_hz.powi(3) / (C_LIGHT * C_LIGHT)) / (x.exp() - 1.0)
+}
+
+/// Rayleigh–Jeans brightness B_ν ≈ 2 ν² k T / c² (W/m²/Hz/sr). The low-energy
+/// (hν ≪ kT) limit of [`planck_bnu`]; explicitly ∝ ν²·T.
+pub fn rayleigh_jeans_bnu(t: f64, nu_hz: f64) -> f64 {
+    2.0 * nu_hz * nu_hz * K_BOLTZ * t / (C_LIGHT * C_LIGHT)
+}
+
+/// Dimensionless photon-energy parameter x = hν/kT. The Rayleigh–Jeans regime
+/// is x ≪ 1, the Wien regime x ≫ 1.
+pub fn photon_energy_ratio(t: f64, nu_hz: f64) -> f64 {
+    H_PLANCK * nu_hz / (K_BOLTZ * t)
+}
+
+/// A cold Planet Nine viewed at millimeter wavelengths. Wraps the WISE crate's
+/// [`P9Thermal`] (mass, distance, internal-temperature floor, Neptune-anchored
+/// radius) so the temperature and radius physics is shared, not duplicated.
+#[derive(Debug, Clone, Copy)]
+pub struct P9Millimeter {
+    /// Underlying thermal body (sets effective temperature and radius).
+    pub body: P9Thermal,
+}
+
+impl P9Millimeter {
+    /// A Planet Nine of `mass_earth` at heliocentric `distance_au` with the
+    /// default cold internal-temperature floor (≈40 K) from the WISE crate.
+    pub fn new(mass_earth: f64, distance_au: f64) -> Self {
+        Self {
+            body: P9Thermal::new(mass_earth, distance_au),
+        }
+    }
+
+    /// Override the internal-luminosity effective-temperature floor (K).
+    pub fn with_temperature(mut self, temp_k: f64) -> Self {
+        self.body.internal_temp_k = temp_k;
+        self
+    }
+
+    /// Effective temperature (K): the larger of solar heating and the internal
+    /// floor. At ACT-relevant distances this is the cold internal floor.
+    pub fn effective_temp(&self) -> f64 {
+        self.body.effective_temp()
+    }
+
+    /// Physical radius (m), Neptune-anchored mass–radius relation.
+    pub fn radius_m(&self) -> f64 {
+        self.body.radius_m()
+    }
+
+    /// Thermal mm flux density (W/m²/Hz) at frequency `nu_hz`, unit-emissivity
+    /// grey body: F_ν = π B_ν(T) (R/d)².
+    pub fn flux_density_si(&self, nu_hz: f64) -> f64 {
+        let bnu = planck_bnu(self.effective_temp(), nu_hz);
+        let r = self.radius_m();
+        let d = self.body.distance_au * AU_M;
+        PI * (r / d).powi(2) * bnu
+    }
+
+    /// Thermal mm flux density in milliJansky at `nu_hz` — the unit ACT
+    /// point-source sensitivities are quoted in.
+    pub fn flux_density_mjy(&self, nu_hz: f64) -> f64 {
+        self.flux_density_si(nu_hz) / MJY
+    }
+
+    /// Flux density in Jansky at `nu_hz`.
+    pub fn flux_density_jy(&self, nu_hz: f64) -> f64 {
+        self.flux_density_si(nu_hz) / JY
+    }
+
+    /// Rayleigh–Jeans approximation to the mm flux density (mJy), using
+    /// [`rayleigh_jeans_bnu`]. Differs from [`flux_density_mjy`] by the small
+    /// (few-percent) RJ correction at ACT frequencies.
+    pub fn flux_density_rj_mjy(&self, nu_hz: f64) -> f64 {
+        let bnu = rayleigh_jeans_bnu(self.effective_temp(), nu_hz);
+        let r = self.radius_m();
+        let d = self.body.distance_au * AU_M;
+        PI * (r / d).powi(2) * bnu / MJY
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p9_2018_wise_search::thermal_model::INTERNAL_TEMP_FLOOR_K;
+
+    /// ACT 150 GHz in Hz.
+    const NU_150: f64 = 150.0e9;
+
+    #[test]
+    fn cold_body_is_on_the_rayleigh_jeans_tail_at_mm() {
+        // At 150 GHz and the 40 K floor, hν/kT ≈ 0.18 ≪ 1: deep in the RJ
+        // regime, the opposite of WISE W1 where hν/kT ≈ 107 (Wien cliff).
+        let x = photon_energy_ratio(INTERNAL_TEMP_FLOOR_K, NU_150);
+        assert!(x < 0.25, "hν/kT = {x:.3} should be ≪ 1 (RJ regime)");
+
+        // The WISE-W1 ratio for the same 40 K body is enormous.
+        let nu_w1 = C_LIGHT / 3.3526e-6;
+        let x_w1 = photon_energy_ratio(INTERNAL_TEMP_FLOOR_K, nu_w1);
+        assert!(x_w1 > 100.0, "W1 hν/kT = {x_w1:.0} should be ≫ 1 (Wien)");
+    }
+
+    #[test]
+    fn planck_matches_rayleigh_jeans_at_mm() {
+        // On the RJ tail the exact Planck and RJ brightness agree to a few
+        // percent (the leading correction is (1 − x/2), x ≈ 0.18).
+        let p = P9Millimeter::new(10.0, 500.0);
+        let exact = p.flux_density_mjy(NU_150);
+        let rj = p.flux_density_rj_mjy(NU_150);
+        let rel = (rj - exact).abs() / exact;
+        assert!(rel < 0.12, "RJ vs Planck relative diff = {rel:.3}");
+        // RJ slightly over-predicts (it omits the −x/2 term).
+        assert!(rj > exact);
+    }
+
+    #[test]
+    fn flux_follows_rayleigh_jeans_nu_squared_times_t() {
+        // RJ brightness ∝ ν²·T at fixed geometry. Doubling ν quadruples flux;
+        // doubling T doubles it.
+        let p = P9Millimeter::new(10.0, 500.0);
+        let f1 = p.flux_density_rj_mjy(NU_150);
+        let f2 = p.flux_density_rj_mjy(2.0 * NU_150);
+        assert!((f2 / f1 - 4.0).abs() < 1e-9, "ν² scaling: {:.4}", f2 / f1);
+
+        let cold = P9Millimeter::new(10.0, 500.0).with_temperature(30.0);
+        let warm = P9Millimeter::new(10.0, 500.0).with_temperature(60.0);
+        let ratio = warm.flux_density_rj_mjy(NU_150) / cold.flux_density_rj_mjy(NU_150);
+        assert!((ratio - 2.0).abs() < 1e-9, "T scaling: {ratio:.4}");
+    }
+
+    #[test]
+    fn flux_falls_as_inverse_distance_squared() {
+        let near = P9Millimeter::new(10.0, 400.0).flux_density_mjy(NU_150);
+        let far = P9Millimeter::new(10.0, 800.0).flux_density_mjy(NU_150);
+        // Double the distance → quarter the flux (radius/temperature fixed).
+        assert!(
+            (near / far - 4.0).abs() < 1e-6,
+            "1/d² scaling: {:.4}",
+            near / far
+        );
+    }
+
+    #[test]
+    fn flux_scales_with_radius_squared() {
+        // F ∝ R². The Neptune relation gives R ∝ M^0.27, so flux ∝ M^0.54;
+        // here we verify the explicit R² law by comparing equal-T bodies of
+        // different radii at fixed distance.
+        let a = P9Millimeter::new(10.0, 500.0).with_temperature(40.0);
+        let b = P9Millimeter::new(20.0, 500.0).with_temperature(40.0);
+        let ratio_flux = b.flux_density_mjy(NU_150) / a.flux_density_mjy(NU_150);
+        let ratio_r2 = (b.radius_m() / a.radius_m()).powi(2);
+        assert!(
+            (ratio_flux - ratio_r2).abs() < 1e-6,
+            "flux ratio {ratio_flux:.4} should equal (R_b/R_a)² = {ratio_r2:.4}"
+        );
+    }
+
+    #[test]
+    fn mm_flux_of_nominal_p9_is_a_few_mjy() {
+        // A 10 M⊕, 40 K Planet Nine at 500 AU has a 150 GHz flux of order a
+        // few mJy — comparable to ACT's 4–12 mJy point-source limit, which is
+        // exactly why the mm search is feasible while WISE is not.
+        let f = P9Millimeter::new(10.0, 500.0).flux_density_mjy(NU_150);
+        assert!(
+            (0.5..50.0).contains(&f),
+            "F_150(10 M⊕, 500 AU) = {f:.2} mJy"
+        );
+    }
+}


### PR DESCRIPTION
Reproduces Naess et al. (2021), "The Atacama Cosmology Telescope: A search for Planet 9" (arXiv:2104.10264).

A cold (~40 K) Planet Nine is hopeless in the near-IR WISE bands (deep on the Wien cliff) but comparatively bright at millimeter wavelengths, where ACT's 98/150/229 GHz maps are sensitive. At 150 GHz a 40 K body sits on the Rayleigh-Jeans tail (hν/kT ≈ 0.18), so flux scales as ν²·T instead of collapsing exponentially.

New crate `p9-2021-act-mm` (reuses `p9-core` and the WISE crate's `P9Thermal` for temperature/radius — no duplicated thermal machinery):

- `thermal_model`: mm-band blackbody flux density (exact Planck and Rayleigh-Jeans) of a P9 of given temperature, radius (Neptune mass-radius), and distance.
- `survey_model`: ACT frequencies, the 4-12 mJy 150 GHz point-source limit, ~18,000 deg² footprint, and 10-candidate count, as labelled reference constants.
- `detectability`: closed-form 1/d² max detectable distance (cross-checked by bisection), mm-vs-WISE-W1 reach comparison, and expected spurious / noise-peak counts over the footprint.

Pinned in tests: RJ ∝ ν²T scaling, flux ∝ 1/d² and ∝ R²; max detectable distance is finite and several hundred AU (consistent with the paper's 425-775 AU for 10 M⊕ at 4-12 mJy), and far exceeds the WISE W1 reach for the same cold body.

All 20 tests pass; `cargo build`, `cargo test`, `cargo fmt` green.

Closes #133