### PR TITLE
Coalesce G6 survey primitives into p9-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,7 +1944,6 @@ name = "p9-2025-ps1-holman"
 version = "0.1.0"
 dependencies = [
  "approx",
- "p9-2022-des",
  "p9-core",
  "rand 0.8.5",
  "rand_distr",

--- a/crates/p9-2022-des/src/sky.rs
+++ b/crates/p9-2022-des/src/sky.rs
@@ -1,70 +1,33 @@
-//! Orbit -> apparent sky-position mapping for the DES footprint model.
+//! DES observing-night grid anchor and per-night Earth states.
+//!
+//! The generic orbit -> apparent sky-position helpers
+//! (`apparent_position_deg`, `apparent_position_with_earth_deg`,
+//! `phase_angle_with_earth`) live in `p9_core::coords::sky`. This module keeps
+//! only the DES-specific night-grid pieces: the survey-start anchor and the
+//! per-night Earth-state precompute.
 //!
 //! The footprint of `survey_model` is defined in *equatorial* coordinates
-//! (RA/dec), so orbital sky positions must be rotated from the heliocentric
-//! ecliptic frame to the equatorial frame before any footprint test (the
-//! analogous fix to p9-2021-ztf's `sky.rs`; substituting ecliptic latitude
-//! for declination misclassifies exactly the survey-boundary regions that
-//! drive unique-coverage estimates). The rotation itself comes from
-//! p9-core's `coords::sky` (starfield's ECLIPJ2000 frame matrix).
+//! (RA/dec), so orbital sky positions are rotated from the heliocentric
+//! ecliptic frame to the equatorial frame (in core's `coords::sky`) before any
+//! footprint test.
 //!
-//! Apparent (geocentric) positions are computed per observing night: the
-//! geocentric vector is the heliocentric vector minus Earth's orbital
-//! position, which captures both the annual parallactic oscillation
-//! (~1/r radians, i.e. +/-0.14 deg at 400 AU) and the slow orbital drift
-//! of the object across the 6-year survey baseline.
-//!
-//! Two Earth models are available:
+//! Two Earth models are available in core:
 //! - `apparent_position_with_earth_deg` (primary): a real Earth state from
 //!   `p9_core::coords::observer` (DE421 via `EphemerisEarth`), with
-//!   light-time retardation and stellar aberration applied through the
-//!   shared apparent chain. Per-night Earth states are precomputed once
-//!   per survey grid (`night_earth_states`) so the kernel is not hit in
-//!   the per-orbit loops.
-//! - `apparent_position_deg` (analytic fallback): a circular, coplanar
-//!   1 AU Earth with phase zero at the survey start, accurate to ~0.03 deg
-//!   in parallax — kept for the speed-critical inner MC loops.
+//!   light-time retardation and stellar aberration. Per-night Earth states are
+//!   precomputed once per survey grid (`earth_states_at`) so the kernel is not
+//!   hit in the per-orbit loops.
+//! - `apparent_position_deg` (analytic fallback): a circular, coplanar 1 AU
+//!   Earth with phase zero at the survey start, accurate to ~0.03 deg in
+//!   parallax — kept for the speed-critical inner MC loops.
 
-use nalgebra::Vector3;
-use p9_core::constants::{GM_SUN, YEAR_DAYS};
-use p9_core::coords::observer::{
-    apparent_direction_from, EarthProvider, EarthState, Time, Timescale,
-};
-use p9_core::coords::sky::ecliptic_vec_to_equatorial_deg;
-use p9_core::types::OrbitalElements;
+use p9_core::coords::observer::{EarthProvider, EarthState, Time, Timescale};
 
 /// Start of the DES wide survey (Y1 began 2013-08-31; the six observing
 /// seasons run through early 2019). Anchor for the night grid's day
 /// offsets.
 pub fn survey_start(ts: &Timescale) -> Time {
     ts.utc((2013, 8, 31))
-}
-
-/// Apparent geocentric equatorial (RA, dec) in degrees of an orbit
-/// `t_days` after its stored epoch, plus the heliocentric distance (AU).
-///
-/// The object's mean anomaly is advanced by its mean motion; Earth is
-/// modeled on a circular coplanar 1-AU orbit (phase zero at t = 0), which is
-/// accurate to ~0.03 deg in parallax — ample for footprint membership.
-pub fn apparent_position_deg(elem: &OrbitalElements, t_days: f64) -> (f64, f64, f64) {
-    let pos = heliocentric_position(elem, t_days);
-    let r_helio = pos.norm();
-
-    let theta = std::f64::consts::TAU * t_days / YEAR_DAYS;
-    let (sin_t, cos_t) = theta.sin_cos();
-    let geo = pos - Vector3::new(cos_t, sin_t, 0.0);
-
-    let (ra, dec) = ecliptic_vec_to_equatorial_deg(&geo);
-    (ra, dec, r_helio)
-}
-
-/// Heliocentric ecliptic position (AU) of an orbit `t_days` after its
-/// stored epoch (mean anomaly advanced at the mean motion).
-fn heliocentric_position(elem: &OrbitalElements, t_days: f64) -> Vector3<f64> {
-    let n = (GM_SUN / (elem.a * elem.a * elem.a)).sqrt(); // rad/day
-    let mut advanced = *elem;
-    advanced.mean_anomaly = (elem.mean_anomaly + n * t_days).rem_euclid(std::f64::consts::TAU);
-    advanced.to_state_vector(GM_SUN).pos
 }
 
 /// Earth states (heliocentric ecliptic J2000) at `offsets_days` after the
@@ -82,72 +45,17 @@ pub fn earth_states_at(
         .collect()
 }
 
-/// Ephemeris-grade apparent geocentric equatorial (RA, dec) in degrees of
-/// an orbit `t_days` after its stored epoch, observed from the given Earth
-/// state (from `earth_states_at`), plus the heliocentric distance (AU).
-///
-/// Unlike the analytic `apparent_position_deg`, this uses a real Earth
-/// position and the full apparent chain: light-time retardation (~2-4 days
-/// at P9 distances) and stellar aberration.
-pub fn apparent_position_with_earth_deg(
-    elem: &OrbitalElements,
-    earth_state: &EarthState,
-    t_days: f64,
-) -> (f64, f64, f64) {
-    let r_helio = heliocentric_position(elem, t_days).norm();
-    let geo = apparent_direction_from(earth_state, |dt| heliocentric_position(elem, t_days + dt));
-    let (ra, dec) = ecliptic_vec_to_equatorial_deg(&geo);
-    (ra, dec, r_helio)
-}
-
-/// Sun–object–Earth phase angle (radians) of an orbit `t_days` after its
-/// stored epoch, observed from the given Earth state (instantaneous
-/// geometry — the few-day light-time displacement changes α by far less
-/// than the H-G law resolves at these distances). Bounded by
-/// asin(1 AU / r): below 0.35° everywhere in the BB21 reference
-/// population (minimum r ≈ 176 AU), ~0.11° at the fiducial 500 AU.
-pub fn phase_angle_with_earth(
-    elem: &OrbitalElements,
-    earth_state: &EarthState,
-    t_days: f64,
-) -> f64 {
-    let helio = heliocentric_position(elem, t_days);
-    let delta = (helio - earth_state.0).norm();
-    p9_core::analysis::photometry::phase_angle(helio.norm(), delta, earth_state.0.norm())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use p9_core::constants::DEG2RAD;
-
-    #[test]
-    fn test_ecliptic_pole_maps_to_obliquity_complement() {
-        // The north ecliptic pole sits at dec = 90 - 23.4393 = 66.56 deg.
-        let (_, dec) = ecliptic_vec_to_equatorial_deg(&Vector3::new(0.0, 0.0, 1.0));
-        assert!((dec - (90.0 - 23.439_291)).abs() < 1e-6, "dec = {dec}");
-    }
-
-    #[test]
-    fn test_equinox_direction_unchanged() {
-        // The vernal-equinox direction is shared by both frames.
-        let (ra, dec) = ecliptic_vec_to_equatorial_deg(&Vector3::new(1.0, 0.0, 0.0));
-        assert!(ra.abs() < 1e-9 && dec.abs() < 1e-9);
-    }
-
-    #[test]
-    fn test_ecliptic_plane_declination_bounded_by_obliquity() {
-        // Positions in the ecliptic plane reach at most |dec| = obliquity.
-        for k in 0..36 {
-            let lambda = k as f64 * 10.0 * DEG2RAD;
-            let (_, dec) =
-                ecliptic_vec_to_equatorial_deg(&Vector3::new(lambda.cos(), lambda.sin(), 0.0));
-            assert!(dec.abs() <= 23.44 + 1e-9, "dec = {dec}");
-        }
-    }
+    use p9_core::coords::sky::{
+        apparent_position_deg, apparent_position_with_earth_deg, phase_angle_with_earth,
+    };
+    use p9_core::types::OrbitalElements;
 
     #[test]
     fn ephemeris_apparent_position_close_to_analytic() {
+        use nalgebra::Vector3;
         use p9_core::coords::observer::EphemerisEarth;
         let mut earth = match EphemerisEarth::try_new() {
             Ok(e) => e,
@@ -244,7 +152,8 @@ mod tests {
                 let dm = -2.5 * hg_phase_factor(DEFAULT_SLOPE_G, alpha).log10();
                 max_alpha = max_alpha.max(alpha);
                 max_dm = max_dm.max(dm);
-                min_r = min_r.min(heliocentric_position(&elem, *t_days).norm());
+                let (_, _, r_helio) = apparent_position_with_earth_deg(&elem, state, *t_days);
+                min_r = min_r.min(r_helio);
             }
         }
         eprintln!(
@@ -267,33 +176,6 @@ mod tests {
         assert!(
             (0.03..0.10).contains(&max_dm),
             "max phase-induced Δm = {max_dm:.4} mag"
-        );
-    }
-
-    #[test]
-    fn test_parallax_amplitude_scales_inversely_with_distance() {
-        // Over one year the apparent RA of a distant object oscillates with
-        // amplitude ~ (1 AU / r) radians.
-        let elem = OrbitalElements {
-            a: 400.0,
-            e: 0.0,
-            i: 0.0,
-            omega: 0.0,
-            omega_big: 0.0,
-            mean_anomaly: 90.0 * DEG2RAD,
-        };
-        let mut ra_min = f64::INFINITY;
-        let mut ra_max = f64::NEG_INFINITY;
-        for k in 0..=24 {
-            let (ra, _, _) = apparent_position_deg(&elem, k as f64 * YEAR_DAYS / 24.0);
-            ra_min = ra_min.min(ra);
-            ra_max = ra_max.max(ra);
-        }
-        let half_amplitude = (ra_max - ra_min) / 2.0;
-        let expected = (1.0_f64 / 400.0).asin() / DEG2RAD; // ~0.143 deg
-        assert!(
-            (half_amplitude - expected).abs() < 0.05,
-            "parallax half-amplitude = {half_amplitude:.3} deg, expected ~{expected:.3}"
         );
     }
 }

--- a/crates/p9-2022-des/src/survey_model.rs
+++ b/crates/p9-2022-des/src/survey_model.rs
@@ -9,11 +9,15 @@
 
 use serde::{Deserialize, Serialize};
 
+use p9_core::analysis::surveys::poisson_binomial_tail;
 use p9_core::coords::observer::{EarthProvider, EarthState, Time, Timescale};
+use p9_core::coords::sky::{
+    apparent_position_deg, apparent_position_with_earth_deg, phase_angle_with_earth,
+};
 use p9_core::types::OrbitalElements;
 
 use crate::color_models::BandMagnitudes;
-use crate::sky::{apparent_position_deg, apparent_position_with_earth_deg, earth_states_at};
+use crate::sky::earth_states_at;
 
 /// Photometric band used in DES observations.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -76,29 +80,6 @@ fn ra_in_range(ra: f64, start: f64, end: f64) -> bool {
 
 fn ra_span_deg(start: f64, end: f64) -> f64 {
     (end - start).rem_euclid(360.0)
-}
-
-/// Survival probability P(X >= k) of a Poisson-binomial variable
-/// (independent Bernoulli trials with heterogeneous probabilities `probs`),
-/// computed by exact dynamic programming over the count distribution.
-pub fn poisson_binomial_tail(probs: &[f64], k: u32) -> f64 {
-    let k = k as usize;
-    if k == 0 {
-        return 1.0;
-    }
-    // dist[j] = P(exactly j successes so far) for j < k; `tail` absorbs
-    // P(>= k successes).
-    let mut dist = vec![0.0_f64; k];
-    dist[0] = 1.0;
-    let mut tail = 0.0_f64;
-    for &p in probs {
-        tail += dist[k - 1] * p;
-        for j in (1..k).rev() {
-            dist[j] = dist[j] * (1.0 - p) + dist[j - 1] * p;
-        }
-        dist[0] *= 1.0 - p;
-    }
-    tail
 }
 
 /// DES survey model parameters for Planet Nine detection.
@@ -306,7 +287,7 @@ impl DesSurvey {
             .map(|(band, t_days, state)| {
                 let (ra, dec, _) = apparent_position_with_earth_deg(elem, state, *t_days);
                 if self.is_in_footprint(ra, dec) {
-                    let alpha = crate::sky::phase_angle_with_earth(elem, state, *t_days);
+                    let alpha = phase_angle_with_earth(elem, state, *t_days);
                     let dm = -2.5 * hg_phase_factor(DEFAULT_SLOPE_G, alpha).log10();
                     self.night_detection_probability(mags.magnitude(*band) + dm, *band)
                 } else {
@@ -508,26 +489,5 @@ mod tests {
             let idx = t / span * grid;
             assert!((idx - idx.round()).abs() < 1e-9, "t = {t} off-grid");
         }
-    }
-
-    #[test]
-    fn poisson_binomial_tail_matches_binomial() {
-        // Homogeneous case reduces to the binomial: n = 10, p = 0.5,
-        // P(X >= 6) = 386/1024.
-        let probs = vec![0.5; 10];
-        let tail = poisson_binomial_tail(&probs, 6);
-        assert!((tail - 386.0 / 1024.0).abs() < 1e-12, "tail = {tail}");
-        // Degenerate edges.
-        assert_eq!(poisson_binomial_tail(&probs, 0), 1.0);
-        assert!(poisson_binomial_tail(&probs, 11) < 1e-12);
-    }
-
-    #[test]
-    fn poisson_binomial_tail_heterogeneous() {
-        // P(X >= 1) = 1 - prod(1 - p_i).
-        let probs = [0.1, 0.4, 0.7];
-        let tail = poisson_binomial_tail(&probs, 1);
-        let expected = 1.0 - 0.9 * 0.6 * 0.3;
-        assert!((tail - expected).abs() < 1e-12);
     }
 }

--- a/crates/p9-2023-lsst-strategy/src/discoverable.rs
+++ b/crates/p9-2023-lsst-strategy/src/discoverable.rs
@@ -8,7 +8,7 @@
 //!
 //! where
 //!   * `footprint(δ, b)` is the Rubin/LSST declination band and Galactic-plane
-//!     cut (reusing `p9_survey::schema::Footprint::accepts`), with the
+//!     cut (reusing `p9_core::analysis::surveys::Footprint::accepts`), with the
 //!     equatorial declination and Galactic latitude of the current sky
 //!     position computed by `p9_core::coords::sky` from the orbit's
 //!     heliocentric ecliptic state;
@@ -24,10 +24,10 @@
 
 use serde::{Deserialize, Serialize};
 
+use p9_core::analysis::surveys::Footprint;
 use p9_core::constants::{DEG2RAD, GM_SUN, RAD2DEG};
 use p9_core::coords::sky::{ecliptic_vec_to_equatorial_deg, equatorial_to_galactic};
 use p9_core::types::OrbitalElements;
-use p9_survey::schema::Footprint;
 
 use crate::strategy::LsstStrategy;
 
@@ -53,7 +53,7 @@ pub struct DiscoverableResult {
 }
 
 impl LsstStrategy {
-    /// The footprint of this strategy as a reusable `p9_survey` `Footprint`.
+    /// The footprint of this strategy as a reusable `p9_core` `Footprint`.
     pub fn footprint(&self) -> Footprint {
         Footprint {
             dec_min_deg: self.dec_min_deg,

--- a/crates/p9-2024-panstarrs/src/detection_pipeline.rs
+++ b/crates/p9-2024-panstarrs/src/detection_pipeline.rs
@@ -11,8 +11,10 @@
 use rand::{Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 
-use p9_2022_des::sky::{apparent_position_deg, apparent_position_with_earth_deg};
 use p9_core::coords::observer::{EarthProvider, EarthState, Timescale};
+use p9_core::coords::sky::{
+    apparent_position_deg, apparent_position_with_earth_deg, phase_angle_with_earth,
+};
 use p9_core::types::OrbitalElements;
 
 use crate::survey_model::Ps1Survey;
@@ -46,7 +48,7 @@ impl Ps1Result {
 
 /// Equatorial (RA, dec) in degrees of an orbit's current apparent sky
 /// position (geocentric, at the orbit's stored epoch), via the shared
-/// ecliptic -> equatorial conversion in `p9_2022_des::sky`.
+/// ecliptic -> equatorial conversion in `p9_core::coords::sky`.
 pub fn equatorial_position_deg(elements: &OrbitalElements) -> (f64, f64) {
     let (ra, dec, _) = apparent_position_deg(elements, 0.0);
     (ra, dec)
@@ -97,7 +99,7 @@ pub fn detection_probability_for_orbit_with_earth(
 ) -> f64 {
     use p9_core::analysis::photometry::{hg_phase_factor, DEFAULT_SLOPE_G};
     let (_, dec) = equatorial_position_with_earth_deg(elements, earth_state);
-    let alpha = p9_2022_des::sky::phase_angle_with_earth(elements, earth_state, 0.0);
+    let alpha = phase_angle_with_earth(elements, earth_state, 0.0);
     let dm = -2.5 * hg_phase_factor(DEFAULT_SLOPE_G, alpha).log10();
     survey.detection_probability(v_magnitude + dm, dec)
 }

--- a/crates/p9-2024-panstarrs/src/survey_model.rs
+++ b/crates/p9-2024-panstarrs/src/survey_model.rs
@@ -7,10 +7,9 @@
 //! cuts, and the measured 99.2% linking efficiency. The single-exposure
 //! depth comes from the shared `p9_core::analysis::surveys` table.
 
+use p9_core::analysis::surveys::poisson_binomial_tail;
 use p9_core::coords::observer::{Time, Timescale};
 use serde::{Deserialize, Serialize};
-
-pub use p9_2022_des::survey_model::poisson_binomial_tail;
 
 /// Quality-cut thresholds applied to PS1 detections.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/p9-2025-ps1-holman/Cargo.toml
+++ b/crates/p9-2025-ps1-holman/Cargo.toml
@@ -9,7 +9,6 @@ rand = { workspace = true }
 rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-p9-2022-des = { version = "0.1.0", path = "../p9-2022-des" }
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/crates/p9-2025-ps1-holman/src/exclusion.rs
+++ b/crates/p9-2025-ps1-holman/src/exclusion.rs
@@ -14,7 +14,7 @@
 use rand::{Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 
-use p9_2022_des::sky::apparent_position_deg;
+use p9_core::coords::sky::apparent_position_deg;
 use p9_core::data::reference_population::generate_reference_population;
 use p9_core::types::OrbitalElements;
 
@@ -41,7 +41,8 @@ pub struct ExclusionResult {
 }
 
 /// Equatorial declination (deg) of an orbit at its stored epoch, via the
-/// shared `p9-2022-des` ecliptic->equatorial apparent-position conversion.
+/// shared `p9_core::coords::sky` ecliptic->equatorial apparent-position
+/// conversion.
 pub fn declination_deg(elements: &OrbitalElements) -> f64 {
     let (_, dec, _) = apparent_position_deg(elements, 0.0);
     dec

--- a/crates/p9-core/src/analysis/surveys.rs
+++ b/crates/p9-core/src/analysis/surveys.rs
@@ -104,6 +104,51 @@ pub fn limiting_magnitude(survey: &str) -> Option<f64> {
         .map(|d| d.limiting_mag)
 }
 
+/// Survival probability P(X >= k) of a Poisson-binomial variable
+/// (independent Bernoulli trials with heterogeneous probabilities `probs`),
+/// computed by exact dynamic programming over the count distribution.
+pub fn poisson_binomial_tail(probs: &[f64], k: u32) -> f64 {
+    let k = k as usize;
+    if k == 0 {
+        return 1.0;
+    }
+    // dist[j] = P(exactly j successes so far) for j < k; `tail` absorbs
+    // P(>= k successes).
+    let mut dist = vec![0.0_f64; k];
+    dist[0] = 1.0;
+    let mut tail = 0.0_f64;
+    for &p in probs {
+        tail += dist[k - 1] * p;
+        for j in (1..k).rev() {
+            dist[j] = dist[j] * (1.0 - p) + dist[j - 1] * p;
+        }
+        dist[0] *= 1.0 - p;
+    }
+    tail
+}
+
+/// A survey/telescope footprint: a declination band, an optional galactic-
+/// latitude exclusion, and the fraction of that band actually imaged to depth.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Footprint {
+    pub dec_min_deg: f64,
+    pub dec_max_deg: f64,
+    /// Require |galactic latitude| ≥ this (0 = no plane cut).
+    pub galactic_lat_min_deg: f64,
+    /// Fraction of the in-footprint sky surveyed to the limiting depth.
+    pub coverage_fraction: f64,
+}
+
+impl Footprint {
+    /// Does a sample at this equatorial position and galactic latitude fall in
+    /// the imaged footprint (geometry only; coverage applied separately)?
+    pub fn accepts(&self, dec_deg: f64, galactic_lat_deg: f64) -> bool {
+        dec_deg >= self.dec_min_deg
+            && dec_deg <= self.dec_max_deg
+            && galactic_lat_deg.abs() >= self.galactic_lat_min_deg
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -144,5 +189,43 @@ mod tests {
         for s in &EXCLUSION_FRACTIONS {
             assert!((0.0..=1.0).contains(&s.unique_fraction), "{}", s.survey);
         }
+    }
+
+    #[test]
+    fn poisson_binomial_tail_matches_binomial() {
+        // Homogeneous case reduces to the binomial: n = 10, p = 0.5,
+        // P(X >= 6) = 386/1024.
+        let probs = vec![0.5; 10];
+        let tail = poisson_binomial_tail(&probs, 6);
+        assert!((tail - 386.0 / 1024.0).abs() < 1e-12, "tail = {tail}");
+        // Degenerate edges.
+        assert_eq!(poisson_binomial_tail(&probs, 0), 1.0);
+        assert!(poisson_binomial_tail(&probs, 11) < 1e-12);
+    }
+
+    #[test]
+    fn poisson_binomial_tail_heterogeneous() {
+        // P(X >= 1) = 1 - prod(1 - p_i).
+        let probs = [0.1, 0.4, 0.7];
+        let tail = poisson_binomial_tail(&probs, 1);
+        let expected = 1.0 - 0.9 * 0.6 * 0.3;
+        assert!((tail - expected).abs() < 1e-12);
+    }
+
+    #[test]
+    fn footprint_accepts_dec_band_and_galactic_cut() {
+        let fp = Footprint {
+            dec_min_deg: -30.0,
+            dec_max_deg: 60.0,
+            galactic_lat_min_deg: 10.0,
+            coverage_fraction: 0.8,
+        };
+        assert!(fp.accepts(0.0, 25.0));
+        assert!(fp.accepts(0.0, -25.0));
+        // Outside declination band.
+        assert!(!fp.accepts(-45.0, 25.0));
+        assert!(!fp.accepts(70.0, 25.0));
+        // Inside the galactic plane cut.
+        assert!(!fp.accepts(0.0, 5.0));
     }
 }

--- a/crates/p9-core/src/coords/sky.rs
+++ b/crates/p9-core/src/coords/sky.rs
@@ -19,7 +19,9 @@ use starfield::framelib::inertial::{Ecliptic, Equatorial, Galactic};
 use starfield::framelib::{Frame, ECLIPJ2000_MATRIX, ECLIPJ2000_MATRIX_INV, GALACTIC};
 use starfield::time::Timescale;
 
-use crate::constants::{J2000, RAD2DEG};
+use crate::constants::{GM_SUN, J2000, RAD2DEG, YEAR_DAYS};
+use crate::coords::observer::{apparent_direction_from, EarthState};
+use crate::types::OrbitalElements;
 
 /// Equatorial (ICRF/J2000) → galactic rotation, from starfield's SPICE
 /// `GALACTIC` frame (static; the epoch argument is ignored by the frame).
@@ -117,6 +119,67 @@ pub fn ecliptic_vec_declination(v: &Vector3<f64>) -> f64 {
 /// (any common frame), via starfield's `Cartesian3::angular_distance`.
 pub fn angular_distance(a: &Vector3<f64>, b: &Vector3<f64>) -> f64 {
     Cartesian3::from_vector3(*a).angular_distance(&Cartesian3::from_vector3(*b))
+}
+
+/// Heliocentric ecliptic position (AU) of an orbit `t_days` after its
+/// stored epoch (mean anomaly advanced at the mean motion).
+fn heliocentric_position(elem: &OrbitalElements, t_days: f64) -> Vector3<f64> {
+    let n = (GM_SUN / (elem.a * elem.a * elem.a)).sqrt(); // rad/day
+    let mut advanced = *elem;
+    advanced.mean_anomaly = (elem.mean_anomaly + n * t_days).rem_euclid(std::f64::consts::TAU);
+    advanced.to_state_vector(GM_SUN).pos
+}
+
+/// Apparent geocentric equatorial (RA, dec) in degrees of an orbit
+/// `t_days` after its stored epoch, plus the heliocentric distance (AU).
+///
+/// The object's mean anomaly is advanced by its mean motion; Earth is
+/// modeled on a circular coplanar 1-AU orbit (phase zero at t = 0), which is
+/// accurate to ~0.03 deg in parallax — ample for footprint membership.
+pub fn apparent_position_deg(elem: &OrbitalElements, t_days: f64) -> (f64, f64, f64) {
+    let pos = heliocentric_position(elem, t_days);
+    let r_helio = pos.norm();
+
+    let theta = std::f64::consts::TAU * t_days / YEAR_DAYS;
+    let (sin_t, cos_t) = theta.sin_cos();
+    let geo = pos - Vector3::new(cos_t, sin_t, 0.0);
+
+    let (ra, dec) = ecliptic_vec_to_equatorial_deg(&geo);
+    (ra, dec, r_helio)
+}
+
+/// Ephemeris-grade apparent geocentric equatorial (RA, dec) in degrees of
+/// an orbit `t_days` after its stored epoch, observed from the given Earth
+/// state, plus the heliocentric distance (AU).
+///
+/// Unlike the analytic `apparent_position_deg`, this uses a real Earth
+/// position and the full apparent chain: light-time retardation (~2-4 days
+/// at P9 distances) and stellar aberration.
+pub fn apparent_position_with_earth_deg(
+    elem: &OrbitalElements,
+    earth_state: &EarthState,
+    t_days: f64,
+) -> (f64, f64, f64) {
+    let r_helio = heliocentric_position(elem, t_days).norm();
+    let geo = apparent_direction_from(earth_state, |dt| heliocentric_position(elem, t_days + dt));
+    let (ra, dec) = ecliptic_vec_to_equatorial_deg(&geo);
+    (ra, dec, r_helio)
+}
+
+/// Sun–object–Earth phase angle (radians) of an orbit `t_days` after its
+/// stored epoch, observed from the given Earth state (instantaneous
+/// geometry — the few-day light-time displacement changes α by far less
+/// than the H-G law resolves at these distances). Bounded by
+/// asin(1 AU / r): below 0.35° everywhere in the BB21 reference
+/// population (minimum r ≈ 176 AU), ~0.11° at the fiducial 500 AU.
+pub fn phase_angle_with_earth(
+    elem: &OrbitalElements,
+    earth_state: &EarthState,
+    t_days: f64,
+) -> f64 {
+    let helio = heliocentric_position(elem, t_days);
+    let delta = (helio - earth_state.0).norm();
+    crate::analysis::photometry::phase_angle(helio.norm(), delta, earth_state.0.norm())
 }
 
 #[cfg(test)]
@@ -256,5 +319,32 @@ mod tests {
             epsilon = 1e-12
         );
         assert_relative_eq!(angular_distance(&x, &x), 0.0, epsilon = 1e-15);
+    }
+
+    #[test]
+    fn test_parallax_amplitude_scales_inversely_with_distance() {
+        // Over one year the apparent RA of a distant object oscillates with
+        // amplitude ~ (1 AU / r) radians.
+        let elem = OrbitalElements {
+            a: 400.0,
+            e: 0.0,
+            i: 0.0,
+            omega: 0.0,
+            omega_big: 0.0,
+            mean_anomaly: 90.0 * DEG2RAD,
+        };
+        let mut ra_min = f64::INFINITY;
+        let mut ra_max = f64::NEG_INFINITY;
+        for k in 0..=24 {
+            let (ra, _, _) = apparent_position_deg(&elem, k as f64 * YEAR_DAYS / 24.0);
+            ra_min = ra_min.min(ra);
+            ra_max = ra_max.max(ra);
+        }
+        let half_amplitude = (ra_max - ra_min) / 2.0;
+        let expected = (1.0_f64 / 400.0).asin() / DEG2RAD; // ~0.143 deg
+        assert!(
+            (half_amplitude - expected).abs() < 0.05,
+            "parallax half-amplitude = {half_amplitude:.3} deg, expected ~{expected:.3}"
+        );
     }
 }

--- a/crates/p9-survey/src/schema.rs
+++ b/crates/p9-survey/src/schema.rs
@@ -12,6 +12,7 @@
 //! angles are degrees, distances AU, areas square degrees, magnitudes V (or
 //! the telescope's stated band, treated as a reflected-light proxy).
 
+use p9_core::analysis::surveys::Footprint;
 use serde::{Deserialize, Serialize};
 
 /// Schema version. The Python loader asserts the file matches this exactly.
@@ -110,28 +111,6 @@ pub struct StudyResult {
     pub v_p16: f64,
     pub v_median: f64,
     pub v_p84: f64,
-}
-
-/// A survey/telescope footprint: a declination band, an optional galactic-
-/// latitude exclusion, and the fraction of that band actually imaged to depth.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Footprint {
-    pub dec_min_deg: f64,
-    pub dec_max_deg: f64,
-    /// Require |galactic latitude| ≥ this (0 = no plane cut).
-    pub galactic_lat_min_deg: f64,
-    /// Fraction of the in-footprint sky surveyed to the limiting depth.
-    pub coverage_fraction: f64,
-}
-
-impl Footprint {
-    /// Does a sample at this equatorial position and galactic latitude fall in
-    /// the imaged footprint (geometry only; coverage applied separately)?
-    pub fn accepts(&self, dec_deg: f64, galactic_lat_deg: f64) -> bool {
-        dec_deg >= self.dec_min_deg
-            && dec_deg <= self.dec_max_deg
-            && galactic_lat_deg.abs() >= self.galactic_lat_min_deg
-    }
 }
 
 /// A telescope/survey: a limiting magnitude in some band plus a footprint.

--- a/crates/p9-survey/src/telescope.rs
+++ b/crates/p9-survey/src/telescope.rs
@@ -20,7 +20,8 @@
 //! shift-stack. So the limiter is not depth (P9 is V≈19–23) but the small
 //! field: tiling the multi-thousand-deg² P9 prior is the constraint.
 
-use crate::schema::{Footprint, Telescope};
+use crate::schema::Telescope;
+use p9_core::analysis::surveys::Footprint;
 
 /// JBT 0.5 m + SPENCER derived optics (see module docs / `focalplane`).
 pub const JBT_APERTURE_M: f64 = 0.485;


### PR DESCRIPTION
Coalesce G6: lift sky apparent-position, poisson-binomial, Footprint into p9-core; repoint survey crates, no shims.