### PR TITLE
Coalesce G3: lift P9 orbit geometry and favored-nu constants into core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,7 +2026,6 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "nalgebra",
- "p9-2016-cassini-ranging",
  "p9-2024-siraj-orbit",
  "p9-core",
  "rand 0.8.5",

--- a/crates/p9-2016-cassini-ranging/src/geometry.rs
+++ b/crates/p9-2016-cassini-ranging/src/geometry.rs
@@ -1,107 +1,11 @@
 //! Planet Nine heliocentric geometry along the Brown & Batygin orbit.
 //!
 //! The Cassini constraint is a function of WHERE P9 is on its orbit, i.e. of
-//! its true anomaly `ν`. This module turns a `ν` into the full heliocentric
-//! position vector (and distance) using `p9_core`'s element→Cartesian
-//! conversion, reusing the workspace `P9Params` and the shared Kepler solver.
+//! its true anomaly `ν`. The generic element→position machinery now lives in
+//! [`p9_core::types`]; this module just re-exports it under the paper-local
+//! names the perturbation code uses.
 
-use nalgebra::Vector3;
-
-use p9_core::constants::{GM_SUN, TWO_PI};
-use p9_core::types::{elements_to_cartesian, OrbitalElements, P9Params, StateVector};
-
-/// Heliocentric geometry of Planet Nine at one true anomaly.
-#[derive(Debug, Clone, Copy)]
-pub struct P9Geometry {
-    /// True anomaly along the orbit (radians).
-    pub true_anomaly: f64,
-    /// Heliocentric position (AU, ecliptic J2000).
-    pub position: Vector3<f64>,
-    /// Heliocentric distance `r(ν) = a(1-e²)/(1 + e cos ν)` (AU).
-    pub distance: f64,
-}
-
-/// Convert a true anomaly to the mean anomaly for an elliptic orbit
-/// (`0 ≤ e < 1`). Inverse of the Kepler chain `M → E → ν`.
-pub fn true_to_mean_anomaly(e: f64, nu: f64) -> f64 {
-    // Eccentric anomaly E from true anomaly ν.
-    let ea = ((1.0 - e) / (1.0 + e)).sqrt() * (nu / 2.0).tan();
-    let ea = 2.0 * ea.atan();
-    // Mean anomaly M = E - e sin E, wrapped to [0, 2π).
-    let m = ea - e * ea.sin();
-    m.rem_euclid(TWO_PI)
-}
-
-/// Heliocentric position of P9 at true anomaly `nu` (radians) on the orbit
-/// described by `params`. The `mean_anomaly` field of `params` is overridden:
-/// the orbit's orientation (a, e, i, ω, Ω) is what matters, and we sweep ν.
-pub fn p9_position_at_true_anomaly(params: &P9Params, nu: f64) -> P9Geometry {
-    let elements = OrbitalElements {
-        a: params.a,
-        e: params.e,
-        i: params.i,
-        omega_big: params.omega_big,
-        omega: params.omega,
-        mean_anomaly: true_to_mean_anomaly(params.e, nu),
-    };
-    let state: StateVector = elements_to_cartesian(&elements, GM_SUN);
-    let position = state.pos;
-    P9Geometry {
-        true_anomaly: nu,
-        position,
-        distance: position.norm(),
-    }
-}
-
-/// Analytic heliocentric distance `r(ν)` for the conic (AU), independent of the
-/// Cartesian path; used as a cross-check.
-pub fn helio_distance_at_true_anomaly(params: &P9Params, nu: f64) -> f64 {
-    let p = params.a * (1.0 - params.e * params.e);
-    p / (1.0 + params.e * nu.cos())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use approx::assert_relative_eq;
-    use std::f64::consts::PI;
-
-    fn bb_orbit() -> P9Params {
-        crate::brown_batygin_orbit()
-    }
-
-    #[test]
-    fn true_mean_roundtrip_through_core_kepler() {
-        let e = 0.6;
-        for deg in [10.0, 73.0, 108.0, 200.0, 333.0] {
-            let nu = deg * PI / 180.0;
-            let m = true_to_mean_anomaly(e, nu);
-            // Re-solve M → E → ν via the shared core solver and compare.
-            let ea = p9_core::types::solve_kepler(e, m);
-            let sin_nu = (1.0 - e * e).sqrt() * ea.sin() / (1.0 - e * ea.cos());
-            let cos_nu = (ea.cos() - e) / (1.0 - e * ea.cos());
-            let nu_back = sin_nu.atan2(cos_nu).rem_euclid(TWO_PI);
-            assert_relative_eq!(nu_back, nu.rem_euclid(TWO_PI), epsilon = 1e-9);
-        }
-    }
-
-    #[test]
-    fn perihelion_and_aphelion_distances() {
-        let p = bb_orbit();
-        let peri = p9_position_at_true_anomaly(&p, 0.0);
-        let apo = p9_position_at_true_anomaly(&p, PI);
-        assert_relative_eq!(peri.distance, p.a * (1.0 - p.e), epsilon = 1e-9);
-        assert_relative_eq!(apo.distance, p.a * (1.0 + p.e), epsilon = 1e-9);
-    }
-
-    #[test]
-    fn cartesian_distance_matches_conic_formula() {
-        let p = bb_orbit();
-        for deg in [0.0, 45.0, 108.0, 180.0, 270.0] {
-            let nu = deg * PI / 180.0;
-            let g = p9_position_at_true_anomaly(&p, nu);
-            let r_conic = helio_distance_at_true_anomaly(&p, nu);
-            assert_relative_eq!(g.distance, r_conic, epsilon = 1e-7);
-        }
-    }
-}
+pub use p9_core::types::{
+    helio_distance_at_true_anomaly, position_at_true_anomaly as p9_position_at_true_anomaly,
+    true_to_mean_anomaly, OrbitGeometry as P9Geometry,
+};

