### PR TITLE
Add Meisner 2016 WISE coadd reproduction crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,6 +1323,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "p9-2016-wise-coadd"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "p9-2018-wise-search",
+ "p9-core",
+ "rand 0.8.5",
+ "rand_distr",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "p9-2017-bias"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "crates/p9-2018-resonance",
     "crates/p9-2018-secular-dynamics",
     "crates/p9-2018-wise-search",
+    "crates/p9-2016-wise-coadd",
     "crates/p9-2018-low-perihelion",
     "crates/p9-2019-clustering",
     "crates/p9-2019-ossos-scattering",

--- a/crates/p9-2016-wise-coadd/Cargo.toml
+++ b/crates/p9-2016-wise-coadd/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "p9-2016-wise-coadd"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+p9-core = { path = "../p9-core" }
+p9-2018-wise-search = { path = "../p9-2018-wise-search" }
+rand = { workspace = true }
+rand_distr = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/p9-2016-wise-coadd/src/band.rs
+++ b/crates/p9-2016-wise-coadd/src/band.rs
@@ -1,0 +1,150 @@
+//! Band-parametrized WISE thermal+reflected model (W1 at 3.4 µm and W2 at
+//! 4.6 µm).
+//!
+//! The sibling crate `p9-2018-wise-search` fixes its `P9Thermal` to the W1
+//! band. The 2016 paper's headline is that the **W2 (4.6 µm)** band is more
+//! favorable than W1 for a *cold* Planet Nine, so this crate must evaluate the
+//! same thermal+reflected physics at two wavelengths. We reuse the sibling's
+//! [`P9Thermal`] verbatim for the planet's geometry (radius law, effective
+//! temperature, distances) and for the W1 numbers, and add a band-generic
+//! Planck/reflected evaluation here so the W2 magnitude is computed with the
+//! *identical* physics, only the wavelength and Vega zero point differing.
+//!
+//! Why W2 helps a cold body: at a fixed temperature `T`, the Planck flux on the
+//! Wien tail scales as exp(−hν/kT). Moving from W1 (ν = c/3.353 µm) to W2
+//! (ν = c/4.603 µm) lowers hν/kT by the wavelength ratio 4.603/3.353 ≈ 1.37, so
+//! the thermal flux rises by a factor ~exp[(hc/kT)(1/λ₁ − 1/λ₂)]. For a 40 K
+//! body that is an enormous factor — W2 sits far less deep on the Wien tail.
+
+use std::f64::consts::PI;
+
+use p9_2018_wise_search::thermal_model::P9Thermal;
+
+/// Physical constants (mirrors of the sibling's, kept local so the band-generic
+/// Planck evaluation is self-contained).
+const H_PLANCK: f64 = 6.626_070_15e-34;
+const K_BOLTZ: f64 = 1.380_649e-23;
+const C_LIGHT: f64 = 2.997_924_58e8;
+const AU_M: f64 = 1.495_978_707e11;
+const R_SUN_M: f64 = 6.957e8;
+const T_SUN: f64 = 5778.0;
+const JY: f64 = 1.0e-26;
+
+/// A WISE photometric band: effective wavelength and Vega zero-point flux
+/// density (Wright et al. 2010, Table 1).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct WiseBand {
+    /// Short label, "W1" or "W2".
+    pub name: &'static str,
+    /// Effective wavelength in meters.
+    pub wavelength_m: f64,
+    /// Vega zero-point flux density in Jansky (0.0 mag source).
+    pub zero_point_jy: f64,
+}
+
+/// WISE W1 (3.3526 µm, F_ν0 = 309.540 Jy; Wright et al. 2010, Table 1).
+pub const W1: WiseBand = WiseBand {
+    name: "W1",
+    wavelength_m: p9_2018_wise_search::thermal_model::W1_WAVELENGTH_M,
+    zero_point_jy: p9_2018_wise_search::thermal_model::W1_ZERO_POINT_JY,
+};
+
+/// WISE W2 (4.6028 µm, F_ν0 = 171.787 Jy; Wright et al. 2010, Table 1).
+pub const W2: WiseBand = WiseBand {
+    name: "W2",
+    wavelength_m: 4.6028e-6,
+    zero_point_jy: 171.787,
+};
+
+/// Planck function B_ν(T) in W/m²/Hz/sr at frequency `nu_hz` (identical to the
+/// sibling's; under-/overflow guarded on the Wien tail).
+fn planck_bnu(t: f64, nu_hz: f64) -> f64 {
+    let x = H_PLANCK * nu_hz / (K_BOLTZ * t);
+    if x > 700.0 {
+        return 0.0;
+    }
+    (2.0 * H_PLANCK * nu_hz.powi(3) / (C_LIGHT * C_LIGHT)) / (x.exp() - 1.0)
+}
+
+/// Thermal grey-body flux density (Jy) of `p9` in `band`: F_ν = π B_ν(T)(R/d)².
+pub fn thermal_flux_jy(p9: &P9Thermal, band: WiseBand) -> f64 {
+    let nu = C_LIGHT / band.wavelength_m;
+    let bnu = planck_bnu(p9.effective_temp(), nu);
+    let r = p9.radius_m();
+    let d = p9.distance_au * AU_M;
+    let solid_angle = PI * (r / d).powi(2);
+    solid_angle * bnu / JY
+}
+
+/// Reflected-sunlight flux density (Jy) of `p9` in `band`, near opposition
+/// (Δ = d − 1 AU). Same geometry as the sibling's W1 reflected channel.
+pub fn reflected_flux_jy(p9: &P9Thermal, band: WiseBand) -> f64 {
+    let nu = C_LIGHT / band.wavelength_m;
+    let bnu_sun = planck_bnu(T_SUN, nu);
+    let r_p = p9.radius_m();
+    let solar_flux_at_planet = PI * bnu_sun * (R_SUN_M / (p9.distance_au * AU_M)).powi(2);
+    let delta_m = (p9.distance_au - 1.0).max(1.0) * AU_M;
+    let reflected = p9.albedo * solar_flux_at_planet * (r_p * r_p) / (4.0 * delta_m * delta_m);
+    reflected / JY
+}
+
+/// Total flux density (Jy) of `p9` in `band`: thermal + reflected.
+pub fn total_flux_jy(p9: &P9Thermal, band: WiseBand) -> f64 {
+    thermal_flux_jy(p9, band) + reflected_flux_jy(p9, band)
+}
+
+/// Apparent Vega magnitude of `p9` in `band` from the total flux density;
+/// +∞ for zero flux.
+pub fn magnitude(p9: &P9Thermal, band: WiseBand) -> f64 {
+    let flux = total_flux_jy(p9, band);
+    if flux <= 0.0 {
+        return f64::INFINITY;
+    }
+    -2.5 * (flux / band.zero_point_jy).log10()
+}
+
+/// Convenience: apparent `band` magnitude of a default-albedo P9 of
+/// `mass_earth` at `distance_au`.
+pub fn band_magnitude(mass_earth: f64, distance_au: f64, band: WiseBand) -> f64 {
+    magnitude(&P9Thermal::new(mass_earth, distance_au), band)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn w1_matches_sibling_exactly() {
+        // The band-generic W1 evaluation must reproduce the sibling's W1
+        // magnitude to round-off (same physics, same constants).
+        let p9 = P9Thermal::new(10.0, 500.0);
+        assert_relative_eq!(magnitude(&p9, W1), p9.w1_magnitude(), max_relative = 1e-12);
+    }
+
+    #[test]
+    fn w2_thermal_far_exceeds_w1_for_cold_body() {
+        // For a cold (40 K floor) body, W2 sits much less deep on the Wien tail,
+        // so its thermal flux dwarfs W1's.
+        let p9 = P9Thermal::new(10.0, 500.0);
+        let ratio = thermal_flux_jy(&p9, W2) / thermal_flux_jy(&p9, W1);
+        assert!(
+            ratio > 1e3,
+            "W2/W1 thermal flux ratio = {ratio:.3e} should be huge on the Wien tail"
+        );
+    }
+
+    #[test]
+    fn brighter_with_mass_and_fainter_with_distance_in_w2() {
+        assert!(band_magnitude(15.0, 500.0, W2) < band_magnitude(5.0, 500.0, W2));
+        assert!(band_magnitude(10.0, 800.0, W2) > band_magnitude(10.0, 400.0, W2));
+    }
+
+    #[test]
+    fn zero_point_gives_zero_magnitude() {
+        for band in [W1, W2] {
+            let m = -2.5 * (band.zero_point_jy / band.zero_point_jy).log10();
+            assert!(m.abs() < 1e-12, "{} zero point", band.name);
+        }
+    }
+}

