### PR TITLE
Add Socas-Navarro & Trujillo 2025 parallax search crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,6 +1779,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "p9-2025-parallax-search"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "p9-core",
+ "p9-survey",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "p9-2025-perturbation"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
     "crates/p9-2026-apsidal-clustering",
     "crates/p9-2025-iras-akari",
     "crates/p9-2025-akari-refutation",
+    "crates/p9-2025-parallax-search",
     "crates/p9-2025-perturbation",
     "crates/p9-2026-iorio-precession",
     "crates/p9-review-article",

--- a/crates/p9-2025-parallax-search/Cargo.toml
+++ b/crates/p9-2025-parallax-search/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "p9-2025-parallax-search"
+version = "0.1.0"
+edition = "2021"
+description = "Reproduction of Socas-Navarro & Trujillo (2025): a targeted parallax search for Planet Nine"
+
+[dependencies]
+p9-core = { path = "../p9-core" }
+p9-survey = { path = "../p9-survey" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+approx = { workspace = true }

--- a/crates/p9-2025-parallax-search/src/discrimination.rs
+++ b/crates/p9-2025-parallax-search/src/discrimination.rs
@@ -1,0 +1,159 @@
+//! Separating a bound distant planet from the stellar background.
+//!
+//! Two numbers make the parallax method work:
+//!
+//! 1. **Contrast.** A 500–700 AU body has a reflex parallax of order arcminutes
+//!    ([`crate::parallax`]); a background reference star at hundreds of pc has a
+//!    parallax of a few milliarcsec. The ratio is `10³–10⁴`, so P9 moves between
+//!    epochs by a margin no field star can fake.
+//!
+//! 2. **Required astrometric precision.** To claim a shift at signal-to-noise
+//!    `snr`, each epoch's position must be measured to better than
+//!    `amplitude / snr`. Because the amplitude falls as `1/d`, the *tolerable*
+//!    per-epoch error also falls as `1/d`: detecting P9 farther out demands ever
+//!    finer astrometry. We report it both as the maximum tolerable error (arcsec,
+//!    falling with `d`) and as the demanded precision in pixels for a given plate
+//!    scale.
+
+use crate::parallax::{epoch_parallax_arcsec, half_parallax_arcsec};
+
+/// Contrast ratio between a Planet Nine at `distance_au` and a background star of
+/// parallax `star_parallax_arcsec`, using the **half-angle** (annual) parallax of
+/// each. P9's reflex parallax is `1 AU / d`; the star's is its true parallax.
+/// The ratio is dimensionless and `≫ 1`.
+pub fn contrast_ratio(distance_au: f64, star_parallax_arcsec: f64) -> f64 {
+    half_parallax_arcsec(distance_au) / star_parallax_arcsec
+}
+
+/// Contrast over a *finite* epoch separation: both P9 and the star are projected
+/// onto the same chord baseline, so the geometric baseline factor cancels and the
+/// ratio is identical to [`contrast_ratio`]. Provided for clarity at the call
+/// site when reasoning about a specific two-epoch observation.
+pub fn contrast_ratio_over_epoch(
+    distance_au: f64,
+    star_parallax_arcsec: f64,
+    epoch_separation_days: f64,
+) -> f64 {
+    // The star's apparent shift over the same baseline scales by the same chord
+    // factor as P9's, so dividing them recovers the annual-parallax ratio.
+    let p9 = epoch_parallax_arcsec(distance_au, epoch_separation_days);
+    let star_full = star_parallax_arcsec; // star half-parallax (annual)
+    let p9_full = half_parallax_arcsec(distance_au);
+    let chord = if p9_full == 0.0 { 0.0 } else { p9 / p9_full };
+    (p9_full * chord) / (star_full * chord)
+}
+
+/// Maximum tolerable per-epoch astrometric error (arcsec) to detect the reflex
+/// parallax of a body at `distance_au` at the requested `snr`, over a baseline of
+/// `epoch_separation_days`. A measured shift `A` detected at `snr` needs
+/// per-epoch error `σ ≤ A / snr`. Falls as `1/d`.
+pub fn max_tolerable_error_arcsec(distance_au: f64, snr: f64, epoch_separation_days: f64) -> f64 {
+    epoch_parallax_arcsec(distance_au, epoch_separation_days) / snr
+}
+
+/// The same demanded precision expressed in detector pixels for a given plate
+/// scale (arcsec/pixel). Smaller is harder; the value falls as `1/d`.
+pub fn required_precision_pixels(
+    distance_au: f64,
+    snr: f64,
+    epoch_separation_days: f64,
+    plate_scale_arcsec_per_px: f64,
+) -> f64 {
+    max_tolerable_error_arcsec(distance_au, snr, epoch_separation_days) / plate_scale_arcsec_per_px
+}
+
+/// Largest heliocentric distance (AU) at which a body's reflex parallax is still
+/// detectable at `snr` given a per-epoch astrometric error `sigma_arcsec` over a
+/// baseline of `epoch_separation_days`. Solve `A(d) / snr = sigma` for `d` using
+/// `A(d) = baseline_arcsec / d`.
+pub fn max_detectable_distance_au(sigma_arcsec: f64, snr: f64, epoch_separation_days: f64) -> f64 {
+    // A(d) = epoch_parallax_arcsec(d) = K / d, so K = A(d0) * d0 for any d0.
+    let d0 = 500.0;
+    let k = epoch_parallax_arcsec(d0, epoch_separation_days) * d0;
+    k / (snr * sigma_arcsec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parallax::YEAR_DAYS;
+    use crate::published;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn contrast_against_field_star_is_thousands() {
+        // 460 AU P9 vs a 1 mas field star: ~7.5' / 1 mas.
+        let r = contrast_ratio(
+            published::REFERENCE_DISTANCE_AU,
+            published::TYPICAL_FIELD_STAR_PARALLAX_ARCSEC,
+        );
+        assert!(r > 1.0e3, "contrast = {r:.0}, expected >1e3");
+        // 460 AU half-parallax 448" / 0.001" = ~4.5e5.
+        assert_relative_eq!(r, 4.484e5, epsilon = 1.0e3);
+    }
+
+    #[test]
+    fn contrast_exceeds_1e3_to_1e4_across_prior_and_realistic_stars() {
+        // Even against an unusually nearby (10 pc, 0.1") reference star, a P9 at
+        // the far edge of the prior still beats it by >10^3.
+        let nearby_star = 0.1; // 10 pc, parallax 0.1 arcsec
+        let r = contrast_ratio(published::P9_DISTANCE_MAX_AU, nearby_star);
+        assert!(r > 1.0e3, "even vs a 10 pc star, contrast = {r:.0}");
+    }
+
+    #[test]
+    fn epoch_contrast_equals_annual_contrast() {
+        // The chord baseline cancels: finite-epoch contrast == annual contrast.
+        let d = 600.0;
+        let s = published::TYPICAL_FIELD_STAR_PARALLAX_ARCSEC;
+        assert_relative_eq!(
+            contrast_ratio_over_epoch(d, s, 30.0),
+            contrast_ratio(d, s),
+            epsilon = 1e-9
+        );
+    }
+
+    #[test]
+    fn required_precision_grows_with_distance() {
+        // Tolerable per-epoch error shrinks as 1/d: detecting a farther P9 needs
+        // finer astrometry.
+        let snr = 5.0;
+        let base = YEAR_DAYS / 2.0;
+        let e500 = max_tolerable_error_arcsec(500.0, snr, base);
+        let e700 = max_tolerable_error_arcsec(700.0, snr, base);
+        assert!(e700 < e500, "precision must tighten with distance");
+        // Exactly inverse-linear in d.
+        assert_relative_eq!(e500 / e700, 700.0 / 500.0, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn required_precision_is_loose_for_p9_full_baseline() {
+        // Over a 6-month baseline at SNR 5, a 700 AU P9 still allows ~1' of
+        // per-epoch error -- far coarser than routine sub-arcsec astrometry.
+        let sigma = max_tolerable_error_arcsec(700.0, 5.0, YEAR_DAYS / 2.0);
+        assert!(sigma > 60.0, "tolerable error = {sigma:.1} arcsec");
+    }
+
+    #[test]
+    fn max_detectable_distance_scales_inversely_with_precision() {
+        // Halving the achievable error doubles the reach.
+        let snr = 5.0;
+        let base = YEAR_DAYS / 2.0;
+        let d_coarse = max_detectable_distance_au(1.0, snr, base);
+        let d_fine = max_detectable_distance_au(0.5, snr, base);
+        assert_relative_eq!(d_fine / d_coarse, 2.0, epsilon = 1e-9);
+        // With 1" per-epoch error and SNR 5 over 6 months, reach is well beyond
+        // the P9 prior (thousands of AU), confirming depth (not astrometry) is
+        // the real limiter -- consistent with the paper's magnitude-limited
+        // conclusion.
+        assert!(d_coarse > 700.0);
+    }
+
+    #[test]
+    fn required_precision_pixels_at_jbt_scale() {
+        // At the 0.130"/px JBT/SPENCER scale, a 700 AU P9 over 6 months at SNR 5
+        // tolerates hundreds of pixels of per-epoch error -- trivially met.
+        let px = required_precision_pixels(700.0, 5.0, YEAR_DAYS / 2.0, 0.130);
+        assert!(px > 100.0, "tolerable error = {px:.0} px");
+    }
+}

--- a/crates/p9-2025-parallax-search/src/lib.rs
+++ b/crates/p9-2025-parallax-search/src/lib.rs
@@ -1,0 +1,61 @@
+//! Reproduction of Socas-Navarro & Trujillo (2025),
+//! *A targeted parallax search for Planet Nine* (arXiv:2504.05473).
+//!
+//! # The method
+//!
+//! Planet Nine, if it lies at a heliocentric distance `d` of order 500–700 AU,
+//! has a tiny *orbital* (proper) motion but a **huge reflex parallax**. Earth's
+//! 1 AU heliocentric displacement subtends, seen from `d`, an angle
+//!
+//! ```text
+//!   p_half = (1 AU / d) * 206265"   (the half-angle, arcsec)
+//! ```
+//!
+//! At 460 AU this is ≈ 7.5 *arcminutes* — four orders of magnitude larger than
+//! any background star's parallax (a field star at even 10 pc has a parallax of
+//! 0.1″; typical survey stars are at hundreds of pc, ≲ a few milliarcsec). So
+//! observing the same field at two epochs separated by a chunk of Earth's orbit
+//! (the paper uses consecutive nights up to a ~6-month / quadrature baseline)
+//! makes Planet Nine *leap* across the field while the stellar background barely
+//! stirs. Combined with P9's slow orbital proper motion (it does not run off in a
+//! consistent direction the way a nearby fast-moving asteroid would), the large
+//! reflex parallax cleanly separates a bound distant planet from the field.
+//!
+//! # What this crate computes (all real, none hard-coded)
+//!
+//! - [`parallax`] — the parallactic displacement of a body at distance `d` over a
+//!   chosen epoch separation, in arcmin, reusing `p9_survey::parallax`. The
+//!   amplitude falls as `1/d`; the full annual peak-to-peak swing and the
+//!   half-angle ("parallax factor") are both exposed.
+//! - [`discrimination`] — the contrast ratio against a background star of given
+//!   parallax (≳ 10³–10⁴×), and the per-epoch astrometric precision required to
+//!   detect the shift at a chosen SNR, which *grows linearly with `d`*.
+//!
+//! Published reference numbers from the paper are kept as labelled constants in
+//! [`published`].
+
+pub mod discrimination;
+pub mod parallax;
+
+/// Labelled reference numbers from Socas-Navarro & Trujillo (2025) and the
+/// physical setup, kept separate from anything this crate computes.
+pub mod published {
+    /// Lower edge of the P9 heliocentric-distance prior the search targets (AU).
+    pub const P9_DISTANCE_MIN_AU: f64 = 500.0;
+    /// Upper edge of the P9 heliocentric-distance prior the search targets (AU).
+    pub const P9_DISTANCE_MAX_AU: f64 = 700.0;
+    /// A representative distance used in the worked examples (AU). The reflex
+    /// half-parallax at this distance is ≈ 7.5 arcmin (see tests).
+    pub const REFERENCE_DISTANCE_AU: f64 = 460.0;
+    /// Reflex parallax half-angle at [`REFERENCE_DISTANCE_AU`], arcmin. This is
+    /// the order-of-arcminutes headline number; the crate recomputes it.
+    pub const HALF_PARALLAX_AT_REF_ARCMIN: f64 = 7.47;
+    /// The targeted survey area (square degrees) imaged in the paper.
+    pub const SURVEY_AREA_DEG2: f64 = 98.0;
+    /// Mean r-band limiting magnitude of the search.
+    pub const LIMITING_MAG_R: f64 = 21.3;
+    /// A representative *background field star* parallax (arcsec). Stars used as
+    /// astrometric reference in these fields sit at hundreds of pc, giving
+    /// parallaxes of a few milliarcsec; 1 mas corresponds to 1 kpc.
+    pub const TYPICAL_FIELD_STAR_PARALLAX_ARCSEC: f64 = 1.0e-3;
+}

--- a/crates/p9-2025-parallax-search/src/parallax.rs
+++ b/crates/p9-2025-parallax-search/src/parallax.rs
@@ -1,0 +1,167 @@
+//! Reflex parallax of a distant body over a chosen epoch separation.
+//!
+//! All of the geometry is the baseline/distance relation already implemented in
+//! `p9_survey::parallax`; this module only *reuses* it and re-expresses it in
+//! the units the parallax search cares about (arcmin, and amplitude vs distance).
+//!
+//! Two quantities matter for the search:
+//!
+//! * the **full annual peak-to-peak** swing (Earth on opposite sides of the Sun,
+//!   a 2 AU baseline) — `p9_survey::parallax::annual_parallax_arcsec`, and
+//! * the **partial-baseline** shift over an arbitrary epoch separation. For two
+//!   epochs separated by a fraction of Earth's orbit the projected baseline is
+//!   `2 AU * sin(Δθ/2)` where `Δθ = 2π * Δt / 1 yr`; a ~6-month (quadrature)
+//!   separation gives the full 2 AU, two consecutive nights give a tiny sliver.
+
+use p9_core::constants::PC_AU;
+use p9_survey::parallax::{annual_parallax_arcsec, parallax_arcsec, AU_KM};
+
+/// Arcseconds per arcminute.
+pub const ARCSEC_PER_ARCMIN: f64 = 60.0;
+/// Days in a (Julian) year, the Earth orbital period used for the baseline.
+pub const YEAR_DAYS: f64 = p9_core::constants::YEAR_DAYS;
+
+/// Reflex-parallax **half-angle** (the classic "parallax", arcsec) of a body at
+/// `distance_au`: the angle Earth's 1 AU radius subtends from the body.
+///
+/// This is `(1 AU / d)` in radians times arcsec-per-radian, i.e. half the annual
+/// peak-to-peak swing. It is what most people mean by "the parallax" of an
+/// object and falls as `1/d`.
+pub fn half_parallax_arcsec(distance_au: f64) -> f64 {
+    // PC_AU == arcsec per radian (the parsec definition).
+    PC_AU / distance_au
+}
+
+/// Reflex-parallax half-angle in **arcminutes** — the paper's order-of-arcmin
+/// headline for a 500–700 AU body.
+pub fn half_parallax_arcmin(distance_au: f64) -> f64 {
+    half_parallax_arcsec(distance_au) / ARCSEC_PER_ARCMIN
+}
+
+/// Full annual peak-to-peak parallax in arcminutes (2 AU baseline), reusing
+/// `p9_survey::parallax::annual_parallax_arcsec`.
+pub fn annual_parallax_arcmin(distance_au: f64) -> f64 {
+    annual_parallax_arcsec(distance_au) / ARCSEC_PER_ARCMIN
+}
+
+/// Projected Earth-orbit baseline (AU) between two epochs separated by
+/// `epoch_separation_days`, for a circular 1 AU orbit. Two positions separated
+/// by orbital phase `Δθ` are `2 * sin(Δθ/2)` AU apart (chord length). A
+/// half-year separation (Δθ = π) gives the full 2 AU; a quarter year gives
+/// `√2 ≈ 1.414` AU.
+pub fn projected_baseline_au(epoch_separation_days: f64) -> f64 {
+    let dtheta = std::f64::consts::TAU * epoch_separation_days / YEAR_DAYS;
+    2.0 * (dtheta / 2.0).sin().abs()
+}
+
+/// Parallactic displacement (arcsec) of a body at `distance_au` observed at two
+/// epochs separated by `epoch_separation_days`, using the chord baseline above.
+/// This is the quantity the search actually measures between two visits.
+pub fn epoch_parallax_arcsec(distance_au: f64, epoch_separation_days: f64) -> f64 {
+    let baseline_km = projected_baseline_au(epoch_separation_days) * AU_KM;
+    parallax_arcsec(baseline_km, distance_au)
+}
+
+/// Same, in arcminutes.
+pub fn epoch_parallax_arcmin(distance_au: f64, epoch_separation_days: f64) -> f64 {
+    epoch_parallax_arcsec(distance_au, epoch_separation_days) / ARCSEC_PER_ARCMIN
+}
+
+/// The amplitude-vs-distance relation as a sampled curve: for each distance in
+/// `distances_au`, the annual half-parallax in arcmin. Useful for showing the
+/// `1/d` falloff explicitly.
+pub fn half_parallax_curve_arcmin(distances_au: &[f64]) -> Vec<(f64, f64)> {
+    distances_au
+        .iter()
+        .map(|&d| (d, half_parallax_arcmin(d)))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::published;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn half_parallax_is_arcminutes_at_p9_distance() {
+        // ~7.5 arcmin half-angle at 460 AU (the paper's worked example).
+        let p = half_parallax_arcmin(published::REFERENCE_DISTANCE_AU);
+        assert_relative_eq!(p, published::HALF_PARALLAX_AT_REF_ARCMIN, epsilon = 0.05);
+        // Order of arcminutes across the whole 500-700 AU prior.
+        assert!(half_parallax_arcmin(500.0) > 5.0);
+        assert!(half_parallax_arcmin(700.0) > 4.0);
+        assert!(half_parallax_arcmin(700.0) < 6.0);
+    }
+
+    #[test]
+    fn half_is_exactly_half_the_annual_swing() {
+        let d = 600.0;
+        assert_relative_eq!(
+            annual_parallax_arcmin(d),
+            2.0 * half_parallax_arcmin(d),
+            epsilon = 1e-9
+        );
+    }
+
+    #[test]
+    fn parallax_falls_as_one_over_distance() {
+        // Doubling the distance halves the parallax (inverse-linear).
+        let p1 = half_parallax_arcmin(500.0);
+        let p2 = half_parallax_arcmin(1000.0);
+        assert_relative_eq!(p1 / p2, 2.0, epsilon = 1e-9);
+        // d * parallax is constant (= 1 AU in arcsec * 1/60).
+        let c500 = 500.0 * half_parallax_arcmin(500.0);
+        let c700 = 700.0 * half_parallax_arcmin(700.0);
+        assert_relative_eq!(c500, c700, epsilon = 1e-9);
+        // That constant is PC_AU / 60 arcmin.
+        assert_relative_eq!(c500, PC_AU / ARCSEC_PER_ARCMIN, epsilon = 1e-6);
+    }
+
+    #[test]
+    fn quadrature_baseline_is_root_two_and_half_year_is_full() {
+        // Quarter-year separation -> chord 2 sin(45 deg) = sqrt(2) AU.
+        assert_relative_eq!(
+            projected_baseline_au(YEAR_DAYS / 4.0),
+            std::f64::consts::SQRT_2,
+            epsilon = 1e-9
+        );
+        // Half-year separation -> full 2 AU diameter.
+        assert_relative_eq!(projected_baseline_au(YEAR_DAYS / 2.0), 2.0, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn six_month_epoch_parallax_matches_annual_swing() {
+        // A ~6-month baseline reaches the full peak-to-peak annual parallax.
+        let d = published::REFERENCE_DISTANCE_AU;
+        assert_relative_eq!(
+            epoch_parallax_arcmin(d, YEAR_DAYS / 2.0),
+            annual_parallax_arcmin(d),
+            epsilon = 1e-9
+        );
+        // ~15 arcmin peak-to-peak at 460 AU.
+        assert_relative_eq!(
+            epoch_parallax_arcmin(d, YEAR_DAYS / 2.0),
+            14.95,
+            epsilon = 0.1
+        );
+    }
+
+    #[test]
+    fn consecutive_night_shift_is_still_arcseconds_for_p9() {
+        // One-day baseline: chord 2 sin(pi/365.25) ~ 0.0172 AU -> at 460 AU the
+        // shift is still ~7.7", a robustly measurable per-night motion that a
+        // ~kpc field star (mas/yr proper motion) cannot mimic in a single night.
+        let s = epoch_parallax_arcsec(published::REFERENCE_DISTANCE_AU, 1.0);
+        assert!(s > 5.0 && s < 12.0, "one-night P9 shift = {s:.2} arcsec");
+    }
+
+    #[test]
+    fn curve_is_monotone_decreasing() {
+        let ds = [400.0, 500.0, 600.0, 700.0, 800.0];
+        let curve = half_parallax_curve_arcmin(&ds);
+        for w in curve.windows(2) {
+            assert!(w[1].1 < w[0].1, "parallax must fall with distance");
+        }
+    }
+}


### PR DESCRIPTION
Reproduces Socas-Navarro & Trujillo (2025), *A targeted parallax search for Planet Nine* (arXiv:2504.05473).

## Method
The paper identifies Planet Nine by its enormous **reflex parallax**: a body at 500-700 AU shows an annual parallax of order arcminutes, four orders of magnitude larger than any background star's (which sit at a few milliarcsec). Imaging the same field at two epochs makes P9 leap across the frame while the stellar background barely stirs; combined with P9's slow orbital proper motion, this cleanly discriminates a bound distant planet from the field.

## What the crate computes (real, none hard-coded)
New crate `p9-2025-parallax-search` reusing `p9-survey`'s parallax module (added as a path dependency):

- `parallax.rs` — reflex parallax half-angle and full annual swing in arcmin; the partial-baseline shift over an arbitrary epoch separation (chord baseline `2 sin(Delta-theta/2)` AU); the `1/d` amplitude-vs-distance curve.
- `discrimination.rs` — contrast ratio vs a background star (>= 10^3-10^4); required per-epoch astrometric precision and its `1/d` scaling; max detectable distance for a given astrometry floor.

## Pinned results
- Reflex half-parallax ~7.47 arcmin at 460 AU (full annual swing ~14.95 arcmin); falls exactly as `1/d`.
- Contrast vs a 1 mas field star ~4.5e5 at 460 AU; still > 10^3 even against a 10 pc star at the far edge of the prior.
- Required astrometric precision tightens linearly with distance; over a 6-month baseline at SNR 5 the tolerable per-epoch error is loose (~arcmin), so depth, not astrometry, is the limiter — consistent with the paper's magnitude-limited conclusion.

14 tests pass; `cargo fmt` clean.

Closes #136