### PR TITLE
Coalesce G2: unify thermal/blackbody IR-mm model into p9-core

### DIFF
--- a/crates/p9-2016-cowan-thermal/src/sed.rs
+++ b/crates/p9-2016-cowan-thermal/src/sed.rs
@@ -30,27 +30,13 @@
 //! body "could be as faint as 1 mJy at 1 mm". We keep these as labelled
 //! reference constants and document the residual against our computed value.
 
-use std::f64::consts::PI;
-
 use p9_core::analysis::photometry::mass_radius_neptunian;
-use p9_core::constants::AU_M;
+use p9_core::analysis::thermal::{planck_bnu, reflected_flux_jy, thermal_flux_jy, C_LIGHT, JY};
 
-/// Planck constant (J·s).
-pub const H_PLANCK: f64 = 6.626_070_15e-34;
-/// Boltzmann constant (J/K).
-pub const K_BOLTZ: f64 = 1.380_649e-23;
-/// Speed of light (m/s).
-pub const C_LIGHT: f64 = 2.997_924_58e8;
 /// Wien displacement-law constant b for the wavelength of peak B_λ (m·K).
 pub const WIEN_B_M_K: f64 = 2.897_771_955e-3;
 /// Earth radius (m).
 pub const R_EARTH_M: f64 = 6.371e6;
-/// Solar radius (m).
-pub const R_SUN_M: f64 = 6.957e8;
-/// Solar effective temperature (K).
-pub const T_SUN: f64 = 5778.0;
-/// 1 Jansky in W/m²/Hz.
-pub const JY: f64 = 1.0e-26;
 
 /// Effective temperature adopted by Cowan et al. (2016) (K).
 pub const COWAN_TEMP_K: f64 = 40.0;
