### PR TITLE
Coalesce G4: lift planet perihelion precession into p9-core

### DIFF
--- a/crates/p9-2016-iorio-precession/src/lib.rs
+++ b/crates/p9-2016-iorio-precession/src/lib.rs
@@ -57,19 +57,13 @@
 
 use serde::{Deserialize, Serialize};
 
+use p9_core::analysis::secular::perturber_perihelion_precession;
 use p9_core::constants::GM_SUN;
-use p9_core::constants::YEAR_DAYS;
 
 // Reuse the 2026 sibling's perturber model and consistency check verbatim.
 pub use p9_2026_iorio_precession::{
     quadrupole_prefactor_consistency, saturn_mean_motion_rad_per_day, Perturber,
 };
-
-/// Radians per arcsecond (1 arcsec = pi/648000 rad).
-const ARCSEC_PER_RAD: f64 = 648_000.0 / std::f64::consts::PI;
-
-/// Days per Julian century.
-const DAYS_PER_CENTURY: f64 = 100.0 * YEAR_DAYS;
 
 /// A known planet whose perihelion precession we constrain, with the adopted
 /// observational bound on its *anomalous* secular apsidal rate.
@@ -175,14 +169,7 @@ pub fn bound_for(name: &str) -> Option<PlanetBound> {
 ///   G = sqrt(1 - e^2) / (1 - e_p9^2)^{3/2}.
 /// ```
 pub fn planet_perihelion_precession_arcsec_per_cy(planet: &PlanetBound, p9: &Perturber) -> f64 {
-    let n = planet.mean_motion_rad_per_day(); // rad/day
-    let mass_ratio = p9.mass_solar();
-    let alpha = planet.a_au / p9.a_au;
-    let geometry = (1.0 - planet.e * planet.e).sqrt() / (1.0 - p9.e * p9.e).powf(1.5);
-
-    let rate_rad_per_day = 0.75 * n * mass_ratio * alpha * alpha * alpha * geometry;
-
-    rate_rad_per_day * DAYS_PER_CENTURY * ARCSEC_PER_RAD
+    perturber_perihelion_precession(planet.a_au, planet.e, p9.mass_solar(), p9.a_au, p9.e)
 }
 
 /// True if this perturber's predicted precession of `planet` exceeds the

--- a/crates/p9-2026-iorio-precession/src/lib.rs
+++ b/crates/p9-2026-iorio-precession/src/lib.rs
@@ -81,8 +81,8 @@
 
 use serde::{Deserialize, Serialize};
 
-use p9_core::analysis::secular::coplanar_quadrupole;
-use p9_core::constants::{EARTH_MASS_SOLAR, GM_SUN, YEAR_DAYS};
+use p9_core::analysis::secular::{coplanar_quadrupole, perturber_perihelion_precession};
+use p9_core::constants::{EARTH_MASS_SOLAR, GM_SUN};
 
 /// Saturn's semi-major axis in AU (JPL mean element, J2000). Labelled here
 /// because `p9-core` does not currently carry an inner/giant-planet semi-major
@@ -104,12 +104,6 @@ pub const E_SATURN: f64 = 0.0539;
 /// (2026) uses to set his constraints; it is a *reference constant*, not a
 /// computed quantity, and tightening it only sharpens the exclusions.
 pub const SATURN_PRECESSION_BOUND_ARCSEC_PER_CY: f64 = 1.0e-3;
-
-/// Radians per arcsecond (1 arcsec = pi/648000 rad).
-const ARCSEC_PER_RAD: f64 = 648_000.0 / std::f64::consts::PI;
-
-/// Days per Julian century.
-const DAYS_PER_CENTURY: f64 = 100.0 * YEAR_DAYS;
 
 /// A candidate distant perturber: mass (in Earth masses), semi-major axis (AU)
 /// and orbital eccentricity. The three hypotheses are constructors below.
@@ -180,16 +174,7 @@ impl Perturber {
 ///   G = sqrt(1 - e_Sat^2) / (1 - e_p^2)^{3/2}.
 /// ```
 pub fn saturn_perihelion_precession_arcsec_per_cy(p: &Perturber) -> f64 {
-    let n_sat = saturn_mean_motion_rad_per_day(); // rad/day
-    let mass_ratio = p.mass_solar();
-    let alpha = A_SATURN_AU / p.a_au;
-    let geometry = (1.0 - E_SATURN * E_SATURN).sqrt() / (1.0 - p.e * p.e).powf(1.5);
-
-    // rate in rad/day
-    let rate_rad_per_day = 0.75 * n_sat * mass_ratio * alpha * alpha * alpha * geometry;
-
-    // rad/day -> arcsec/century
-    rate_rad_per_day * DAYS_PER_CENTURY * ARCSEC_PER_RAD
+    perturber_perihelion_precession(A_SATURN_AU, E_SATURN, p.mass_solar(), p.a_au, p.e)
 }
 
 /// Saturn's Keplerian mean motion n = sqrt(GM_sun / a^3) in radians/day.
@@ -255,7 +240,7 @@ pub fn critical_distance_au(p: &Perturber) -> f64 {
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use p9_core::constants::TWO_PI;
+    use p9_core::constants::{TWO_PI, YEAR_DAYS};
 
     #[test]
     fn test_mean_motion_matches_saturn_period() {

--- a/crates/p9-core/src/analysis/secular.rs
+++ b/crates/p9-core/src/analysis/secular.rs
@@ -22,6 +22,54 @@
 
 use std::f64::consts::PI;
 
+use crate::constants::{GM_SUN, YEAR_DAYS};
+
+/// Radians per arcsecond (1 arcsec = π/648000 rad).
+const ARCSEC_PER_RAD: f64 = 648_000.0 / PI;
+
+/// Days per Julian century.
+const DAYS_PER_CENTURY: f64 = 100.0 * YEAR_DAYS;
+
+/// Secular precession rate of an inner planet's longitude of perihelion induced
+/// by a coplanar external perturber, in **arcseconds per century**.
+///
+/// This is the doubly orbit-averaged quadrupole apsidal rate (Lagrange's
+/// planetary equation for ϖ in the coplanar limit applied to
+/// [`coplanar_quadrupole`]), whose closed form is
+///
+/// ```text
+///   d(ϖ)/dt = (3/4) n (m_p/M_sun) (a/a_p)^3 * G(e, e_p),
+///   G(e, e_p) = sqrt(1 - e^2) / (1 - e_p^2)^{3/2},
+/// ```
+///
+/// with `n = sqrt(GM_sun / a^3)` the planet's Keplerian mean motion. The rate
+/// scales linearly in the perturber mass and as the inverse cube of its
+/// distance (the tidal-field gradient ∝ GM_p / a_p^3), and is independent of
+/// the planet's own eccentricity to leading order.
+///
+/// * `a_au`: inner planet semi-major axis (AU)
+/// * `e`: inner planet eccentricity
+/// * `mass_p_solar`: perturber mass in solar masses
+/// * `a_p_au`: perturber semi-major axis (AU)
+/// * `e_p`: perturber eccentricity
+pub fn perturber_perihelion_precession(
+    a_au: f64,
+    e: f64,
+    mass_p_solar: f64,
+    a_p_au: f64,
+    e_p: f64,
+) -> f64 {
+    let n = (GM_SUN / a_au.powi(3)).sqrt(); // rad/day
+    let alpha = a_au / a_p_au;
+    let geometry = (1.0 - e * e).sqrt() / (1.0 - e_p * e_p).powf(1.5);
+
+    // rate in rad/day
+    let rate_rad_per_day = 0.75 * n * mass_p_solar * alpha * alpha * alpha * geometry;
+
+    // rad/day -> arcsec/century
+    rate_rad_per_day * DAYS_PER_CENTURY * ARCSEC_PER_RAD
+}
+
 /// Quadrupole coupling constant C = gm_p α² / (4 a_p (1 − e_p²)^{3/2}).
 fn coupling(a: f64, a_p: f64, e_p: f64, gm_p: f64) -> f64 {
     let alpha = a / a_p;
@@ -208,6 +256,34 @@ mod tests {
     use crate::constants::GM_SUN;
 
     const GM_P: f64 = 10.0 * 3.003489e-6 * GM_SUN; // 10 Earth masses
+
+    #[test]
+    fn test_precession_scales_linearly_with_mass() {
+        // Two masses, same a, e and perturber geometry: rate scales linearly.
+        let r1 = perturber_perihelion_precession(9.5371, 0.0, 3.0 * 3.003489e-6, 400.0, 0.0);
+        let r2 = perturber_perihelion_precession(9.5371, 0.0, 9.0 * 3.003489e-6, 400.0, 0.0);
+        assert!((r2 / r1 - 3.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_precession_scales_as_inverse_cube_of_distance() {
+        // Two perturber distances, same mass: ratio follows (a1/a2)^3.
+        let m = 5.0 * 3.003489e-6;
+        let r_near = perturber_perihelion_precession(9.5371, 0.0, m, 200.0, 0.0);
+        let r_far = perturber_perihelion_precession(9.5371, 0.0, m, 400.0, 0.0);
+        let cube = (400.0_f64 / 200.0).powi(3); // = 8
+        assert!((r_near / r_far - cube).abs() < 1e-6 * cube);
+    }
+
+    #[test]
+    fn test_eccentric_perturber_enhances_precession() {
+        // (1 - e_p^2)^{-3/2} enhancement from perturber eccentricity.
+        let m = 5.0 * 3.003489e-6;
+        let r_c = perturber_perihelion_precession(9.5371, 0.0, m, 300.0, 0.0);
+        let r_e = perturber_perihelion_precession(9.5371, 0.0, m, 300.0, 0.5);
+        let factor = (1.0 - 0.5_f64 * 0.5).powf(-1.5);
+        assert!((r_e / r_c - factor).abs() < 1e-12 * factor);
+    }
 
     #[test]
     fn test_quadrupole_has_no_apsidal_dependence() {


### PR DESCRIPTION
Coalesce G4: lift planet perihelion precession into p9-core::analysis::secular; repoint both Iorio crates.