--- a/crates/p9-2016-cassini-ranging/src/lib.rs
+++ b/crates/p9-2016-cassini-ranging/src/lib.rs
@@ -46,47 +46,21 @@
 pub mod geometry;
 pub mod perturbation;
 
-use p9_core::constants::DEG2RAD;
-use p9_core::types::P9Params;
-
-/// Planet Nine on the Brown & Batygin (2016) orbit, exactly as tabulated by
-/// Fienga et al. (2016), Table 1: `a = 700 AU`, `e = 0.6`, `i = 30°`,
-/// `ω = 150°`, `Ω = 113°` (IERS ecliptic). The mean anomaly is irrelevant here
-/// — the analysis sweeps the true anomaly explicitly. Note `Ω = 113°` differs
-/// from `P9Params::nominal_2016()` (`Ω = 100°`), so this paper-specific orbit
-/// is built directly.
-pub fn brown_batygin_orbit() -> P9Params {
-    P9Params {
-        mass_earth: published::P9_MASS_EARTH,
-        a: 700.0,
-        e: 0.6,
-        i: 30.0 * DEG2RAD,
-        omega: 150.0 * DEG2RAD,
-        omega_big: 113.0 * DEG2RAD,
-        mean_anomaly: 0.0,
-    }
-}
+// The Brown & Batygin (2016) reference orbit and the favored-ν zone now live in
+// `p9_core::data::ephemeris_constraint`; re-export the orbit so callers can
+// build it without naming core.
+pub use p9_core::data::ephemeris_constraint::brown_batygin_orbit;
 
 /// Published reference values from Fienga et al. (2016), kept as labelled
-/// constants (NOT used to derive any computed quantity).
+/// constants (NOT used to derive any computed quantity). The favored-ν zone is
+/// re-exported from [`p9_core::data::ephemeris_constraint`].
 pub mod published {
-    /// Planet Nine mass assumed by the paper, in Earth masses.
-    pub const P9_MASS_EARTH: f64 = 10.0;
-
-    /// Most-probable true anomaly of P9 that REDUCES the Cassini Earth–Saturn
-    /// range residuals (degrees): `v = 117.8°₋₁₀⁺¹¹` (Fienga et al. 2016, §4).
-    pub const PREFERRED_TRUE_ANOMALY_DEG: f64 = 117.8;
-
-    /// Favored interval for the true anomaly (degrees): `v ∈ [108°, 129°]`
-    /// (Fienga et al. 2016, Conclusions / Fig 6 green zone).
-    pub const FAVORED_INTERVAL_DEG: (f64, f64) = (108.0, 129.0);
+    pub use p9_core::data::ephemeris_constraint::{
+        FAVORED_INTERVAL_DEG, P9_MASS_EARTH, PREFERRED_TRUE_ANOMALY_DEG, TRUE_ANOMALY_TOLERANCE_DEG,
+    };
 
     /// Approximate P9 heliocentric distance at the preferred true anomaly (AU).
     pub const PREFERRED_HELIO_DISTANCE_AU: f64 = 600.0;
-
-    /// Tolerance (deg) within which our analytic-proxy favored anomaly should
-    /// land of the published preferred true anomaly.
-    pub const TRUE_ANOMALY_TOLERANCE_DEG: f64 = 30.0;
 }
 
 pub use geometry::{p9_position_at_true_anomaly, P9Geometry};