--- a/crates/p9-2016-wise-coadd/src/coadd.rs
+++ b/crates/p9-2016-wise-coadd/src/coadd.rs
@@ -1,0 +1,137 @@
+//! Coadd depth gain from √N frame stacking.
+//!
+//! Meisner, Bromley, Kenyon & Anderson (2016) build *inertial coadds* of W1
+//! exposures binned into ∼1-day intervals, then shift-and-stack those daily
+//! coadds along trial Planet Nine motions. Stacking N independent,
+//! background-limited frames raises the signal-to-noise by √N (signal adds as
+//! N, noise as √N), so the limiting flux drops by √N and the limiting
+//! *magnitude* deepens by
+//!
+//!   Δm = 2.5 · log10(√N) = 1.25 · log10(N).
+//!
+//! This is the same matched-filter / coadd √N law used by the
+//! `p9-2025-stacking` crate; here it converts the shared single-frame WISE
+//! depth (`p9_core::analysis::surveys`, "WISE W1" = 16.5) into the deeper
+//! coadd depth that lets the search reach ~800 AU instead of the
+//! single-exposure ~430 AU quoted in the abstract.
+//!
+//! Per-band single-frame depths: the shared survey table pins W1 = 16.5. The
+//! single-frame W2 depth is shallower (W2 is intrinsically noisier and the
+//! published single-exposure 5σ W2 limit, Wright et al. 2010, is ≈ 15.6 Vega);
+//! we keep it as a labelled reference constant. The *coadd* W1 90%-completeness
+//! depth the 2016 paper actually reports, W1 ≈ 16.66, is kept as a labelled
+//! reference for cross-checking the gain.
+
+use p9_2018_wise_search::survey_model::W1_DEPTH_REFERENCE;
+
+use crate::band::{WiseBand, W2};
+
+/// Single-frame W1 depth (Vega), from the shared survey table via the sibling.
+pub const SINGLE_FRAME_W1_DEPTH: f64 = W1_DEPTH_REFERENCE;
+
+/// Single-frame W2 depth (Vega), labelled reference constant. WISE W2 is
+/// intrinsically noisier than W1; the published single-exposure 5σ W2 limit is
+/// ≈ 15.6 Vega (Wright et al. 2010). Kept here as a reference; the coadd gain
+/// is band-independent (√N law), so the W2/W1 detectability contrast is driven
+/// by the *flux* (band.rs), not by the depth offset.
+pub const SINGLE_FRAME_W2_DEPTH: f64 = 15.6;
+
+/// Published 2016 coadd W1 completeness depth (Vega): Meisner et al. (2016)
+/// quote 90% completeness at W1 < 16.66 over ∼2000 deg². Labelled reference.
+pub const PUBLISHED_COADD_W1_DEPTH: f64 = 16.66;
+
+/// Single-frame depth (Vega) for a WISE band.
+pub fn single_frame_depth(band: WiseBand) -> f64 {
+    if band == W2 {
+        SINGLE_FRAME_W2_DEPTH
+    } else {
+        SINGLE_FRAME_W1_DEPTH
+    }
+}
+
+/// Magnitude deepening from coadding `n_frames` background-limited frames:
+/// Δm = 2.5·log10(√N) = 1.25·log10(N). Zero for N ≤ 1.
+pub fn coadd_depth_gain(n_frames: u32) -> f64 {
+    if n_frames <= 1 {
+        return 0.0;
+    }
+    1.25 * (n_frames as f64).log10()
+}
+
+/// Coadd limiting magnitude in `band` after stacking `n_frames`: the
+/// single-frame depth plus the √N gain (deeper = larger magnitude).
+pub fn coadd_depth(band: WiseBand, n_frames: u32) -> f64 {
+    single_frame_depth(band) + coadd_depth_gain(n_frames)
+}
+
+/// Number of frames implied by a desired magnitude `gain` under the √N law:
+/// N = 10^(gain / 1.25). Useful to invert the published coadd depth.
+pub fn frames_for_gain(gain: f64) -> f64 {
+    10.0_f64.powf(gain / 1.25)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::band::W1;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn coadd_is_deeper_than_single_frame() {
+        // Any real stack (N>1) is strictly deeper than the single-frame depth.
+        let n = 100;
+        let deep = coadd_depth(W1, n);
+        assert!(
+            deep > SINGLE_FRAME_W1_DEPTH,
+            "coadd {deep:.3} must exceed single-frame {SINGLE_FRAME_W1_DEPTH}"
+        );
+    }
+
+    #[test]
+    fn gain_follows_root_n_law() {
+        // Δm(N) = 1.25 log10 N; quadrupling N adds 1.25·log10(4) ≈ 0.753 mag.
+        assert_relative_eq!(
+            coadd_depth_gain(4),
+            1.25 * 4.0_f64.log10(),
+            max_relative = 1e-12
+        );
+        // 100 frames -> 1.25·2 = 2.5 mag deeper.
+        assert_relative_eq!(coadd_depth_gain(100), 2.5, max_relative = 1e-12);
+        // Stacking is a √N flux improvement: 4× frames -> 2× SNR -> 0.753 mag.
+        assert!((coadd_depth_gain(4) - 0.7526).abs() < 1e-3);
+    }
+
+    #[test]
+    fn gain_is_monotone_in_n() {
+        let mut last = -1.0;
+        for n in [1u32, 2, 10, 100, 1000] {
+            let g = coadd_depth_gain(n);
+            assert!(g >= last, "gain must be non-decreasing in N");
+            last = g;
+        }
+        assert_eq!(coadd_depth_gain(1), 0.0);
+        assert_eq!(coadd_depth_gain(0), 0.0);
+    }
+
+    #[test]
+    fn frames_reproduce_published_coadd_depth() {
+        // The published W1 coadd 90% depth (16.66) is ~0.16 mag deeper than the
+        // single-frame 16.5; under √N that is a very small effective stack
+        // (~1.3 frames), consistent with ∼1-day daily coadds being only a few
+        // exposures deep per ~1-day bin near the ecliptic.
+        let gain = PUBLISHED_COADD_W1_DEPTH - SINGLE_FRAME_W1_DEPTH;
+        let n = frames_for_gain(gain);
+        assert!(gain > 0.0 && n > 1.0, "gain {gain:.3} -> N {n:.2}");
+        // Round-trip: applying that N reproduces the published depth.
+        assert_relative_eq!(
+            coadd_depth(W1, n.round() as u32),
+            SINGLE_FRAME_W1_DEPTH + coadd_depth_gain(n.round() as u32),
+            max_relative = 1e-12
+        );
+    }
+
+    #[test]
+    fn w2_single_frame_is_shallower_than_w1() {
+        assert!(single_frame_depth(W2) < single_frame_depth(W1));
+    }
+}