@@ -131,11 +117,7 @@ impl P9Sed {
 
     /// Planck function B_ν(T) in W/m²/Hz/sr at frequency `nu_hz`.
     pub fn planck_bnu(t: f64, nu_hz: f64) -> f64 {
-        let x = H_PLANCK * nu_hz / (K_BOLTZ * t);
-        if x > 700.0 {
-            return 0.0;
-        }
-        (2.0 * H_PLANCK * nu_hz.powi(3) / (C_LIGHT * C_LIGHT)) / (x.exp() - 1.0)
+        planck_bnu(t, nu_hz)
     }
 
     /// Wavelength of peak spectral radiance B_λ via the Wien displacement law:
@@ -148,10 +130,7 @@ impl P9Sed {
     /// unit emissivity: F_ν = π B_ν(T) (R/d)².
     pub fn thermal_flux_si(&self, lambda_m: f64) -> f64 {
         let nu = C_LIGHT / lambda_m;
-        let bnu = Self::planck_bnu(self.temp_k, nu);
-        let r = self.radius_m();
-        let d = self.distance_au * AU_M;
-        PI * bnu * (r / d).powi(2)
+        thermal_flux_jy(self.temp_k, self.radius_m(), self.distance_au, nu) * JY
     }
 
     /// Reflected-sunlight flux density at wavelength `lambda_m` (W/m²/Hz),
@@ -163,12 +142,7 @@ impl P9Sed {
     ///   F_refl = albedo · [π B_ν(T_sun) (R_sun/r)²] · (R_p² / (4 Δ²)).
     pub fn reflected_flux_si(&self, lambda_m: f64) -> f64 {
         let nu = C_LIGHT / lambda_m;
-        let bnu_sun = Self::planck_bnu(T_SUN, nu);
-        let r_m = self.distance_au * AU_M;
-        let solar_flux_at_planet = PI * bnu_sun * (R_SUN_M / r_m).powi(2);
-        let r_p = self.radius_m();
-        let delta_m = (self.distance_au - 1.0).max(1.0) * AU_M;
-        self.albedo * solar_flux_at_planet * (r_p * r_p) / (4.0 * delta_m * delta_m)
+        reflected_flux_jy(self.albedo, self.radius_m(), self.distance_au, nu) * JY
     }
 
     /// Thermal flux density at `lambda_m` in milli-Jansky.
@@ -229,6 +203,7 @@ impl P9Sed {
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
+    use p9_core::analysis::thermal::{H_PLANCK, K_BOLTZ};
 
     /// WISE W1 effective wavelength (m).
     const W1_M: f64 = 3.3526e-6;

--- a/crates/p9-2016-fortney-thermal/src/lib.rs
+++ b/crates/p9-2016-fortney-thermal/src/lib.rs
@@ -51,26 +51,19 @@
 use std::f64::consts::PI;
 
 use p9_core::analysis::photometry::{mass_radius_neptunian, ALBEDO_NEPTUNE};
+use p9_core::analysis::thermal::{planck_bnu, thermal_flux_jy, C_LIGHT};
 use p9_core::constants::AU_M;
 
 pub mod published;
 
 /// Stefan-Boltzmann constant (W / m² / K⁴), 2018 CODATA.
 pub const SIGMA_SB: f64 = 5.670_374_419e-8;
-/// Planck constant (J·s).
-pub const H_PLANCK: f64 = 6.626_070_15e-34;
-/// Boltzmann constant (J/K).
-pub const K_BOLTZ: f64 = 1.380_649e-23;
-/// Speed of light (m/s).
-pub const C_LIGHT: f64 = 2.997_924_58e8;
 /// Wien displacement constant b = h c / (4.965114231 k) (m·K).
 pub const WIEN_B_M_K: f64 = 2.897_771_955e-3;
 /// Earth radius (m); matches the photometry mass-radius anchor.
 pub const R_EARTH_M: f64 = 6.371e6;
 /// Solar luminosity (W).
 pub const L_SUN_W: f64 = 3.828e26;
-/// 1 Jansky in W/m²/Hz.
-pub const JY: f64 = 1.0e-26;
 
 /// WISE W2 effective wavelength (4.6 µm); the redder of the two short WISE
 /// bands and the one the Meisner et al. (2018) shift-and-stack search uses.
@@ -173,11 +166,7 @@ impl P9Thermal {
 
     /// Planck function B_ν(T) in W/m²/Hz/sr at frequency `nu_hz`.
     pub fn planck_bnu(t: f64, nu_hz: f64) -> f64 {
-        let x = H_PLANCK * nu_hz / (K_BOLTZ * t);
-        if x > 700.0 {
-            return 0.0;
-        }
-        (2.0 * H_PLANCK * nu_hz.powi(3) / (C_LIGHT * C_LIGHT)) / (x.exp() - 1.0)
+        planck_bnu(t, nu_hz)
     }
 
     /// Thermal (blackbody) flux density at `wavelength_m` in Jansky, observed
@@ -185,11 +174,7 @@ impl P9Thermal {
     /// emitter gives F_ν = π B_ν(T) (R/d)².
     pub fn flux_density_jy(&self, wavelength_m: f64) -> f64 {
         let nu = C_LIGHT / wavelength_m;
-        let bnu = Self::planck_bnu(self.effective_temp(), nu);
-        let r = self.radius_m();
-        let d = self.distance_au * AU_M;
-        let solid_angle = PI * (r / d).powi(2);
-        solid_angle * bnu / JY
+        thermal_flux_jy(self.effective_temp(), self.radius_m(), self.distance_au, nu)
     }
 
     /// Far-IR (350 µm) flux density in Jansky.
@@ -218,6 +203,7 @@ pub fn effective_temp(mass_earth: f64, distance_au: f64) -> f64 {
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
+    use p9_core::analysis::thermal::{H_PLANCK, K_BOLTZ};
 
     #[test]
     fn nominal_p9_effective_temp_in_published_band() {

--- a/crates/p9-2016-linder-evolution/src/thermal.rs
+++ b/crates/p9-2016-linder-evolution/src/thermal.rs
@@ -32,19 +32,9 @@
 //! (mid/far-IR beats optical for the cold body) is reproduced where the model
 //! is most trustworthy.
 
-use std::f64::consts::PI;
-
 use p9_core::analysis::photometry::mass_radius_neptunian;
-use p9_core::constants::{AU_M, EARTH_RADIUS_KM};
-
-/// Planck constant (J·s).
-const H_PLANCK: f64 = 6.626_070_15e-34;
-/// Boltzmann constant (J/K).
-const K_BOLTZ: f64 = 1.380_649e-23;
-/// Speed of light (m/s).
-const C_LIGHT: f64 = 2.997_924_58e8;
-/// 1 Jansky in W/m²/Hz.
-const JY: f64 = 1.0e-26;
+use p9_core::analysis::thermal::{flux_to_magnitude, thermal_flux_jy, C_LIGHT};
+use p9_core::constants::EARTH_RADIUS_KM;
 
 /// Earth radius in meters (from the shared `EARTH_RADIUS_KM`).
 const R_EARTH_M: f64 = EARTH_RADIUS_KM * 1.0e3;
@@ -138,33 +128,21 @@ impl P9 {
         T_FLOOR_10ME_K * (self.mass_earth / 10.0).powf(T_FLOOR_MASS_EXPONENT)
     }
 
-    /// Planck function B_ν(T) in W/m²/Hz/sr.
-    fn planck_bnu(t: f64, nu_hz: f64) -> f64 {
-        let x = H_PLANCK * nu_hz / (K_BOLTZ * t);
-        if x > 700.0 {
-            return 0.0;
-        }
-        (2.0 * H_PLANCK * nu_hz.powi(3) / (C_LIGHT * C_LIGHT)) / (x.exp() - 1.0)
-    }
-
     /// Intrinsic thermal flux density in `band` (Jy): a grey body of unit
     /// emissivity, F_ν = π B_ν(T_eff) (R/d)².
     pub fn thermal_flux_jy(&self, band: Band) -> f64 {
-        let bnu = Self::planck_bnu(self.effective_temperature(), band.frequency_hz());
-        let r = self.radius_m();
-        let d = self.distance_au * AU_M;
-        let solid_angle = PI * (r / d).powi(2);
-        solid_angle * bnu / JY
+        thermal_flux_jy(
+            self.effective_temperature(),
+            self.radius_m(),
+            self.distance_au,
+            band.frequency_hz(),
+        )
     }
 
     /// Apparent Vega-system magnitude in `band` from the intrinsic thermal
     /// flux. Returns +∞ when the flux underflows to zero (deep Wien tail).
     pub fn thermal_magnitude(&self, band: Band) -> f64 {
-        let flux = self.thermal_flux_jy(band);
-        if flux <= 0.0 {
-            return f64::INFINITY;
-        }
-        -2.5 * (flux / band.zero_point_jy()).log10()
+        flux_to_magnitude(self.thermal_flux_jy(band), band.zero_point_jy())
     }
 
     /// The band (among `bands`) in which the planet is intrinsically brightest

--- a/crates/p9-2016-wise-coadd/src/band.rs
+++ b/crates/p9-2016-wise-coadd/src/band.rs
@@ -16,19 +16,11 @@
 //! the thermal flux rises by a factor ~exp[(hc/kT)(1/λ₁ − 1/λ₂)]. For a 40 K
 //! body that is an enormous factor — W2 sits far less deep on the Wien tail.
 
-use std::f64::consts::PI;
-
 use p9_2018_wise_search::thermal_model::P9Thermal;
-
-/// Physical constants (mirrors of the sibling's, kept local so the band-generic
-/// Planck evaluation is self-contained).
-const H_PLANCK: f64 = 6.626_070_15e-34;
-const K_BOLTZ: f64 = 1.380_649e-23;
-const C_LIGHT: f64 = 2.997_924_58e8;
-const AU_M: f64 = 1.495_978_707e11;
-const R_SUN_M: f64 = 6.957e8;
-const T_SUN: f64 = 5778.0;
-const JY: f64 = 1.0e-26;
+use p9_core::analysis::thermal::{
+    flux_to_magnitude, reflected_flux_jy as p9_core_reflected_flux,
+    thermal_flux_jy as p9_core_thermal_flux, C_LIGHT,
+};
 
 /// A WISE photometric band: effective wavelength and Vega zero-point flux
 /// density (Wright et al. 2010, Table 1).
@@ -56,36 +48,17 @@ pub const W2: WiseBand = WiseBand {
     zero_point_jy: 171.787,
 };
 
-/// Planck function B_ν(T) in W/m²/Hz/sr at frequency `nu_hz` (identical to the
-/// sibling's; under-/overflow guarded on the Wien tail).
-fn planck_bnu(t: f64, nu_hz: f64) -> f64 {
-    let x = H_PLANCK * nu_hz / (K_BOLTZ * t);
-    if x > 700.0 {
-        return 0.0;
-    }
-    (2.0 * H_PLANCK * nu_hz.powi(3) / (C_LIGHT * C_LIGHT)) / (x.exp() - 1.0)
-}
-
 /// Thermal grey-body flux density (Jy) of `p9` in `band`: F_ν = π B_ν(T)(R/d)².
 pub fn thermal_flux_jy(p9: &P9Thermal, band: WiseBand) -> f64 {
     let nu = C_LIGHT / band.wavelength_m;
-    let bnu = planck_bnu(p9.effective_temp(), nu);
-    let r = p9.radius_m();
-    let d = p9.distance_au * AU_M;
-    let solid_angle = PI * (r / d).powi(2);
-    solid_angle * bnu / JY
+    p9_core_thermal_flux(p9.effective_temp(), p9.radius_m(), p9.distance_au, nu)
 }
 
 /// Reflected-sunlight flux density (Jy) of `p9` in `band`, near opposition
 /// (Δ = d − 1 AU). Same geometry as the sibling's W1 reflected channel.
 pub fn reflected_flux_jy(p9: &P9Thermal, band: WiseBand) -> f64 {
     let nu = C_LIGHT / band.wavelength_m;
-    let bnu_sun = planck_bnu(T_SUN, nu);
-    let r_p = p9.radius_m();
-    let solar_flux_at_planet = PI * bnu_sun * (R_SUN_M / (p9.distance_au * AU_M)).powi(2);
-    let delta_m = (p9.distance_au - 1.0).max(1.0) * AU_M;
-    let reflected = p9.albedo * solar_flux_at_planet * (r_p * r_p) / (4.0 * delta_m * delta_m);
-    reflected / JY
+    p9_core_reflected_flux(p9.albedo, p9.radius_m(), p9.distance_au, nu)
 }
 
 /// Total flux density (Jy) of `p9` in `band`: thermal + reflected.
@@ -96,11 +69,7 @@ pub fn total_flux_jy(p9: &P9Thermal, band: WiseBand) -> f64 {
 /// Apparent Vega magnitude of `p9` in `band` from the total flux density;
 /// +∞ for zero flux.
 pub fn magnitude(p9: &P9Thermal, band: WiseBand) -> f64 {
-    let flux = total_flux_jy(p9, band);
-    if flux <= 0.0 {
-        return f64::INFINITY;
-    }
-    -2.5 * (flux / band.zero_point_jy).log10()
+    flux_to_magnitude(total_flux_jy(p9, band), band.zero_point_jy)
 }
 
 /// Convenience: apparent `band` magnitude of a default-albedo P9 of

--- a/crates/p9-2016-wise-coadd/src/detectability.rs
+++ b/crates/p9-2016-wise-coadd/src/detectability.rs
@@ -10,6 +10,7 @@
 //! brighter for a cold planet.
 
 use p9_2018_wise_search::thermal_model::P9Thermal;
+use p9_core::analysis::thermal::max_detectable_distance as core_max_detectable_distance;
 
 use crate::band::{band_magnitude, WiseBand};
 
@@ -23,30 +24,9 @@ pub fn is_detectable(band: WiseBand, depth: f64, mass_earth: f64, distance_au: f
 /// `depth` in `band`, by bisection on the monotone magnitude–distance relation.
 /// `None` if undetectable even at the near edge of the search range.
 pub fn max_detectable_distance(band: WiseBand, depth: f64, mass_earth: f64) -> Option<f64> {
-    let d_min = 50.0_f64;
-    let d_max = 50_000.0_f64;
-
-    if !is_detectable(band, depth, mass_earth, d_min) {
-        return None;
-    }
-    if is_detectable(band, depth, mass_earth, d_max) {
-        return Some(d_max);
-    }
-
-    let mut lo = d_min;
-    let mut hi = d_max;
-    for _ in 0..200 {
-        let mid = 0.5 * (lo + hi);
-        if is_detectable(band, depth, mass_earth, mid) {
-            lo = mid;
-        } else {
-            hi = mid;
-        }
-        if hi - lo < 1e-4 {
-            break;
-        }
-    }
-    Some(0.5 * (lo + hi))
+    core_max_detectable_distance(50.0, 50_000.0, depth, |d| {
+        band_magnitude(mass_earth, d, band)
+    })
 }
 
 /// Detectability of a fully specified planet against a band depth (uses the

--- a/crates/p9-2018-wise-search/src/detectability.rs
+++ b/crates/p9-2018-wise-search/src/detectability.rs
@@ -8,6 +8,8 @@
 //! near-Sun magnitude is brighter than the depth — the maximum detectable
 //! distance. It is found by bisection.
 
+use p9_core::analysis::thermal::max_detectable_distance as core_max_detectable_distance;
+
 use crate::survey_model::WiseSurvey;
 use crate::thermal_model::{w1_magnitude, P9Thermal};
 
@@ -23,33 +25,9 @@ pub fn is_detectable_w1(survey: &WiseSurvey, mass_earth: f64, distance_au: f64) 
 /// (`d_min`) is already fainter than the depth (the planet is undetectable at
 /// any distance in the search range).
 pub fn max_detectable_distance(survey: &WiseSurvey, mass_earth: f64) -> Option<f64> {
-    let d_min = 50.0_f64;
-    let d_max = 50_000.0_f64;
-
-    // Brightness decreases monotonically with distance: detectable at d_min,
-    // not at d_max, with a single crossing in between.
-    if !is_detectable_w1(survey, mass_earth, d_min) {
-        return None;
-    }
-    if is_detectable_w1(survey, mass_earth, d_max) {
-        // Detectable even at the far edge of the search range; report the edge.
-        return Some(d_max);
-    }
-
-    let mut lo = d_min;
-    let mut hi = d_max;
-    for _ in 0..200 {
-        let mid = 0.5 * (lo + hi);
-        if is_detectable_w1(survey, mass_earth, mid) {
-            lo = mid;
-        } else {
-            hi = mid;
-        }
-        if hi - lo < 1e-4 {
-            break;
-        }
-    }
-    Some(0.5 * (lo + hi))
+    core_max_detectable_distance(50.0, 50_000.0, survey.w1_depth, |d| {
+        w1_magnitude(mass_earth, d)
+    })
 }
 
 /// Per-position W1 detection probability: the magnitude-efficiency at the

--- a/crates/p9-2018-wise-search/src/thermal_model.rs
+++ b/crates/p9-2018-wise-search/src/thermal_model.rs
@@ -31,24 +31,14 @@
 //! is the shared Neptune-anchored mass-radius relation in
 //! `p9_core::analysis::photometry` (R ≈ 3.34 R⊕ at 10 M⊕).
 
-use std::f64::consts::PI;
-
 use p9_core::analysis::photometry::mass_radius_neptunian;
+use p9_core::analysis::thermal::{
+    effective_temp, flux_to_magnitude, reflected_flux_jy, solar_equilibrium_temp, thermal_flux_jy,
+    C_LIGHT,
+};
 
-/// Planck constant (J·s).
-const H_PLANCK: f64 = 6.626_070_15e-34;
-/// Boltzmann constant (J/K).
-const K_BOLTZ: f64 = 1.380_649e-23;
-/// Speed of light (m/s).
-const C_LIGHT: f64 = 2.997_924_58e8;
 /// Earth radius (m).
 const R_EARTH_M: f64 = 6.371e6;
-/// 1 AU in meters.
-const AU_M: f64 = 1.495_978_707e11;
-/// Solar radius (m).
-const R_SUN_M: f64 = 6.957e8;
-/// Solar effective temperature (K).
-const T_SUN: f64 = 5778.0;
 
 /// WISE W1 effective wavelength in meters (3.3526 µm; Wright et al. 2010).
 pub const W1_WAVELENGTH_M: f64 = 3.3526e-6;
@@ -57,9 +47,6 @@ pub const W1_WAVELENGTH_M: f64 = 3.3526e-6;
 /// has F_ν = 309.540 Jy at W1 (Wright et al. 2010, Table 1). A source of
 /// flux F has W1 = −2.5 log10(F / F_ν0).
 pub const W1_ZERO_POINT_JY: f64 = 309.540;
-
-/// 1 Jansky in W/m²/Hz.
-const JY: f64 = 1.0e-26;
 
 /// Default geometric/Bond-like albedo for the reflected-light channel
 /// (Neptune-like, used by the workspace photometry).
@@ -107,35 +94,21 @@ impl P9Thermal {
     /// Solar equilibrium temperature (K) for a fast rotator radiating from
     /// its full surface: T_eq = T_sun √(R_sun / 2d) (1 − A)^¼.
     pub fn solar_equilibrium_temp(&self) -> f64 {
-        let d_m = self.distance_au * AU_M;
-        T_SUN * (R_SUN_M / (2.0 * d_m)).sqrt() * (1.0 - self.albedo).powf(0.25)
+        solar_equilibrium_temp(self.distance_au, self.albedo)
     }
 
     /// Effective temperature: the larger of the internal-heat floor and the
     /// solar-equilibrium temperature. Beyond a few hundred AU the solar term
     /// is ~10 K, so the internal floor dominates.
     pub fn effective_temp(&self) -> f64 {
-        self.solar_equilibrium_temp().max(self.internal_temp_k)
-    }
-
-    /// Planck function B_ν(T) in W/m²/Hz/sr at frequency `nu_hz`.
-    fn planck_bnu(t: f64, nu_hz: f64) -> f64 {
-        let x = H_PLANCK * nu_hz / (K_BOLTZ * t);
-        if x > 700.0 {
-            return 0.0;
-        }
-        (2.0 * H_PLANCK * nu_hz.powi(3) / (C_LIGHT * C_LIGHT)) / (x.exp() - 1.0)
+        effective_temp(self.distance_au, self.albedo, self.internal_temp_k)
     }
 
     /// Thermal flux density at W1 (Jy), a grey-body emitter of unit
     /// emissivity: F_ν = π B_ν(T) (R/d)².
     pub fn thermal_flux_w1_jy(&self) -> f64 {
         let nu = C_LIGHT / W1_WAVELENGTH_M;
-        let bnu = Self::planck_bnu(self.effective_temp(), nu);
-        let r = self.radius_m();
-        let d = self.distance_au * AU_M;
-        let solid_angle = PI * (r / d).powi(2);
-        solid_angle * bnu / JY
+        thermal_flux_jy(self.effective_temp(), self.radius_m(), self.distance_au, nu)
     }
 
     /// Reflected-sunlight flux density at W1 (Jy), observed near opposition
@@ -148,13 +121,7 @@ impl P9Thermal {
     ///   F_refl = albedo · [π B_ν(T_sun) (R_sun/r)²] · (R_p² / (4 Δ²)).
     pub fn reflected_flux_w1_jy(&self) -> f64 {
         let nu = C_LIGHT / W1_WAVELENGTH_M;
-        let bnu_sun = Self::planck_bnu(T_SUN, nu);
-        let solar_flux_at_planet = PI * bnu_sun * (R_SUN_M / (self.distance_au * AU_M)).powi(2);
-        let r_p = self.radius_m();
-        let delta_m = (self.distance_au - 1.0).max(1.0) * AU_M;
-        let reflected =
-            self.albedo * solar_flux_at_planet * (r_p * r_p) / (4.0 * delta_m * delta_m);
-        reflected / JY
+        reflected_flux_jy(self.albedo, self.radius_m(), self.distance_au, nu)
     }
 
     /// Total W1 flux density (Jy): thermal + reflected.
@@ -165,11 +132,7 @@ impl P9Thermal {
     /// Apparent W1 (Vega) magnitude from the total flux density. Fainter
     /// (larger) numbers for smaller flux; +∞ when the flux is zero.
     pub fn w1_magnitude(&self) -> f64 {
-        let flux = self.total_flux_w1_jy();
-        if flux <= 0.0 {
-            return f64::INFINITY;
-        }
-        -2.5 * (flux / W1_ZERO_POINT_JY).log10()
+        flux_to_magnitude(self.total_flux_w1_jy(), W1_ZERO_POINT_JY)
     }
 }
 

--- a/crates/p9-2021-act-mm/src/detectability.rs
+++ b/crates/p9-2021-act-mm/src/detectability.rs
@@ -16,10 +16,11 @@
 
 use p9_2018_wise_search::detectability::max_detectable_distance as wise_max_distance;
 use p9_2018_wise_search::survey_model::WiseSurvey;
+use p9_core::analysis::thermal::planck_bnu;
 use p9_core::constants::AU_M;
 
 use crate::survey_model::ActSurvey;
-use crate::thermal_model::{planck_bnu, P9Millimeter, MJY};
+use crate::thermal_model::{P9Millimeter, MJY};
 
 /// Whether a P9 of `mass_earth` at `distance_au` is at or above the ACT flux
 /// limit at the survey frequency.

--- a/crates/p9-2021-act-mm/src/thermal_model.rs
+++ b/crates/p9-2021-act-mm/src/thermal_model.rs
@@ -23,43 +23,13 @@
 use std::f64::consts::PI;
 
 use p9_2018_wise_search::thermal_model::P9Thermal;
+use p9_core::analysis::thermal::{planck_bnu, rayleigh_jeans_bnu, JY as CORE_JY};
 use p9_core::constants::AU_M;
 
-/// Planck constant (J·s).
-pub const H_PLANCK: f64 = 6.626_070_15e-34;
-/// Boltzmann constant (J/K).
-pub const K_BOLTZ: f64 = 1.380_649e-23;
-/// Speed of light (m/s).
-pub const C_LIGHT: f64 = 2.997_924_58e8;
-
 /// 1 Jansky in W/m²/Hz.
-pub const JY: f64 = 1.0e-26;
+pub const JY: f64 = CORE_JY;
 /// 1 milliJansky in W/m²/Hz.
 pub const MJY: f64 = 1.0e-29;
-
-/// Planck function B_ν(T) in W/m²/Hz/sr at frequency `nu_hz`.
-///
-/// This is the exact Planck law; at ACT mm frequencies and ~40 K it is well
-/// approximated by [`rayleigh_jeans_bnu`] (the two agree to a few percent).
-pub fn planck_bnu(t: f64, nu_hz: f64) -> f64 {
-    let x = H_PLANCK * nu_hz / (K_BOLTZ * t);
-    if x > 700.0 {
-        return 0.0;
-    }
-    (2.0 * H_PLANCK * nu_hz.powi(3) / (C_LIGHT * C_LIGHT)) / (x.exp() - 1.0)
-}
-
-/// Rayleigh–Jeans brightness B_ν ≈ 2 ν² k T / c² (W/m²/Hz/sr). The low-energy
-/// (hν ≪ kT) limit of [`planck_bnu`]; explicitly ∝ ν²·T.
-pub fn rayleigh_jeans_bnu(t: f64, nu_hz: f64) -> f64 {
-    2.0 * nu_hz * nu_hz * K_BOLTZ * t / (C_LIGHT * C_LIGHT)
-}
-
-/// Dimensionless photon-energy parameter x = hν/kT. The Rayleigh–Jeans regime
-/// is x ≪ 1, the Wien regime x ≫ 1.
-pub fn photon_energy_ratio(t: f64, nu_hz: f64) -> f64 {
-    H_PLANCK * nu_hz / (K_BOLTZ * t)
-}
 
 /// A cold Planet Nine viewed at millimeter wavelengths. Wraps the WISE crate's
 /// [`P9Thermal`] (mass, distance, internal-temperature floor, Neptune-anchored
@@ -131,6 +101,7 @@ impl P9Millimeter {
 mod tests {
     use super::*;
     use p9_2018_wise_search::thermal_model::INTERNAL_TEMP_FLOOR_K;
+    use p9_core::analysis::thermal::{photon_energy_ratio, C_LIGHT};
 
     /// ACT 150 GHz in Hz.
     const NU_150: f64 = 150.0e9;

--- a/crates/p9-2025-iras-akari/src/thermal_model.rs
+++ b/crates/p9-2025-iras-akari/src/thermal_model.rs
@@ -16,22 +16,12 @@
 //! 1.86 R⊕ at 10 M⊕ — a ~3.2× flux underestimate that pushed the paper's
 //! whole favorable corner below the IRAS detection limit.
 
-use std::f64::consts::PI;
+use p9_core::analysis::thermal::{planck_bnu, solar_equilibrium_temp, thermal_flux_jy, C_LIGHT};
 
 use crate::survey_model::{AkariFisSurvey, IrasSurvey};
 
-/// Planck constant (J·s)
-const H_PLANCK: f64 = 6.626_070_15e-34;
-/// Boltzmann constant (J/K)
-const K_BOLTZ: f64 = 1.380_649e-23;
-/// Speed of light (m/s)
-const C_LIGHT: f64 = 2.997_924_58e8;
 /// Earth radius (m)
 const R_EARTH: f64 = 6.371e6;
-/// 1 AU in meters
-const AU_M: f64 = 1.495_978_707e11;
-/// 1 Jansky in W/m²/Hz
-const JY: f64 = 1.0e-26;
 
 /// Physical parameters for a Planet Nine thermal model.
 #[derive(Debug, Clone, Copy)]
@@ -54,11 +44,7 @@ impl P9ThermalParams {
 
     /// Planck function B_ν(T) in W/m²/Hz/sr at frequency `nu_hz`.
     pub fn planck_bnu(t_eff: f64, nu_hz: f64) -> f64 {
-        let x = H_PLANCK * nu_hz / (K_BOLTZ * t_eff);
-        if x > 500.0 {
-            return 0.0;
-        }
-        (2.0 * H_PLANCK * nu_hz.powi(3) / (C_LIGHT * C_LIGHT)) / (x.exp() - 1.0)
+        planck_bnu(t_eff, nu_hz)
     }
 
     /// Wavelength in meters to frequency in Hz.
@@ -75,11 +61,7 @@ impl P9ThermalParams {
     /// deviations from a blackbody expected for a cold (≈40 K) ice giant.
     pub fn flux_density_jy_with_emissivity(&self, wavelength_m: f64, emissivity: f64) -> f64 {
         let nu = Self::wavelength_to_freq(wavelength_m);
-        let bnu = Self::planck_bnu(self.t_eff, nu);
-        let r = self.radius_m();
-        let d = self.distance_au * AU_M;
-        let solid_angle = PI * (r / d).powi(2);
-        emissivity * solid_angle * bnu / JY
+        emissivity * thermal_flux_jy(self.t_eff, self.radius_m(), self.distance_au, nu)
     }
 
     /// Predicted blackbody (ε = 1) flux density in Janskys.
@@ -93,10 +75,7 @@ impl P9ThermalParams {
     ///
     /// At 500+ AU this gives ~10–12 K, much below the 30–50 K internal heat.
     pub fn solar_equilibrium_temp(distance_au: f64, albedo: f64) -> f64 {
-        let t_sun = 5778.0;
-        let r_sun_m = 6.957e8;
-        let d_m = distance_au * AU_M;
-        t_sun * (r_sun_m / (2.0 * d_m)).sqrt() * (1.0 - albedo).powf(0.25)
+        solar_equilibrium_temp(distance_au, albedo)
     }
 }
 

--- a/crates/p9-2025-simons-forecast/src/thermal.rs
+++ b/crates/p9-2025-simons-forecast/src/thermal.rs
@@ -33,26 +33,13 @@
 //! the floor dominates) — the same temperature model as the WISE crate, so the
 //! two reproductions share a physical body.
 
-use std::f64::consts::PI;
-
 use p9_core::analysis::photometry::mass_radius_neptunian;
+use p9_core::analysis::thermal::{
+    effective_temp, planck_bnu, rayleigh_jeans_bnu, solar_equilibrium_temp, thermal_flux_jy,
+};
 
-/// Planck constant (J·s).
-const H_PLANCK: f64 = 6.626_070_15e-34;
-/// Boltzmann constant (J/K).
-const K_BOLTZ: f64 = 1.380_649e-23;
-/// Speed of light (m/s).
-const C_LIGHT: f64 = 2.997_924_58e8;
 /// Earth radius (m).
 const R_EARTH_M: f64 = 6.371e6;
-/// 1 AU in meters.
-const AU_M: f64 = 1.495_978_707e11;
-/// Solar radius (m).
-const R_SUN_M: f64 = 6.957e8;
-/// Solar effective temperature (K).
-const T_SUN: f64 = 5778.0;
-/// 1 Jansky in W/m²/Hz.
-const JY: f64 = 1.0e-26;
 
 /// Neptune-like geometric/Bond albedo, used only for the solar-equilibrium
 /// temperature term.
@@ -99,23 +86,18 @@ impl P9Thermal {
     /// Solar equilibrium temperature (K) for a fast rotator radiating from its
     /// full surface: T_eq = T_sun √(R_sun / 2d) (1 − A)^¼.
     pub fn solar_equilibrium_temp(&self) -> f64 {
-        let d_m = self.distance_au * AU_M;
-        T_SUN * (R_SUN_M / (2.0 * d_m)).sqrt() * (1.0 - self.albedo).powf(0.25)
+        solar_equilibrium_temp(self.distance_au, self.albedo)
     }
 
     /// Effective temperature: the larger of the internal-heat floor and the
     /// solar-equilibrium temperature.
     pub fn effective_temp(&self) -> f64 {
-        self.solar_equilibrium_temp().max(self.internal_temp_k)
+        effective_temp(self.distance_au, self.albedo, self.internal_temp_k)
     }
 
     /// Planck function B_ν(T) in W/m²/Hz/sr at frequency `nu_hz`.
     pub fn planck_bnu(t: f64, nu_hz: f64) -> f64 {
-        let x = H_PLANCK * nu_hz / (K_BOLTZ * t);
-        if x > 700.0 {
-            return 0.0;
-        }
-        (2.0 * H_PLANCK * nu_hz.powi(3) / (C_LIGHT * C_LIGHT)) / (x.exp() - 1.0)
+        planck_bnu(t, nu_hz)
     }
 
     /// Rayleigh–Jeans approximation to the Planck function (valid for x ≪ 1):
@@ -125,7 +107,7 @@ impl P9Thermal {
     /// Exposed so tests can pin that the exact Planck flux follows ∝ ν² T at
     /// the SO/ACT bands.
     pub fn rayleigh_jeans_bnu(t: f64, nu_hz: f64) -> f64 {
-        2.0 * nu_hz * nu_hz * K_BOLTZ * t / (C_LIGHT * C_LIGHT)
+        rayleigh_jeans_bnu(t, nu_hz)
     }
 
     /// Thermal flux density (Jy) at frequency `nu_hz`, a blackbody emitter of
@@ -133,11 +115,12 @@ impl P9Thermal {
     ///
     ///   F_ν = π B_ν(T) (R / d)².
     pub fn flux_jy(&self, nu_hz: f64) -> f64 {
-        let bnu = Self::planck_bnu(self.effective_temp(), nu_hz);
-        let r = self.radius_m();
-        let d = self.distance_au * AU_M;
-        let solid_angle = PI * (r / d).powi(2);
-        solid_angle * bnu / JY
+        thermal_flux_jy(
+            self.effective_temp(),
+            self.radius_m(),
+            self.distance_au,
+            nu_hz,
+        )
     }
 
     /// Thermal flux density (mJy) at frequency `nu_hz`.
@@ -156,6 +139,7 @@ pub fn flux_mjy(mass_earth: f64, distance_au: f64, nu_ghz: f64) -> f64 {
 mod tests {
     use super::*;
     use crate::bands::SO_280;
+    use p9_core::analysis::thermal::{H_PLANCK, K_BOLTZ};
 
     #[test]
     fn cold_body_is_in_rayleigh_jeans_regime_at_280ghz() {

--- a/crates/p9-core/src/analysis/mod.rs
+++ b/crates/p9-core/src/analysis/mod.rs
@@ -6,6 +6,7 @@ pub mod resonance;
 pub mod secular;
 pub mod stacking;
 pub mod surveys;
+pub mod thermal;
 
 /// Snapshot of orbital elements for all active particles at a given time.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/crates/p9-core/src/analysis/thermal.rs
+++ b/crates/p9-core/src/analysis/thermal.rs
@@ -1,0 +1,227 @@
+//! Shared blackbody / grey-body thermal model primitives for the IR–mm Planet
+//! Nine detectability reproductions.
+//!
+//! Several crates model the thermal (and reflected-sunlight) emission of a cold
+//! Planet Nine across the infrared and millimeter bands. They share the same
+//! underlying physics — the Planck function, an effective-temperature energy
+//! balance (internal-luminosity floor vs. solar equilibrium), the
+//! solid-angle × brightness flux law, the conversion of a flux density to a
+//! Vega-system magnitude, and a bisection for the maximum detectable distance.
+//!
+//! This module hosts the **generic, parameterized** versions of those
+//! primitives. Every crate-specific number — band wavelength, Vega zero point,
+//! geometric albedo, internal-temperature floor, mass–radius anchoring — stays
+//! in the calling crate and is passed in. Only the band-agnostic math lives
+//! here.
+
+use std::f64::consts::PI;
+
+/// Planck constant (J·s).
+pub const H_PLANCK: f64 = 6.626_070_15e-34;
+/// Boltzmann constant (J/K).
+pub const K_BOLTZ: f64 = 1.380_649e-23;
+/// Speed of light (m/s).
+pub const C_LIGHT: f64 = 2.997_924_58e8;
+/// Solar radius (m).
+pub const R_SUN_M: f64 = 6.957e8;
+/// Solar effective temperature (K).
+pub const T_SUN: f64 = 5778.0;
+/// 1 AU in meters.
+pub const AU_M: f64 = 1.495_978_707e11;
+/// 1 Jansky in W/m²/Hz.
+pub const JY: f64 = 1.0e-26;
+
+/// Planck function B_ν(T) in W/m²/Hz/sr at frequency `nu_hz`.
+///
+/// The dimensionless argument x = hν/kT is guarded: for x > 700 (deep on the
+/// Wien tail) the spectral radiance underflows to 0, which also avoids
+/// overflowing `exp`.
+pub fn planck_bnu(t: f64, nu_hz: f64) -> f64 {
+    let x = H_PLANCK * nu_hz / (K_BOLTZ * t);
+    if x > 700.0 {
+        return 0.0;
+    }
+    (2.0 * H_PLANCK * nu_hz.powi(3) / (C_LIGHT * C_LIGHT)) / (x.exp() - 1.0)
+}
+
+/// Rayleigh–Jeans brightness B_ν ≈ 2 ν² k T / c² (W/m²/Hz/sr). The low-energy
+/// (hν ≪ kT) limit of [`planck_bnu`]; explicitly ∝ ν²·T.
+pub fn rayleigh_jeans_bnu(t: f64, nu_hz: f64) -> f64 {
+    2.0 * nu_hz * nu_hz * K_BOLTZ * t / (C_LIGHT * C_LIGHT)
+}
+
+/// Dimensionless photon-energy parameter x = hν/kT. The Rayleigh–Jeans regime
+/// is x ≪ 1, the Wien regime x ≫ 1.
+pub fn photon_energy_ratio(t: f64, nu_hz: f64) -> f64 {
+    H_PLANCK * nu_hz / (K_BOLTZ * t)
+}
+
+/// Solar equilibrium temperature (K) for a fast rotator radiating from its full
+/// surface at heliocentric distance `distance_au` with geometric/Bond albedo
+/// `albedo`: T_eq = T_sun √(R_sun / 2d) (1 − A)^¼.
+pub fn solar_equilibrium_temp(distance_au: f64, albedo: f64) -> f64 {
+    let d_m = distance_au * AU_M;
+    T_SUN * (R_SUN_M / (2.0 * d_m)).sqrt() * (1.0 - albedo).powf(0.25)
+}
+
+/// Effective temperature (K): the larger of the internal-heat floor
+/// `internal_temp_k` and the solar-equilibrium temperature at `distance_au`
+/// with `albedo`. Beyond a few hundred AU the solar term is ~10 K, so the
+/// internal floor dominates.
+pub fn effective_temp(distance_au: f64, albedo: f64, internal_temp_k: f64) -> f64 {
+    solar_equilibrium_temp(distance_au, albedo).max(internal_temp_k)
+}
+
+/// Thermal grey-body flux density (Jy) of a unit-emissivity emitter of physical
+/// radius `radius_m` at heliocentric distance `distance_au`, evaluated at
+/// frequency `nu_hz`: F_ν = π B_ν(T) (R/d)².
+pub fn thermal_flux_jy(t: f64, radius_m: f64, distance_au: f64, nu_hz: f64) -> f64 {
+    let bnu = planck_bnu(t, nu_hz);
+    let d = distance_au * AU_M;
+    let solid_angle = PI * (radius_m / d).powi(2);
+    solid_angle * bnu / JY
+}
+
+/// Reflected-sunlight flux density (Jy) of a body of radius `radius_m` and
+/// reflectance `albedo` at heliocentric distance `distance_au`, observed near
+/// opposition (Δ = d − 1 AU, floored at 1 AU), evaluated at frequency `nu_hz`.
+///
+/// The Sun is a blackbody at [`T_SUN`]; the solar flux at the planet is
+/// π B_ν(T_sun) (R_sun / r)². The planet intercepts a disc πR_p², reflects a
+/// fraction `albedo` into ~2π sr (Lambert factor absorbed into the geometric
+/// albedo), and that reradiated flux falls as 1/Δ² to the observer:
+///
+///   F_refl = albedo · [π B_ν(T_sun) (R_sun/r)²] · (R_p² / (4 Δ²)).
+pub fn reflected_flux_jy(albedo: f64, radius_m: f64, distance_au: f64, nu_hz: f64) -> f64 {
+    let bnu_sun = planck_bnu(T_SUN, nu_hz);
+    let solar_flux_at_planet = PI * bnu_sun * (R_SUN_M / (distance_au * AU_M)).powi(2);
+    let delta_m = (distance_au - 1.0).max(1.0) * AU_M;
+    let reflected =
+        albedo * solar_flux_at_planet * (radius_m * radius_m) / (4.0 * delta_m * delta_m);
+    reflected / JY
+}
+
+/// Apparent Vega-system magnitude from a flux density `flux` and a band Vega
+/// zero-point flux `zero_point` (same units). Fainter (larger) numbers for
+/// smaller flux; +∞ when the flux is non-positive.
+pub fn flux_to_magnitude(flux: f64, zero_point: f64) -> f64 {
+    if flux <= 0.0 {
+        return f64::INFINITY;
+    }
+    -2.5 * (flux / zero_point).log10()
+}
+
+/// Maximum heliocentric distance (AU) at which `magnitude_at(distance)` reaches
+/// `depth`, found by bisection on the monotone (fainting-with-distance)
+/// magnitude–distance relation over `[d_min, d_max]`.
+///
+/// Returns `None` if the source is already fainter than `depth` at `d_min`
+/// (undetectable anywhere in range); returns `Some(d_max)` if it is still
+/// brighter than `depth` at `d_max` (detectable to the far edge of the range).
+pub fn max_detectable_distance(
+    d_min: f64,
+    d_max: f64,
+    depth: f64,
+    magnitude_at: impl Fn(f64) -> f64,
+) -> Option<f64> {
+    if magnitude_at(d_min) > depth {
+        return None;
+    }
+    if magnitude_at(d_max) <= depth {
+        return Some(d_max);
+    }
+
+    let mut lo = d_min;
+    let mut hi = d_max;
+    for _ in 0..200 {
+        let mid = 0.5 * (lo + hi);
+        if magnitude_at(mid) <= depth {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+        if hi - lo < 1e-4 {
+            break;
+        }
+    }
+    Some(0.5 * (lo + hi))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn planck_underflows_on_deep_wien_tail() {
+        // A 40 K body at WISE W1 (3.3526 µm) has x ≈ 107 ≫ 700? No — but the
+        // guard returns exactly 0 once x exceeds 700, and the flux is otherwise
+        // a tiny positive number on the Wien tail.
+        let nu_w1 = C_LIGHT / 3.3526e-6;
+        let b = planck_bnu(40.0, nu_w1);
+        assert!(b >= 0.0 && b < 1e-40, "B_nu(40 K, W1) = {b:.3e}");
+        // Hard guard: an extreme x returns exactly 0.
+        assert_eq!(planck_bnu(1.0, nu_w1), 0.0);
+    }
+
+    #[test]
+    fn rayleigh_jeans_matches_planck_at_low_x() {
+        // At 280 GHz and 40 K, x ≈ 0.34: the RJ approximation tracks the exact
+        // Planck function to better than 20%.
+        let nu = 280e9;
+        let t = 40.0;
+        assert!(photon_energy_ratio(t, nu) < 0.5);
+        let exact = planck_bnu(t, nu);
+        let rj = rayleigh_jeans_bnu(t, nu);
+        assert!((exact - rj).abs() / rj < 0.2);
+    }
+
+    #[test]
+    fn solar_equilibrium_is_cold_beyond_a_few_hundred_au() {
+        // At 500 AU the solar-equilibrium temperature is ~10 K, below a 40 K
+        // internal floor, so the effective temperature is the floor.
+        assert!(solar_equilibrium_temp(500.0, 0.41) < 15.0);
+        assert!((effective_temp(500.0, 0.41, 40.0) - 40.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn flux_falls_as_inverse_distance_squared() {
+        let near = thermal_flux_jy(40.0, 2.0e7, 400.0, 150e9);
+        let far = thermal_flux_jy(40.0, 2.0e7, 800.0, 150e9);
+        assert!((near / far - 4.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn flux_scales_with_radius_squared() {
+        let a = thermal_flux_jy(40.0, 1.0e7, 500.0, 150e9);
+        let b = thermal_flux_jy(40.0, 2.0e7, 500.0, 150e9);
+        assert!((b / a - 4.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn zero_point_gives_zero_magnitude() {
+        let zp = 309.540;
+        assert!(flux_to_magnitude(zp, zp).abs() < 1e-12);
+    }
+
+    #[test]
+    fn magnitude_is_infinite_for_zero_flux() {
+        assert!(flux_to_magnitude(0.0, 309.540).is_infinite());
+    }
+
+    #[test]
+    fn max_detectable_distance_brackets_the_crossover() {
+        // A toy magnitude that faints by 5 log10(d): pick a depth and confirm
+        // the returned distance reproduces it.
+        let depth = 16.5;
+        let mag = |d: f64| 5.0 * d.log10();
+        let d = max_detectable_distance(50.0, 50_000.0, depth, mag).expect("detectable");
+        assert!((mag(d) - depth).abs() < 1e-3);
+    }
+
+    #[test]
+    fn max_detectable_distance_none_when_undetectable_at_near_edge() {
+        let mag = |d: f64| 5.0 * d.log10();
+        // Depth far brighter than even the near-edge magnitude → never detectable.
+        assert!(max_detectable_distance(50.0, 50_000.0, 1.0, mag).is_none());
+    }
+}


### PR DESCRIPTION
Coalesce G2: unify Planck/effective-temperature thermal model into p9-core::analysis::thermal; repoint IR/mm/thermal crates, no shims.