### PR TITLE
Coalesce G5: giant-planet wire/angular-momentum into p9-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,7 +1326,6 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "nalgebra",
- "p9-2016-obliquity",
  "p9-core",
  "serde",
  "serde_json",
@@ -1338,7 +1337,6 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "nalgebra",
- "p9-2016-obliquity",
  "p9-core",
  "serde",
  "serde_json",

--- a/crates/p9-2016-obliquity-gomes/Cargo.toml
+++ b/crates/p9-2016-obliquity-gomes/Cargo.toml
@@ -6,7 +6,6 @@ description = "Reproduction of Gomes, Deienno & Morbidelli (2016) 'The inclinati
 
 [dependencies]
 p9-core = { path = "../p9-core" }
-p9-2016-obliquity = { path = "../p9-2016-obliquity" }
 nalgebra = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/p9-2016-obliquity-gomes/src/precession_model.rs
+++ b/crates/p9-2016-obliquity-gomes/src/precession_model.rs
@@ -4,8 +4,9 @@
 //! ## Physical picture
 //!
 //! We treat the four giant planets as a single rigid "wire" of orbital
-//! angular momentum L_p (reusing the per-planet model in the sibling crate's
-//! `solar_model`), and Planet Nine as an outer wire of angular momentum L_9.
+//! angular momentum L_p (reusing the per-planet wire set in
+//! `p9_core::initial_conditions::giant_planets`), and Planet Nine as an outer
+//! wire of angular momentum L_9.
 //! The two wires interact through the quadrupole secular Hamiltonian. The
 //! total angular momentum
 //!
@@ -39,8 +40,8 @@
 
 use std::f64::consts::PI;
 
-use p9_2016_obliquity::solar_model;
 use p9_core::constants::*;
+use p9_core::initial_conditions::giant_planets;
 
 /// Parameters of the Gomes precession model.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