--- a/crates/p9-2016-wise-coadd/src/detectability.rs
+++ b/crates/p9-2016-wise-coadd/src/detectability.rs
@@ -1,0 +1,112 @@
+//! Maximum heliocentric distance to which a coadd detects a given-mass P9, per
+//! band.
+//!
+//! As in the sibling crate, band magnitude faints monotonically with distance,
+//! so for any mass bright enough at the near edge there is a single crossing of
+//! the (coadd) depth, found by bisection. The 2016 paper's deep coadd reaches
+//! larger distances than single frames precisely because the depth is deeper by
+//! the √N gain (`coadd`). The W2-vs-W1 contrast — W2 reaching a cold body
+//! farther out — comes from the band flux (`band`): on the Wien tail W2 is far
+//! brighter for a cold planet.
+
+use p9_2018_wise_search::thermal_model::P9Thermal;
+
+use crate::band::{band_magnitude, WiseBand};
+
+/// Whether a P9 of `mass_earth` at `distance_au` is brighter than `depth` in
+/// `band` (modelled band magnitude at or below the depth).
+pub fn is_detectable(band: WiseBand, depth: f64, mass_earth: f64, distance_au: f64) -> bool {
+    band_magnitude(mass_earth, distance_au, band) <= depth
+}
+
+/// Maximum heliocentric distance (AU) at which a P9 of `mass_earth` reaches
+/// `depth` in `band`, by bisection on the monotone magnitude–distance relation.
+/// `None` if undetectable even at the near edge of the search range.
+pub fn max_detectable_distance(band: WiseBand, depth: f64, mass_earth: f64) -> Option<f64> {
+    let d_min = 50.0_f64;
+    let d_max = 50_000.0_f64;
+
+    if !is_detectable(band, depth, mass_earth, d_min) {
+        return None;
+    }
+    if is_detectable(band, depth, mass_earth, d_max) {
+        return Some(d_max);
+    }
+
+    let mut lo = d_min;
+    let mut hi = d_max;
+    for _ in 0..200 {
+        let mid = 0.5 * (lo + hi);
+        if is_detectable(band, depth, mass_earth, mid) {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+        if hi - lo < 1e-4 {
+            break;
+        }
+    }
+    Some(0.5 * (lo + hi))
+}
+
+/// Detectability of a fully specified planet against a band depth (uses the
+/// planet's own albedo / internal temperature).
+pub fn planet_is_detectable(band: WiseBand, depth: f64, p9: &P9Thermal) -> bool {
+    crate::band::magnitude(p9, band) <= depth
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::band::{W1, W2};
+    use crate::coadd::{coadd_depth, single_frame_depth};
+
+    #[test]
+    fn max_distance_increases_with_mass() {
+        let depth = coadd_depth(W1, 100);
+        let d_heavy = max_detectable_distance(W1, depth, 15.0).expect("heavy detectable");
+        let d_light = max_detectable_distance(W1, depth, 8.0).expect("light detectable");
+        assert!(
+            d_heavy > d_light,
+            "heavier planet reaches farther: {d_heavy:.0} vs {d_light:.0} AU"
+        );
+    }
+
+    #[test]
+    fn deeper_coadd_reaches_farther_than_single_frame() {
+        // The whole point of the 2016 coadd: a deeper limit reaches a larger
+        // maximum distance than the single-frame depth, at fixed mass/band.
+        let mass = 12.0;
+        let single = max_detectable_distance(W1, single_frame_depth(W1), mass)
+            .expect("detectable single-frame");
+        let deep =
+            max_detectable_distance(W1, coadd_depth(W1, 100), mass).expect("detectable coadd");
+        assert!(
+            deep > single,
+            "coadd reach {deep:.0} AU must exceed single-frame {single:.0} AU"
+        );
+    }
+
+    #[test]
+    fn w2_reaches_a_cold_p9_farther_than_w1() {
+        // Headline of the paper: for a cold body W2 is more favorable. At the
+        // SAME numerical depth, W2 reaches the planet at larger distance than
+        // W1 because the cold-body band flux is higher at 4.6 µm.
+        let mass = 10.0;
+        let depth = 18.0; // common reference depth for an apples-to-apples band test
+        let d_w1 = max_detectable_distance(W1, depth, mass).expect("W1 detectable");
+        let d_w2 = max_detectable_distance(W2, depth, mass).expect("W2 detectable");
+        assert!(
+            d_w2 > d_w1,
+            "W2 reach {d_w2:.0} AU should exceed W1 reach {d_w1:.0} AU for a cold P9"
+        );
+    }
+
+    #[test]
+    fn crossover_magnitude_equals_depth() {
+        let depth = coadd_depth(W1, 100);
+        let d = max_detectable_distance(W1, depth, 12.0).expect("detectable");
+        let m = band_magnitude(12.0, d, W1);
+        assert!((m - depth).abs() < 1e-2, "W1({d:.1} AU) = {m:.3}");
+    }
+}

--- a/crates/p9-2016-wise-coadd/src/exclusion.rs
+++ b/crates/p9-2016-wise-coadd/src/exclusion.rs
@@ -1,0 +1,210 @@
+//! Parameter-space exclusion from the coadd non-detection.
+//!
+//! Meisner et al. (2016) detect no moving Planet Nine in their deep W1 coadds.
+//! As in the sibling 3π-search crate, the fraction of a reference P9 population
+//! the coadd *would* have detected is the fraction the non-detection excludes.
+//! The per-object detection probability is the product of
+//!   * a logistic magnitude-efficiency centered on the **coadd** depth (the
+//!     `coadd` √N-deepened limit), evaluated at the object's band magnitude
+//!     (`band`), and
+//!   * the galactic-plane footprint mask, reused verbatim from
+//!     `p9-2018-wise-search` (`WiseSurvey`).
+//!
+//! We reuse the sibling's [`WiseSurvey`] by constructing it with the coadd
+//! depth as its `w1_depth`; its logistic `detection_efficiency` and
+//! `in_footprint`/`sky_coverage_fraction` then apply unchanged.
+
+use serde::{Deserialize, Serialize};
+
+use p9_2018_wise_search::sky::galactic_latitude_deg;
+use p9_2018_wise_search::survey_model::WiseSurvey;
+use p9_core::types::OrbitalElements;
+
+use crate::band::{band_magnitude, WiseBand};
+use crate::coadd::{coadd_depth, single_frame_depth};
+
+/// One reference Planet Nine realization (orbit, mass, current distance).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct ReferenceP9 {
+    pub elements: OrbitalElements,
+    pub mass_earth: f64,
+    pub distance_au: f64,
+}
+
+/// Result of the coadd exclusion analysis.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExclusionResult {
+    /// Expected fraction of the reference population the coadd would detect.
+    pub fraction_excluded: f64,
+    /// Number of realizations evaluated.
+    pub n_total: u32,
+    /// Expected number detected (sum of per-object probabilities).
+    pub expected_excluded: f64,
+}
+
+/// A `WiseSurvey` whose depth is the coadd depth in `band` after `n_frames`,
+/// reusing the sibling's logistic/footprint machinery.
+pub fn coadd_survey(band: WiseBand, n_frames: u32) -> WiseSurvey {
+    WiseSurvey {
+        w1_depth: coadd_depth(band, n_frames),
+        ..WiseSurvey::default()
+    }
+}
+
+/// A `WiseSurvey` at the single-frame depth in `band` (for the coadd-vs-single
+/// contrast).
+pub fn single_frame_survey(band: WiseBand) -> WiseSurvey {
+    WiseSurvey {
+        w1_depth: single_frame_depth(band),
+        ..WiseSurvey::default()
+    }
+}
+
+/// Expected exclusion fraction of `population` in `band` for a survey whose
+/// depth is `survey.w1_depth` (use [`coadd_survey`] or [`single_frame_survey`]).
+/// Deterministic: accumulates per-object probabilities, no RNG inside.
+pub fn compute_exclusion(
+    survey: &WiseSurvey,
+    band: WiseBand,
+    population: &[ReferenceP9],
+) -> ExclusionResult {
+    let n_total = population.len() as u32;
+    let expected_excluded: f64 = population
+        .iter()
+        .map(|p| {
+            let mag = band_magnitude(p.mass_earth, p.distance_au, band);
+            let footprint = if survey.in_footprint(galactic_latitude_deg(&p.elements)) {
+                1.0
+            } else {
+                0.0
+            };
+            survey.detection_efficiency(mag) * footprint
+        })
+        .sum();
+
+    let fraction_excluded = if n_total > 0 {
+        expected_excluded / n_total as f64
+    } else {
+        0.0
+    };
+
+    ExclusionResult {
+        fraction_excluded,
+        n_total,
+        expected_excluded,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::band::{W1, W2};
+    use p9_core::constants::DEG2RAD;
+
+    /// A seeded synthetic reference population spread over mass/distance and
+    /// orbital angles, built without external crates (self-contained LCG so the
+    /// crate has no dev-dependency beyond approx). Distances span 250–900 AU,
+    /// masses 5–15 M⊕.
+    fn population(n: usize, seed: u64) -> Vec<ReferenceP9> {
+        let mut state = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        let mut next = || {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            ((state >> 11) as f64) / ((1u64 << 53) as f64)
+        };
+        (0..n)
+            .map(|_| {
+                let mass = 5.0 + 10.0 * next();
+                let distance = 250.0 + 650.0 * next();
+                let i = (10.0 + 20.0 * next()) * DEG2RAD;
+                let omega = 360.0 * next() * DEG2RAD;
+                let omega_big = 360.0 * next() * DEG2RAD;
+                let m = 360.0 * next() * DEG2RAD;
+                ReferenceP9 {
+                    elements: OrbitalElements {
+                        a: distance,
+                        e: 0.2,
+                        i,
+                        omega,
+                        omega_big,
+                        mean_anomaly: m,
+                    },
+                    mass_earth: mass,
+                    distance_au: distance,
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn exclusion_fraction_is_a_probability() {
+        let pop = population(3000, 2016);
+        let survey = coadd_survey(W1, 100);
+        let r = compute_exclusion(&survey, W1, &pop);
+        assert!(
+            r.fraction_excluded > 0.0 && r.fraction_excluded < 1.0,
+            "fraction = {}",
+            r.fraction_excluded
+        );
+    }
+
+    #[test]
+    fn exclusion_increases_with_assumed_mass() {
+        let base = population(3000, 7);
+        let survey = coadd_survey(W1, 100);
+        let light: Vec<ReferenceP9> = base
+            .iter()
+            .map(|p| ReferenceP9 {
+                mass_earth: 5.0,
+                ..*p
+            })
+            .collect();
+        let heavy: Vec<ReferenceP9> = base
+            .iter()
+            .map(|p| ReferenceP9 {
+                mass_earth: 18.0,
+                ..*p
+            })
+            .collect();
+        let f_light = compute_exclusion(&survey, W1, &light).fraction_excluded;
+        let f_heavy = compute_exclusion(&survey, W1, &heavy).fraction_excluded;
+        assert!(
+            f_heavy > f_light + 0.005,
+            "heavy {f_heavy:.4} should exceed light {f_light:.4}"
+        );
+    }
+
+    #[test]
+    fn coadd_excludes_more_than_single_frame() {
+        // The deeper coadd detects (excludes) a larger fraction than single
+        // frames — the central result of the paper.
+        let pop = population(3000, 99);
+        let single = single_frame_survey(W1);
+        let coadd = coadd_survey(W1, 100);
+        let f_single = compute_exclusion(&single, W1, &pop).fraction_excluded;
+        let f_coadd = compute_exclusion(&coadd, W1, &pop).fraction_excluded;
+        assert!(
+            f_coadd > f_single,
+            "coadd {f_coadd:.4} should exceed single-frame {f_single:.4}"
+        );
+    }
+
+    #[test]
+    fn w2_excludes_more_than_w1_for_cold_population() {
+        // For a cold reference population, W2 (more favorable thermally)
+        // excludes a larger fraction than W1 at the same coadd depth number.
+        let pop = population(3000, 31);
+        let depth = 17.0;
+        let survey = WiseSurvey {
+            w1_depth: depth,
+            ..WiseSurvey::default()
+        };
+        let f_w1 = compute_exclusion(&survey, W1, &pop).fraction_excluded;
+        let f_w2 = compute_exclusion(&survey, W2, &pop).fraction_excluded;
+        assert!(
+            f_w2 > f_w1,
+            "W2 {f_w2:.4} should exceed W1 {f_w1:.4} for a cold population"
+        );
+    }
+}

--- a/crates/p9-2016-wise-coadd/src/lib.rs
+++ b/crates/p9-2016-wise-coadd/src/lib.rs
@@ -1,0 +1,42 @@
+//! Reproduction of Meisner, Bromley, Kenyon & Anderson (2016),
+//! "Searching for Planet Nine with coadded WISE and NEOWISE data"
+//! (arXiv:1611.00015).
+//!
+//! Meisner et al. build *inertial coadds* of WISE/NEOWISE W1 exposures binned
+//! into ∼1-day intervals and shift-and-stack them along trial Planet Nine
+//! motions. Coadding deepens the limiting magnitude by the √N stacking law,
+//! extending the search from a single-exposure reach of ~430 AU to ~800 AU over
+//! ∼2000 deg² (W1 < 16.66 at 90% completeness). The non-detection of a moving
+//! source excludes a region of P9 (mass, distance) space. For a *cold* body the
+//! paper notes W2 (4.6 µm) is more favorable than W1 (3.4 µm).
+//!
+//! This crate reuses the sibling `p9-2018-wise-search` aggressively — its
+//! `P9Thermal` geometry/physics, its `WiseSurvey` footprint and logistic
+//! efficiency, and its orbit→galactic-latitude sky mapping — and adds only the
+//! genuinely new 2016 pieces:
+//!
+//! - [`coadd`]: the √N (1.25·log10 N) coadd depth gain over the single-frame
+//!   WISE depth (the shared survey table's W1 = 16.5), with the published
+//!   coadd W1 = 16.66 kept as a labelled reference.
+//! - [`band`]: the same thermal+reflected physics evaluated in **both** W1 and
+//!   W2, so the cold-body W2-over-W1 advantage is computed, not assumed.
+//! - [`detectability`]: the maximum heliocentric distance a given-mass P9 is
+//!   detectable in, against a coadd depth — increasing with mass, deeper for
+//!   the coadd than single frames, and farther in W2 than W1 for a cold body.
+//! - [`exclusion`]: the excluded fraction of a seeded reference P9 population —
+//!   in (0,1), increasing with mass, larger for the coadd than single frames.
+//!
+//! **Honest residual (same finding as the sibling).** At W1 (3.4 µm) a cold
+//! (~40 K) P9 lies so far down the Wien tail that its thermal flux is utterly
+//! negligible and the W1 detectability is set by *reflected* sunlight. W2 is
+//! less hostile (the Wien-tail factor improves by ~exp[(hc/kT)(1/λ₁−1/λ₂)]),
+//! which is exactly the 2016 paper's point — but at 40 K even W2 thermal
+//! emission remains weak, so both bands' cold-P9 reach is reflected-dominated
+//! at these distances. The W2-over-W1 advantage this crate pins is real and in
+//! the right direction; its absolute magnitude depends on the (uncertain) cold
+//! effective temperature, kept as a documented model input.
+
+pub mod band;
+pub mod coadd;
+pub mod detectability;
+pub mod exclusion;


### PR DESCRIPTION
Reproduces Meisner, Bromley, Kenyon & Anderson (2016), "Searching for Planet Nine with coadded WISE and NEOWISE data" (arXiv:1611.00015).

New crate `p9-2016-wise-coadd`, reusing the sibling `p9-2018-wise-search` (P9Thermal physics/geometry, WiseSurvey footprint + logistic efficiency, orbit→galactic-latitude mapping) and `p9-core` (survey table, photometry). Computes, not hard-codes:

- `coadd`: the √N stacking depth gain over the single-frame WISE depth, Δm = 2.5·log10(√N) = 1.25·log10(N) (same law as `p9-2025-stacking`). Single-frame W1 = 16.5 from the shared survey table; published 2016 coadd W1 = 16.66 (90% completeness) and single-frame W2 ≈ 15.6 kept as labelled reference constants.
- `band`: the sibling's thermal+reflected physics evaluated in both W1 (3.4 µm) and W2 (4.6 µm), so the cold-body W2-over-W1 advantage is derived from the Wien-tail flux, not assumed. The W1 path reproduces the sibling's magnitude to round-off.
- `detectability`: max heliocentric distance a given-mass P9 reaches a coadd depth (bisection on the monotone mag–distance relation) — increases with mass, deeper coadd reaches farther than single frames, W2 reaches a cold P9 farther than W1.
- `exclusion`: excluded fraction of a seeded reference P9 population — in (0,1), increases with mass, larger for the coadd than single frames, larger in W2 than W1 for a cold population.

Honest residual (same as the sibling): at 3.4 µm a cold ~40 K P9 sits so far down the Wien tail that W1 detectability is reflected-light dominated; W2 is less hostile but at 40 K still weak, so both bands' cold-P9 reach is reflected-dominated. The W2-over-W1 direction is real; its magnitude depends on the assumed cold effective temperature, documented as a model input.

Hard gate: `cargo build`/`cargo test -p p9-2016-wise-coadd` green (17 tests), `cargo fmt` clean.

Closes #132