--- a/crates/p9-2016-holman-payne/src/lib.rs
+++ b/crates/p9-2016-holman-payne/src/lib.rs
@@ -51,14 +51,17 @@ pub mod sky;
 
 use p9_core::types::P9Params;
 
-// Reuse the sibling's orbit and geometry verbatim — the two papers analyze the
-// same Brown & Batygin (2016) reference orbit and the same Sun–Saturn geometry.
-pub use p9_2016_cassini_ranging::brown_batygin_orbit;
-pub use p9_2016_cassini_ranging::geometry::{p9_position_at_true_anomaly, P9Geometry};
+// The two papers analyze the same Brown & Batygin (2016) reference orbit and
+// the same Sun–Saturn geometry; both now live in `p9_core`. The range-residual
+// physics is still reused from the sibling `p9_2016_cassini_ranging` crate.
+pub use p9_core::data::ephemeris_constraint::brown_batygin_orbit;
+pub use p9_core::types::{
+    position_at_true_anomaly as p9_position_at_true_anomaly, OrbitGeometry as P9Geometry,
+};
 
 /// Planet Nine on the Brown & Batygin (2016) orbit used throughout this paper.
-/// Alias of the sibling crate's [`brown_batygin_orbit`]; provided so callers can
-/// build the orbit without naming the sibling crate.
+/// Alias of the core [`brown_batygin_orbit`]; provided so callers can build the
+/// orbit without naming core.
 pub fn holman_payne_orbit() -> P9Params {
     brown_batygin_orbit()
 }

--- a/crates/p9-core/src/data/ephemeris_constraint.rs
+++ b/crates/p9-core/src/data/ephemeris_constraint.rs
@@ -1,0 +1,44 @@
+//! Cassini / Iorio favored true-anomaly zone for Planet Nine.
+//!
+//! Cassini Earth–Saturn range residuals (Fienga et al. 2016) and Saturn-
+//! precession bounds favor Planet Nine being near true anomaly `ν ≈ 108–129°`
+//! on the Brown & Batygin (2016) reference orbit *right now* (and disfavor
+//! large complementary arcs). This module is the shared, documented home for
+//! that reference orbit and the favored-ν constants; the paper-specific range-
+//! residual physics lives in the reproduction crates.
+
+use crate::constants::DEG2RAD;
+use crate::types::P9Params;
+
+/// Planet Nine on the Brown & Batygin (2016) orbit, exactly as tabulated by
+/// Fienga et al. (2016), Table 1: `a = 700 AU`, `e = 0.6`, `i = 30°`,
+/// `ω = 150°`, `Ω = 113°` (IERS ecliptic). The mean anomaly is irrelevant for
+/// the favored-ν analysis — callers sweep the true anomaly explicitly. Note
+/// `Ω = 113°` differs from `P9Params::nominal_2016()` (`Ω = 100°`), so this
+/// paper-reference orbit is built directly.
+pub fn brown_batygin_orbit() -> P9Params {
+    P9Params {
+        mass_earth: P9_MASS_EARTH,
+        a: 700.0,
+        e: 0.6,
+        i: 30.0 * DEG2RAD,
+        omega: 150.0 * DEG2RAD,
+        omega_big: 113.0 * DEG2RAD,
+        mean_anomaly: 0.0,
+    }
+}
+
+/// Planet Nine mass assumed by the Brown & Batygin orbit (Earth masses).
+pub const P9_MASS_EARTH: f64 = 10.0;
+
+/// Most-probable true anomaly of P9 that REDUCES the Cassini Earth–Saturn
+/// range residuals (degrees): `v = 117.8°₋₁₀⁺¹¹` (Fienga et al. 2016, §4).
+pub const PREFERRED_TRUE_ANOMALY_DEG: f64 = 117.8;
+
+/// Favored interval for the true anomaly (degrees): `v ∈ [108°, 129°]`
+/// (Fienga et al. 2016, Conclusions / Fig 6 green zone).
+pub const FAVORED_INTERVAL_DEG: (f64, f64) = (108.0, 129.0);
+
+/// Tolerance (deg) within which an analytic-proxy favored anomaly should land
+/// of the published preferred true anomaly.
+pub const TRUE_ANOMALY_TOLERANCE_DEG: f64 = 30.0;

--- a/crates/p9-core/src/data/mod.rs
+++ b/crates/p9-core/src/data/mod.rs
@@ -1,5 +1,6 @@
 //! Vetted observational data tables shared across the paper crates.
 