@@ -80,12 +81,12 @@ impl GomesParams {
 
 /// Giant-planet orbital angular momentum magnitude (M_sun·AU²/day).
 pub fn l_planets() -> f64 {
-    solar_model::giant_planet_angular_momentum()
+    giant_planets::giant_planet_angular_momentum()
 }
 
 /// Planet Nine orbital angular momentum magnitude (M_sun·AU²/day).
 pub fn l_p9(p: &GomesParams) -> f64 {
-    solar_model::p9_angular_momentum(p.m9_solar(), p.a9, p.e9)
+    giant_planets::p9_angular_momentum(p.m9_solar(), p.a9, p.e9)
 }
 
 /// Total angular-momentum magnitude with the two wires inclined by `i_mutual`.
@@ -121,10 +122,10 @@ fn coupling_constant(m1: f64, m2: f64, a_inner: f64, a_outer: f64, epsilon_outer
 }
 
 /// Total giant-planet ↔ Planet Nine quadrupole coupling, summed per planet
-/// (∝ Σ mᵢ aᵢ²), reusing the giant-planet wire set from the sibling crate.
+/// (∝ Σ mᵢ aᵢ²), reusing the giant-planet wire set from p9-core.
 pub fn coupling_planets_p9(p: &GomesParams) -> f64 {
     let eps9 = p.epsilon_9();
-    solar_model::GIANT_PLANETS
+    giant_planets::GIANT_PLANETS
         .iter()
         .map(|&(m_i, a_i)| coupling_constant(m_i, p.m9_solar(), a_i, p.a9, eps9))
         .sum()

--- a/crates/p9-2016-obliquity-lai/Cargo.toml
+++ b/crates/p9-2016-obliquity-lai/Cargo.toml
@@ -6,7 +6,6 @@ description = "Reproduction of Lai (2016) 'Solar Obliquity Induced by Planet Nin
 
 [dependencies]
 p9-core = { path = "../p9-core" }
-p9-2016-obliquity = { path = "../p9-2016-obliquity" }
 nalgebra = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/p9-2016-obliquity-lai/src/lib.rs
+++ b/crates/p9-2016-obliquity-lai/src/lib.rs
@@ -1,7 +1,7 @@
 //! Reproduction of Lai (2016)
 //! "Solar Obliquity Induced by Planet Nine: Analytic Theory" (arXiv:1608.01421).
 //!
-//! Where the sibling crate [`p9_2016_obliquity`] integrates the full vector
+//! Where the sibling `p9-2016-obliquity` crate integrates the full vector
 //! secular Hamiltonian numerically, Lai (2016) writes down a *closed-form*
 //! analytic theory for the same physics and this crate reproduces it.
 //!
@@ -21,8 +21,8 @@
 //! and Lai's published coefficients (87.5 Gyr, 55.8 Gyr, 462 AU prefactor)
 //! are kept as labelled constants and pinned against the computation in tests.
 //!
-//! The planet angular momenta reuse the sibling crate's
-//! [`p9_2016_obliquity::solar_model`] giant-planet table and angular-momentum
+//! The planet angular momenta reuse the
+//! `p9_core::initial_conditions::giant_planets` table and angular-momentum
 //! helper; the solar J₂ and masses come from `p9_core::constants`.
 
 pub mod planets;

--- a/crates/p9-2016-obliquity-lai/src/planets.rs
+++ b/crates/p9-2016-obliquity-lai/src/planets.rs
@@ -2,13 +2,14 @@
 //! sums over for the total orbital angular momentum `L`, the P9-forced
 //! precession rate `Ω_L`, and the solar spin precession `Ω★ps`.
 //!
-//! The four giants reuse [`p9_2016_obliquity::solar_model::GIANT_PLANETS`]; the
-//! four terrestrials are added here (they contribute < 0.1% of `L` and `Ω_L`
-//! but matter at the percent level for `Ω★ps ∝ Σ mⱼ/aⱼ³`, which is weighted
-//! toward the inner planets relative to the angular-momentum sums).
+//! The four giants reuse
+//! [`p9_core::initial_conditions::giant_planets::GIANT_PLANETS`]; the four
+//! terrestrials are added here (they contribute < 0.1% of `L` and `Ω_L` but
+//! matter at the percent level for `Ω★ps ∝ Σ mⱼ/aⱼ³`, which is weighted toward
+//! the inner planets relative to the angular-momentum sums).
 
-use p9_2016_obliquity::solar_model::GIANT_PLANETS;
 use p9_core::constants::*;
+use p9_core::initial_conditions::giant_planets::GIANT_PLANETS;
 
 /// Terrestrial planet (mass in M_sun, semi-major axis in AU). Masses from
 /// JPL DE440 GM ratios; semi-major axes are mean osculating values.

--- a/crates/p9-2016-obliquity/src/parameter_survey.rs
+++ b/crates/p9-2016-obliquity/src/parameter_survey.rs
@@ -4,9 +4,9 @@
 //! required to produce the observed 6° solar obliquity.
 
 use p9_core::constants::*;
+use p9_core::initial_conditions::giant_planets;
 
 use crate::secular_hamiltonian::{integrate_obliquity, SecularParams, SpinOrbitState};
-use crate::solar_model;
 
 /// Result of a parameter survey point.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -73,8 +73,8 @@ pub fn find_required_inclination(
 
 /// Create an initial state for given P9 parameters.
 fn make_initial_state(m9_solar: f64, a9: f64, e9: f64, i9: f64) -> SpinOrbitState {
-    let l_gp_mag = solar_model::giant_planet_angular_momentum();
-    let l_9_mag = solar_model::p9_angular_momentum(m9_solar, a9, e9);
+    let l_gp_mag = giant_planets::giant_planet_angular_momentum();
+    let l_9_mag = giant_planets::p9_angular_momentum(m9_solar, a9, e9);
     SpinOrbitState::from_inclinations(i9, std::f64::consts::PI, l_gp_mag, l_9_mag)
 }
 

--- a/crates/p9-2016-obliquity/src/secular_hamiltonian.rs
+++ b/crates/p9-2016-obliquity/src/secular_hamiltonian.rs
@@ -14,6 +14,7 @@
 //!   dL̂_i/dt = (3/L_i) Σ_j C_ij (L̂_i · L̂_j) (L̂_i × L̂_j)
 
 use p9_core::constants::*;
+use p9_core::initial_conditions::giant_planets;
 
 use crate::solar_model;
 
@@ -117,7 +118,7 @@ fn coupling_constant(m1: f64, m2: f64, a_inner: f64, a_outer: f64, epsilon_outer
 /// systematic in the spin-orbit coupling that shifts the required-i₉
 /// contours.
 fn coupling_gp_9(m9_solar: f64, a9: f64, epsilon_9: f64) -> f64 {
-    solar_model::GIANT_PLANETS
+    giant_planets::GIANT_PLANETS
         .iter()
         .map(|&(m_i, a_i)| coupling_constant(m_i, m9_solar, a_i, a9, epsilon_9))
         .sum()
@@ -126,7 +127,7 @@ fn coupling_gp_9(m9_solar: f64, a9: f64, epsilon_9: f64) -> f64 {
 /// Solar-spin-ring ↔ giant-planet coupling, summed planet by planet
 /// (∝ Σ mᵢ/aᵢ³; the collapsed ring underestimates this by ~42%).
 fn coupling_sun_gp(m_sun_eff: f64, a_tilde: f64) -> f64 {
-    solar_model::GIANT_PLANETS
+    giant_planets::GIANT_PLANETS
         .iter()
         .map(|&(m_i, a_i)| coupling_constant(m_sun_eff, m_i, a_tilde, a_i, 1.0))
         .sum()
@@ -269,9 +270,9 @@ pub fn integrate_obliquity(
     let dt = params.dt;
     let n_steps = (t_age / dt).ceil() as usize;
 
-    let l_gp_mag = solar_model::giant_planet_angular_momentum();
+    let l_gp_mag = giant_planets::giant_planet_angular_momentum();
     let epsilon_9 = params.epsilon_9();
-    let l_9_mag = solar_model::p9_angular_momentum(params.m9_solar, params.a9, params.e9);
+    let l_9_mag = giant_planets::p9_angular_momentum(params.m9_solar, params.a9, params.e9);
 
     // Giant planet ↔ Planet Nine coupling (constant, per-planet sum)
     let c_gp_9 = coupling_gp_9(params.m9_solar, params.a9, epsilon_9);
@@ -384,8 +385,8 @@ mod tests {
         // H6 regression: the collapsed L-conserving ring (m_total at a_eff
         // with L = m_total √(GM a_eff)) underestimates both coupling sums
         // by ~40-45%; the per-planet sums must be substantially larger.
-        let m_total: f64 = solar_model::GIANT_PLANETS.iter().map(|&(m, _)| m).sum();
-        let l_total = solar_model::giant_planet_angular_momentum();
+        let m_total: f64 = giant_planets::GIANT_PLANETS.iter().map(|&(m, _)| m).sum();
+        let l_total = giant_planets::giant_planet_angular_momentum();
         let a_eff = (l_total / m_total).powi(2) / G_AU3_MSUN_DAY2;
 
         let m9 = 10.0 * EARTH_MASS_SOLAR;
@@ -419,8 +420,8 @@ mod tests {
         // must match the analytic frequency.
         let m9_solar = 10.0 * EARTH_MASS_SOLAR;
         let (a9, e9) = (700.0, 0.6);
-        let l_gp_mag = solar_model::giant_planet_angular_momentum();
-        let l_9_mag = solar_model::p9_angular_momentum(m9_solar, a9, e9);
+        let l_gp_mag = giant_planets::giant_planet_angular_momentum();
+        let l_9_mag = giant_planets::p9_angular_momentum(m9_solar, a9, e9);
 
         let initial = SpinOrbitState::from_inclinations(20.0 * DEG2RAD, PI, l_gp_mag, l_9_mag);
         let theta = initial.mutual_inclination();
@@ -466,8 +467,8 @@ mod tests {
         // for truncation error to dominate roundoff.
         let m9_solar = 10.0 * EARTH_MASS_SOLAR;
         let (a9, e9) = (70.0, 0.6);
-        let l_gp_mag = solar_model::giant_planet_angular_momentum();
-        let l_9_mag = solar_model::p9_angular_momentum(m9_solar, a9, e9);
+        let l_gp_mag = giant_planets::giant_planet_angular_momentum();
+        let l_9_mag = giant_planets::p9_angular_momentum(m9_solar, a9, e9);
         let initial = SpinOrbitState::from_inclinations(30.0 * DEG2RAD, PI, l_gp_mag, l_9_mag);
 
         let t_total = 1e7 * YEAR_DAYS;
@@ -510,9 +511,9 @@ mod tests {
     #[test]
     fn test_no_obliquity_without_p9_inclination() {
         // With i_9 = 0, all vectors are aligned → no obliquity excitation
-        let l_gp_mag = solar_model::giant_planet_angular_momentum();
+        let l_gp_mag = giant_planets::giant_planet_angular_momentum();
         let m9_solar = 10.0 * EARTH_MASS_SOLAR;
-        let l_9_mag = solar_model::p9_angular_momentum(m9_solar, 700.0, 0.6);
+        let l_9_mag = giant_planets::p9_angular_momentum(m9_solar, 700.0, 0.6);
 
         let initial = SpinOrbitState::from_inclinations(0.001, PI, l_gp_mag, l_9_mag);
 
@@ -537,8 +538,8 @@ mod tests {
     #[test]
     fn test_obliquity_excited_by_inclined_p9() {
         let m9_solar = 15.0 * EARTH_MASS_SOLAR;
-        let l_gp_mag = solar_model::giant_planet_angular_momentum();
-        let l_9_mag = solar_model::p9_angular_momentum(m9_solar, 500.0, 0.5);
+        let l_gp_mag = giant_planets::giant_planet_angular_momentum();
+        let l_9_mag = giant_planets::p9_angular_momentum(m9_solar, 500.0, 0.5);
 
         let initial = SpinOrbitState::from_inclinations(30.0 * DEG2RAD, PI, l_gp_mag, l_9_mag);
 
@@ -565,8 +566,8 @@ mod tests {
     #[test]
     fn test_mutual_inclination_roughly_conserved() {
         let m9_solar = 10.0 * EARTH_MASS_SOLAR;
-        let l_gp_mag = solar_model::giant_planet_angular_momentum();
-        let l_9_mag = solar_model::p9_angular_momentum(m9_solar, 700.0, 0.6);
+        let l_gp_mag = giant_planets::giant_planet_angular_momentum();
+        let l_9_mag = giant_planets::p9_angular_momentum(m9_solar, 700.0, 0.6);
 
         let initial = SpinOrbitState::from_inclinations(20.0 * DEG2RAD, PI, l_gp_mag, l_9_mag);
 
@@ -597,8 +598,8 @@ mod tests {
     #[test]
     fn test_integration_produces_snapshots() {
         let m9_solar = 10.0 * EARTH_MASS_SOLAR;
-        let l_gp_mag = solar_model::giant_planet_angular_momentum();
-        let l_9_mag = solar_model::p9_angular_momentum(m9_solar, 700.0, 0.6);
+        let l_gp_mag = giant_planets::giant_planet_angular_momentum();
+        let l_9_mag = giant_planets::p9_angular_momentum(m9_solar, 700.0, 0.6);
 
         let initial = SpinOrbitState::from_inclinations(20.0 * DEG2RAD, PI, l_gp_mag, l_9_mag);
 

--- a/crates/p9-2016-obliquity/src/solar_model.rs
+++ b/crates/p9-2016-obliquity/src/solar_model.rs
@@ -76,36 +76,6 @@ pub fn solar_ring_semimajor_axis(omega: f64) -> f64 {
     (numerator / denominator).powf(1.0 / 3.0)
 }
 
-/// The four giant planets as (mass in M_sun, semi-major axis in AU) — the
-/// rigid coplanar "wire" set whose couplings are summed *per planet*
-/// (Bailey+ 2016). Collapsing them to a single angular-momentum-conserving
-/// ring underestimates Σmᵢ/aᵢ³-type couplings by ~40% and Σmᵢaᵢ² ones
-/// by ~45%.
-pub const GIANT_PLANETS: [(f64, f64); 4] = [
-    (MASS_JUPITER_SOLAR, 5.2026),
-    (MASS_SATURN_SOLAR, 9.5549),
-    (MASS_URANUS_SOLAR, 19.2184),
-    (MASS_NEPTUNE_SOLAR, A_NEPTUNE_AU),
-];
-
-/// Combined angular momentum of the four giant planets.
-///
-/// L_planets = Σ m_i * sqrt(G * M_sun * a_i) for each giant planet.
-/// Returns in M_sun * AU² / day.
-pub fn giant_planet_angular_momentum() -> f64 {
-    GIANT_PLANETS
-        .iter()
-        .map(|&(m, a)| m * (G_AU3_MSUN_DAY2 * M_SUN_SOLAR * a).sqrt())
-        .sum()
-}
-
-/// Planet Nine angular momentum magnitude.
-///
-/// L₉ = m₉ * sqrt(G * M_sun * a₉) * sqrt(1 - e₉²)
-pub fn p9_angular_momentum(mass_solar: f64, a: f64, e: f64) -> f64 {
-    mass_solar * (G_AU3_MSUN_DAY2 * M_SUN_SOLAR * a).sqrt() * (1.0 - e * e).sqrt()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -169,28 +139,5 @@ mod tests {
 
         // Should be very small (inside the Sun)
         assert!(a_tilde > 0.0 && a_tilde < R_SUN_AU);
-    }
-
-    #[test]
-    fn test_giant_planet_angular_momentum() {
-        let l = giant_planet_angular_momentum();
-        // Should be positive and dominated by Jupiter
-        assert!(l > 0.0);
-
-        let l_jup = MASS_JUPITER_SOLAR * (G_AU3_MSUN_DAY2 * 5.2026_f64).sqrt();
-        // Jupiter should be > 50% of total
-        assert!(l_jup / l > 0.5);
-    }
-
-    #[test]
-    fn test_p9_angular_momentum() {
-        let m9 = 10.0 * EARTH_MASS_SOLAR;
-        let l9 = p9_angular_momentum(m9, 700.0, 0.6);
-        let l_planets = giant_planet_angular_momentum();
-
-        // P9's angular momentum is significant but smaller than giant planets
-        // At a=700 AU, L_9/L_gp ~ 0.2 (large a compensates small mass)
-        assert!(l9 < l_planets);
-        assert!(l9 > 0.0);
     }
 }

--- a/crates/p9-core/src/initial_conditions/giant_planets.rs
+++ b/crates/p9-core/src/initial_conditions/giant_planets.rs
@@ -1,0 +1,73 @@
+//! Coplanar giant-planet "wire" set and angular-momentum helpers.
+//!
+//! A flat secular representation of the four giant planets as
+//! `(mass [M_sun], semi-major axis [AU])` pairs, distinct from the full
+//! J2000 state vectors in [`super::planets`]: the secular obliquity/precession
+//! theories (Bailey+ 2016, Gomes+ 2016, Lai 2016) treat the planets as rigid
+//! coplanar wires and only need mass and semi-major axis.
+//!
+//! Masses come from p9-core's [`MASS_JUPITER_SOLAR`] … [`MASS_NEPTUNE_SOLAR`]
+//! constants (the same DE440 planetary-system masses used by
+//! [`super::planets`]); Neptune's semi-major axis is [`A_NEPTUNE_AU`]. The
+//! Jupiter/Saturn/Uranus semi-major axes are the secular-theory values used by
+//! the obliquity reproductions and are canonical here for those crates.
+
+use crate::constants::*;
+
+/// The four giant planets as (mass in M_sun, semi-major axis in AU) — the
+/// rigid coplanar "wire" set whose couplings are summed *per planet*
+/// (Bailey+ 2016). Collapsing them to a single angular-momentum-conserving
+/// ring underestimates Σmᵢ/aᵢ³-type couplings by ~40% and Σmᵢaᵢ² ones
+/// by ~45%.
+pub const GIANT_PLANETS: [(f64, f64); 4] = [
+    (MASS_JUPITER_SOLAR, 5.2026),
+    (MASS_SATURN_SOLAR, 9.5549),
+    (MASS_URANUS_SOLAR, 19.2184),
+    (MASS_NEPTUNE_SOLAR, A_NEPTUNE_AU),
+];
+
+/// Combined angular momentum of the four giant planets.
+///
+/// L_planets = Σ m_i * sqrt(G * M_sun * a_i) for each giant planet.
+/// Returns in M_sun * AU² / day.
+pub fn giant_planet_angular_momentum() -> f64 {
+    GIANT_PLANETS
+        .iter()
+        .map(|&(m, a)| m * (G_AU3_MSUN_DAY2 * a).sqrt())
+        .sum()
+}
+
+/// Planet Nine angular momentum magnitude.
+///
+/// L₉ = m₉ * sqrt(G * M_sun * a₉) * sqrt(1 - e₉²)
+pub fn p9_angular_momentum(mass_solar: f64, a: f64, e: f64) -> f64 {
+    mass_solar * (G_AU3_MSUN_DAY2 * a).sqrt() * (1.0 - e * e).sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_giant_planet_angular_momentum() {
+        let l = giant_planet_angular_momentum();
+        // Should be positive and dominated by Jupiter
+        assert!(l > 0.0);
+
+        let l_jup = MASS_JUPITER_SOLAR * (G_AU3_MSUN_DAY2 * 5.2026_f64).sqrt();
+        // Jupiter should be > 50% of total
+        assert!(l_jup / l > 0.5);
+    }
+
+    #[test]
+    fn test_p9_angular_momentum() {
+        let m9 = 10.0 * EARTH_MASS_SOLAR;
+        let l9 = p9_angular_momentum(m9, 700.0, 0.6);
+        let l_planets = giant_planet_angular_momentum();
+
+        // P9's angular momentum is significant but smaller than giant planets
+        // At a=700 AU, L_9/L_gp ~ 0.2 (large a compensates small mass)
+        assert!(l9 < l_planets);
+        assert!(l9 > 0.0);
+    }
+}

--- a/crates/p9-core/src/initial_conditions/mod.rs
+++ b/crates/p9-core/src/initial_conditions/mod.rs
@@ -1,2 +1,3 @@
+pub mod giant_planets;
 pub mod planets;
 pub mod scattered_disk;


### PR DESCRIPTION
Coalesce G5: lift giant-planet wire/angular-momentum model into p9-core::initial_conditions; repoint obliquity crates.