+pub mod ephemeris_constraint;
 pub mod etno;
 pub mod refresh;
 pub mod stable_kbos;

--- a/crates/p9-core/src/types.rs
+++ b/crates/p9-core/src/types.rs
@@ -352,6 +352,107 @@ pub fn elements_to_cartesian(elem: &OrbitalElements, gm: f64) -> StateVector {
     StateVector { pos, vel }
 }
 
+// ============================================================
+// True-anomaly geometry helper
+// ============================================================
+
+/// Heliocentric geometry of an orbit evaluated at one true anomaly.
+#[derive(Debug, Clone, Copy)]
+pub struct OrbitGeometry {
+    /// True anomaly along the orbit (radians).
+    pub true_anomaly: f64,
+    /// Heliocentric position (AU, ecliptic J2000).
+    pub position: Vector3<f64>,
+    /// Heliocentric distance `r(ν) = a(1-e²)/(1 + e cos ν)` (AU).
+    pub distance: f64,
+}
+
+/// Convert a true anomaly to the mean anomaly for an elliptic orbit
+/// (`0 ≤ e < 1`). Inverse of the Kepler chain `M → E → ν`.
+pub fn true_to_mean_anomaly(e: f64, nu: f64) -> f64 {
+    // Eccentric anomaly E from true anomaly ν.
+    let ea = ((1.0 - e) / (1.0 + e)).sqrt() * (nu / 2.0).tan();
+    let ea = 2.0 * ea.atan();
+    // Mean anomaly M = E - e sin E, wrapped to [0, 2π).
+    let m = ea - e * ea.sin();
+    m.rem_euclid(TWO_PI)
+}
+
+/// Heliocentric position of an orbit at true anomaly `nu` (radians) on the
+/// orbit described by `params`. The `mean_anomaly` field of `params` is
+/// overridden: the orbit's orientation (a, e, i, ω, Ω) is what matters, and the
+/// caller sweeps ν. Built on [`elements_to_cartesian`].
+pub fn position_at_true_anomaly(params: &P9Params, nu: f64) -> OrbitGeometry {
+    let elements = OrbitalElements {
+        a: params.a,
+        e: params.e,
+        i: params.i,
+        omega_big: params.omega_big,
+        omega: params.omega,
+        mean_anomaly: true_to_mean_anomaly(params.e, nu),
+    };
+    let state: StateVector = elements_to_cartesian(&elements, GM_SUN);
+    let position = state.pos;
+    OrbitGeometry {
+        true_anomaly: nu,
+        position,
+        distance: position.norm(),
+    }
+}
+
+/// Analytic heliocentric distance `r(ν)` for the conic (AU), independent of the
+/// Cartesian path; used as a cross-check.
+pub fn helio_distance_at_true_anomaly(params: &P9Params, nu: f64) -> f64 {
+    let p = params.a * (1.0 - params.e * params.e);
+    p / (1.0 + params.e * nu.cos())
+}
+
+#[cfg(test)]
+mod true_anomaly_geometry_tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use std::f64::consts::PI;
+
+    fn bb_orbit() -> P9Params {
+        crate::data::ephemeris_constraint::brown_batygin_orbit()
+    }
+
+    #[test]
+    fn true_mean_roundtrip_through_core_kepler() {
+        let e = 0.6;
+        for deg in [10.0, 73.0, 108.0, 200.0, 333.0] {
+            let nu = deg * PI / 180.0;
+            let m = true_to_mean_anomaly(e, nu);
+            // Re-solve M → E → ν via the shared core solver and compare.
+            let ea = solve_kepler(e, m);
+            let sin_nu = (1.0 - e * e).sqrt() * ea.sin() / (1.0 - e * ea.cos());
+            let cos_nu = (ea.cos() - e) / (1.0 - e * ea.cos());
+            let nu_back = sin_nu.atan2(cos_nu).rem_euclid(TWO_PI);
+            assert_relative_eq!(nu_back, nu.rem_euclid(TWO_PI), epsilon = 1e-9);
+        }
+    }
+
+    #[test]
+    fn perihelion_and_aphelion_distances() {
+        let p = bb_orbit();
+        let peri = position_at_true_anomaly(&p, 0.0);
+        let apo = position_at_true_anomaly(&p, PI);
+        assert_relative_eq!(peri.distance, p.a * (1.0 - p.e), epsilon = 1e-9);
+        assert_relative_eq!(apo.distance, p.a * (1.0 + p.e), epsilon = 1e-9);
+    }
+
+    #[test]
+    fn cartesian_distance_matches_conic_formula() {
+        let p = bb_orbit();
+        for deg in [0.0, 45.0, 108.0, 180.0, 270.0] {
+            let nu = deg * PI / 180.0;
+            let g = position_at_true_anomaly(&p, nu);
+            let r_conic = helio_distance_at_true_anomaly(&p, nu);
+            assert_relative_eq!(g.distance, r_conic, epsilon = 1e-7);
+        }
+    }
+}
+
 /// Convert Cartesian state vector to Keplerian elements.
 pub fn cartesian_to_elements(state: &StateVector, gm: f64) -> OrbitalElements {
     let r = &state.pos;

--- a/crates/p9-survey/Cargo.toml
+++ b/crates/p9-survey/Cargo.toml
@@ -8,7 +8,6 @@ description = "Cross-paper survey of Planet Nine sky-position predictions, brigh
 p9-core = { path = "../p9-core" }
 nalgebra = { workspace = true }
 p9-2024-siraj-orbit = { path = "../p9-2024-siraj-orbit" }
-p9-2016-cassini-ranging = { path = "../p9-2016-cassini-ranging" }
 rand = { workspace = true }
 rand_distr = { workspace = true }
 serde = { workspace = true }

--- a/crates/p9-survey/src/ephemeris.rs
+++ b/crates/p9-survey/src/ephemeris.rs
@@ -7,20 +7,19 @@
 //! today — i.e. a prior on the current true anomaly — which directly cuts the
 //! sky RA range, not just the declination.
 //!
-//! The favored interval and tolerance are sourced from the reproduction crate
-//! `p9_2016_cassini_ranging::published`; here we turn them into (1) a smooth
+//! The favored interval and tolerance are sourced from
+//! `p9_core::data::ephemeris_constraint`; here we turn them into (1) a smooth
 //! ν-weight to reweight the otherwise-uniform orbital phase, and (2) the
 //! favored-ν sky arc for plotting.
 
 use nalgebra::Vector3;
-use p9_2016_cassini_ranging::geometry::p9_position_at_true_anomaly;
-use p9_2016_cassini_ranging::published::{FAVORED_INTERVAL_DEG, TRUE_ANOMALY_TOLERANCE_DEG};
 use p9_core::constants::DEG2RAD;
 use p9_core::coords::sky::ecliptic_vec_to_equatorial_deg;
-use p9_core::types::P9Params;
+use p9_core::data::ephemeris_constraint::{FAVORED_INTERVAL_DEG, TRUE_ANOMALY_TOLERANCE_DEG};
+use p9_core::types::{position_at_true_anomaly, P9Params};
 
-/// Favored true-anomaly interval (deg), from Fienga et al. 2016 via the
-/// cassini-ranging crate.
+/// Favored true-anomaly interval (deg), from Fienga et al. 2016 via
+/// `p9_core::data::ephemeris_constraint`.
 pub fn favored_interval_deg() -> (f64, f64) {
     FAVORED_INTERVAL_DEG
 }
@@ -64,7 +63,7 @@ pub fn favored_arc(orbit: &P9Params, n: usize) -> Vec<[f64; 2]> {
     (0..n)
         .map(|k| {
             let nu = (a + (b - a) * k as f64 / (n.max(2) - 1) as f64) * DEG2RAD;
-            let pos: Vector3<f64> = p9_position_at_true_anomaly(orbit, nu).position;
+            let pos: Vector3<f64> = position_at_true_anomaly(orbit, nu).position;
             let (ra, dec) = ecliptic_vec_to_equatorial_deg(&pos);
             [ra, dec]
         })

--- a/crates/p9-survey/src/lib.rs
+++ b/crates/p9-survey/src/lib.rs
@@ -79,7 +79,10 @@ pub fn run_survey(n_samples: usize, seed: u64) -> SurveyDataset {
         favored_nu_hi_deg: nu_hi,
         // The favored-ν zone belongs to the orbit Fienga et al. actually fit
         // (the Brown & Batygin geometry), so map it through that orbit.
-        favored_arc: ephemeris::favored_arc(&p9_2016_cassini_ranging::brown_batygin_orbit(), 64),
+        favored_arc: ephemeris::favored_arc(
+            &p9_core::data::ephemeris_constraint::brown_batygin_orbit(),
+            64,
+        ),
     };
 
     SurveyDataset {


### PR DESCRIPTION
Coalesce G3: lift P9 true-anomaly geometry + favored-ν ephemeris constants into p9-core; drop survey→cassini dep.