### PR TITLE
De-qualify inline p9_core call sites

### DIFF
--- a/crates/p9-2016-constraints/src/clustering_metric.rs
+++ b/crates/p9-2016-constraints/src/clustering_metric.rs
@@ -15,6 +15,8 @@ use std::f64::consts::PI;
 
 use p9_core::analysis::circular::{mean_resultant_length, wrap_to_pi};
 use p9_core::constants::*;
+use p9_core::data::etno::longitudes_of_perihelion;
+use p9_core::data::stable_kbos::{longitude_of_perihelion, stable_kbos};
 use p9_core::types::OrbitalElements;
 
 /// Sedna-like "high perihelion" threshold (AU). Detached objects lifted to
@@ -84,9 +86,9 @@ pub fn evaluate_clustering(
 /// headline "ϖ = 71° ± 16°" corresponds to a tighter dispersion than the
 /// full sample's circular statistics give).
 pub fn observed_six_kbo_r_bar() -> f64 {
-    let varpis: Vec<f64> = p9_core::data::stable_kbos::stable_kbos()
+    let varpis: Vec<f64> = stable_kbos()
         .iter()
-        .map(|k| p9_core::data::stable_kbos::longitude_of_perihelion(&k.elements))
+        .map(|k| longitude_of_perihelion(&k.elements))
         .collect();
     mean_resultant_length(&varpis)
 }
@@ -95,7 +97,7 @@ pub fn observed_six_kbo_r_bar() -> f64 {
 /// 10-object Brown (2017) ETNO sample (the workspace's vetted observational
 /// table, `p9_core::data::etno`).
 pub fn observed_etno_r_bar() -> f64 {
-    mean_resultant_length(&p9_core::data::etno::longitudes_of_perihelion())
+    mean_resultant_length(&longitudes_of_perihelion())
 }
 
 /// Compute confinement probability for a subsample.

--- a/crates/p9-2016-evidence/src/kbo_elements.rs
+++ b/crates/p9-2016-evidence/src/kbo_elements.rs
@@ -9,6 +9,7 @@ use p9_core::analysis::circular::{circular_mean, mean_resultant_length};
 use p9_core::constants::*;
 use p9_core::data::stable_kbos::{longitude_of_perihelion, stable_kbos, KboRecord};
 use p9_core::forces::ExtraForce;
+use p9_core::initial_conditions::planets::neptune_only_j2000;
 use p9_core::integrator::whm::WhmIntegrator;
 use p9_core::types::{cartesian_to_elements, OrbitalElements, SimConfig};
 
@@ -91,7 +92,7 @@ pub fn clone_stability_screen(
     let mut particles: Vec<_> = clones.iter().map(|c| c.to_state_vector(GM_SUN)).collect();
     let mut active = vec![true; particles.len()];
 
-    let mut bodies = p9_core::initial_conditions::planets::neptune_only_j2000();
+    let mut bodies = neptune_only_j2000();
     let integrator = WhmIntegrator::with_extra_forces(vec![ExtraForce::J2Jsu]);
 
     let config = SimConfig {

--- a/crates/p9-2016-evidence/src/plots.rs
+++ b/crates/p9-2016-evidence/src/plots.rs
@@ -10,6 +10,7 @@
 use std::fmt::Write;
 
 use crate::phase_portrait::TrajectoryPoint;
+use p9_core::analysis::circular::wrap_to_pi;
 use p9_core::constants::*;
 use p9_core::data::stable_kbos::KboRecord;
 use p9_core::initial_conditions::scattered_disk_sim::DiskSnapshot;
@@ -210,7 +211,7 @@ pub fn scattered_disk_clustering(
         }
 
         let varpi = elem.omega + elem.omega_big;
-        let dv = p9_core::analysis::circular::wrap_to_pi(varpi - varpi_p9);
+        let dv = wrap_to_pi(varpi - varpi_p9);
 
         let px = margin + (elem.a - a_min) / a_range * plot_w;
         let py = margin + (1.0 - (dv + std::f64::consts::PI) / TWO_PI) * plot_h;

--- a/crates/p9-2016-evidence/src/resonance.rs
+++ b/crates/p9-2016-evidence/src/resonance.rs
@@ -15,6 +15,7 @@
 //! so the angle circulated at n₉(p² − q²)/q even for an exactly resonant
 //! orbit and `is_librating` could never fire.)
 
+use p9_core::analysis::circular::wrap_to_pi;
 use p9_core::analysis::resonance as core_resonance;
 use p9_core::constants::*;
 use p9_core::types::OrbitalElements;
@@ -88,7 +89,7 @@ pub fn resonant_angle(
     // Interior particle: exchange roles in p9-core's exterior convention,
     // i.e. core's (p, q, λ, λ_planet, ϖ) ← (q, p, λ, λ₉, ϖ).
     let phi = core_resonance::resonant_angle(q, p, lambda_part, lambda_p9, varpi_part);
-    p9_core::analysis::circular::wrap_to_pi(phi)
+    wrap_to_pi(phi)
 }
 
 /// Check if a series of resonant angles indicates libration (resonance

--- a/crates/p9-2016-linder-evolution/src/lib.rs
+++ b/crates/p9-2016-linder-evolution/src/lib.rs
@@ -101,6 +101,7 @@ pub fn is_detectable(mag: f64, limiting_mag: f64) -> bool {
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
+    use p9_core::analysis::surveys::limiting_magnitude;
 
     #[test]
     fn ten_earth_mass_at_700au_matches_published_v() {
@@ -153,7 +154,7 @@ mod tests {
         // A fainter (lower-mass, more-distant) Planet Nine quickly drops below
         // optical survey limits. PS1 3pi reaches r ≈ 21.5; a 5 M⊕ body at
         // 1000 AU is far fainter in reflected light.
-        let ps1 = p9_core::analysis::surveys::limiting_magnitude("PS1 3pi").unwrap();
+        let ps1 = limiting_magnitude("PS1 3pi").unwrap();
         let v = reflected_v_magnitude(5.0, 1000.0);
         assert!(
             !is_detectable(v, ps1),
@@ -161,7 +162,7 @@ mod tests {
         );
         // ... while the nominal 10 M⊕ at 700 AU sits near the deepest optical
         // limit (DES r ≈ 23.8), illustrating how marginal optical detection is.
-        let des = p9_core::analysis::surveys::limiting_magnitude("DES").unwrap();
+        let des = limiting_magnitude("DES").unwrap();
         let v_nom = reflected_v_magnitude(10.0, 700.0);
         assert!(
             is_detectable(v_nom, des),

--- a/crates/p9-2016-obliquity/src/secular_hamiltonian.rs
+++ b/crates/p9-2016-obliquity/src/secular_hamiltonian.rs
@@ -13,6 +13,7 @@
 //! The equations of motion in vector form are:
 //!   dL̂_i/dt = (3/L_i) Σ_j C_ij (L̂_i · L̂_j) (L̂_i × L̂_j)
 
+use p9_core::analysis::circular::wrap_to_pi;
 use p9_core::constants::*;
 use p9_core::initial_conditions::giant_planets;
 
@@ -355,7 +356,7 @@ fn make_snapshot(state: &SpinOrbitState, t: f64) -> ObliquitySnapshot {
     let _i_sun = state.l_sun[2].clamp(-1.0, 1.0).acos();
     let omega_big_sun = state.l_sun[1].atan2(state.l_sun[0]);
 
-    let delta = p9_core::analysis::circular::wrap_to_pi(omega_big_sun - omega_big_9);
+    let delta = wrap_to_pi(omega_big_sun - omega_big_9);
 
     ObliquitySnapshot {
         t,

--- a/crates/p9-2017-dynamics/src/resonance.rs
+++ b/crates/p9-2017-dynamics/src/resonance.rs
@@ -13,6 +13,7 @@
 //! with its (P, Q) = (q, p) exterior convention).
 
 use p9_core::analysis::hansen::{hansen_coefficient, mean_to_true_anomaly};
+use p9_core::analysis::resonance::resonant_angle;
 use p9_core::constants::{EARTH_MASS_SOLAR, GM_SUN, TWO_PI};
 use serde::{Deserialize, Serialize};
 use std::f64::consts::PI;
@@ -40,13 +41,7 @@ impl Resonance {
     /// Resonant angle φ = q λ − p λ₉ + (p − q) ϖ for this p:q resonance
     /// (single workspace convention via `p9_core::analysis::resonance`).
     pub fn resonant_angle(&self, lambda: f64, lambda_9: f64, varpi: f64) -> f64 {
-        p9_core::analysis::resonance::resonant_angle(
-            self.q as u32,
-            self.p as u32,
-            lambda,
-            lambda_9,
-            varpi,
-        )
+        resonant_angle(self.q as u32, self.p as u32, lambda, lambda_9, varpi)
     }
 
     /// Quadrupole-limit pendulum half-width (AU) of the p:q resonance, via

--- a/crates/p9-2017-ossos-bias/src/detection.rs
+++ b/crates/p9-2017-ossos-bias/src/detection.rs
@@ -28,6 +28,7 @@
 //!    isotropic parent into an apparently clustered detected sample.
 
 use p9_core::analysis::photometry::{apparent_magnitude, opposition_delta};
+use p9_core::analysis::surveys::limiting_magnitude;
 use p9_core::constants::{DEG2RAD, GM_SUN, TWO_PI};
 use p9_core::coords::sky::ecliptic_vec_declination;
 use p9_core::types::OrbitalElements;
@@ -72,7 +73,7 @@ impl Default for SurveyModel {
     fn default() -> Self {
         // Depth: use the deepest tabulated wide-field survey (DES, r ≈ 23.8)
         // from the shared survey table.
-        let limiting_mag = p9_core::analysis::surveys::limiting_magnitude("DES").unwrap_or(23.8);
+        let limiting_mag = limiting_magnitude("DES").unwrap_or(23.8);
 
         // Discovery-longitude windows. OSSOS observed a handful of blocks at
         // specific ecliptic longitudes; combined with the other wide-field

--- a/crates/p9-2019-review/src/detection_prospects.rs
+++ b/crates/p9-2019-review/src/detection_prospects.rs
@@ -7,6 +7,7 @@
 //! shared with `p9_core::analysis::surveys` where available.
 
 use p9_core::analysis::photometry;
+use p9_core::analysis::surveys::limiting_magnitude;
 use p9_core::constants::*;
 use p9_core::types::P9Params;
 
@@ -87,13 +88,11 @@ pub fn survey_limits() -> Vec<SurveyLimit> {
     vec![
         SurveyLimit {
             name: "Pan-STARRS",
-            v_limit: p9_core::analysis::surveys::limiting_magnitude("PS1 3pi")
-                .expect("PS1 in shared table"),
+            v_limit: limiting_magnitude("PS1 3pi").expect("PS1 in shared table"),
         },
         SurveyLimit {
             name: "DECam/DES",
-            v_limit: p9_core::analysis::surveys::limiting_magnitude("DES")
-                .expect("DES in shared table"),
+            v_limit: limiting_magnitude("DES").expect("DES in shared table"),
         },
         SurveyLimit {
             name: "Subaru HSC",

--- a/crates/p9-2019-selfgrav-disk/src/secular.rs
+++ b/crates/p9-2019-selfgrav-disk/src/secular.rs
@@ -42,6 +42,7 @@
 
 use crate::disk::DiskProfile;
 use crate::laplace::softened_laplace;
+use p9_core::analysis::circular::wrap_to_pi;
 use p9_core::constants::GM_SUN;
 use std::f64::consts::PI;
 
@@ -71,7 +72,7 @@ impl SecularSolution {
     /// Forced Delta varpi relative to the disk apse (radians, wrapped to
     /// (-pi, pi]). 0 means aligned with the disk apse, +-pi anti-aligned.
     pub fn forced_delta_varpi(&self) -> f64 {
-        p9_core::analysis::circular::wrap_to_pi(self.varpi_forced - self.varpi_disk)
+        wrap_to_pi(self.varpi_forced - self.varpi_disk)
     }
 }
 

--- a/crates/p9-2021-napier-critique/src/critique.rs
+++ b/crates/p9-2021-napier-critique/src/critique.rs
@@ -22,7 +22,7 @@
 //! Reference: Napier, Gerdes, Lin et al. (2021), PSJ 2, 59
 //! (arXiv:2102.05601).
 
-use p9_core::analysis::circular::mean_resultant_length;
+use p9_core::analysis::circular::{mean_resultant_length, rayleigh_p_value};
 use p9_core::constants::{DEG2RAD, TWO_PI};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
@@ -181,7 +181,7 @@ pub fn run_critique<R: Rng>(
     CritiqueResult {
         n: angles.len(),
         r_bar_observed: mean_resultant_length(angles),
-        rayleigh_p: p9_core::analysis::circular::rayleigh_p_value(angles),
+        rayleigh_p: rayleigh_p_value(angles),
         consistency_p: consistency_p_value(angles, sel, n_mc, rng),
     }
 }
@@ -215,7 +215,7 @@ mod tests {
         // Headline pin (1): against the WRONG (pure-uniform) null, the
         // observed ETNO sample looks significantly clustered.
         let varpis = longitudes_of_perihelion();
-        let p = p9_core::analysis::circular::rayleigh_p_value(&varpis);
+        let p = rayleigh_p_value(&varpis);
         assert!(p < 0.05, "naive Rayleigh p = {p:.4} (expected < 0.05)");
     }
 

--- a/crates/p9-2021-orbit/src/statistical_measures.rs
+++ b/crates/p9-2021-orbit/src/statistical_measures.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 
 use p9_core::analysis::circular::{circular_mean, mean_resultant_length, rayleigh_p_value};
 use p9_core::constants::{DEG2RAD, TWO_PI};
+use p9_core::data::etno::longitudes_of_perihelion;
 
 /// Result of the clustering confidence analysis.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -153,7 +154,7 @@ pub fn clustering_significance_mc(
 /// full bias treatment; this vetted 10-object table with the analytic
 /// Rayleigh test lands within a point of that.
 pub fn paper_clustering_confidence() -> ClusteringConfidence {
-    let varpis = p9_core::data::etno::longitudes_of_perihelion();
+    let varpis = longitudes_of_perihelion();
     compute_clustering_significance(&varpis)
 }
 
@@ -195,7 +196,7 @@ mod tests {
     /// The seeded uniform-null MC agrees with the analytic Rayleigh p-value.
     #[test]
     fn test_mc_uniform_null_matches_analytic() {
-        let varpis = p9_core::data::etno::longitudes_of_perihelion();
+        let varpis = longitudes_of_perihelion();
         let analytic = compute_clustering_significance(&varpis);
         let mc = clustering_significance_mc(&varpis, 50_000, 42, NullModel::Uniform);
         assert!(
@@ -211,7 +212,7 @@ mod tests {
     /// p-value cannot decrease.
     #[test]
     fn test_bias_aware_null_is_more_conservative() {
-        let varpis = p9_core::data::etno::longitudes_of_perihelion();
+        let varpis = longitudes_of_perihelion();
         let uniform = clustering_significance_mc(&varpis, 20_000, 7, NullModel::Uniform);
         let biased = clustering_significance_mc(&varpis, 20_000, 7, NullModel::SurveyBias);
         assert!(

--- a/crates/p9-2021-ztf/src/survey_model.rs
+++ b/crates/p9-2021-ztf/src/survey_model.rs
@@ -5,6 +5,7 @@
 //! used in Brown & Batygin (2021). The depth limit comes from the shared
 //! survey table in `p9_core::analysis::surveys`.
 
+use p9_core::analysis::surveys::limiting_magnitude;
 use serde::{Deserialize, Serialize};
 
 /// ZTF survey model parameters for Planet Nine detection.
@@ -24,8 +25,7 @@ pub struct ZtfSurvey {
 impl Default for ZtfSurvey {
     fn default() -> Self {
         Self {
-            depth_limit: p9_core::analysis::surveys::limiting_magnitude("ZTF")
-                .expect("ZTF in shared survey table"),
+            depth_limit: limiting_magnitude("ZTF").expect("ZTF in shared survey table"),
             efficiency_steepness: 4.0,
             dec_limit_deg: -30.0,
         }

--- a/crates/p9-2022-des/src/recovery_analysis.rs
+++ b/crates/p9-2022-des/src/recovery_analysis.rs
@@ -12,6 +12,7 @@
 use rand::{Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 
+use p9_core::analysis::surveys::combined_unique_exclusion;
 use p9_core::coords::observer::{EarthProvider, EarthState};
 use p9_core::data::reference_population::{generate_reference_population, heliocentric_distance};
 use p9_core::types::{OrbitalElements, P9Params};
@@ -168,7 +169,7 @@ pub fn combined_ztf_des() -> f64 {
         .find(|s| s.survey == "ZTF")
         .expect("ZTF in shared exclusion table")
         .unique_fraction;
-    p9_core::analysis::surveys::combined_unique_exclusion(&[ztf, unique_exclusion()])
+    combined_unique_exclusion(&[ztf, unique_exclusion()])
 }
 
 #[cfg(test)]

--- a/crates/p9-2022-des/src/sky.rs
+++ b/crates/p9-2022-des/src/sky.rs
@@ -49,7 +49,8 @@ pub fn earth_states_at(
 mod tests {
     use super::*;
     use p9_core::coords::sky::{
-        apparent_position_deg, apparent_position_with_earth_deg, phase_angle_with_earth,
+        angular_distance, apparent_position_deg, apparent_position_with_earth_deg,
+        phase_angle_with_earth,
     };
     use p9_core::types::OrbitalElements;
 
@@ -84,7 +85,7 @@ mod tests {
             let (ra_a, dec_a, r_a) = apparent_position_deg(&elem, t_days);
             let (ra_e, dec_e, r_e) = apparent_position_with_earth_deg(&elem, state, t_days);
             assert!((r_a - r_e).abs() < 1e-9);
-            let sep = p9_core::coords::sky::angular_distance(
+            let sep = angular_distance(
                 &Vector3::new(
                     dec_a.to_radians().cos() * ra_a.to_radians().cos(),
                     dec_a.to_radians().cos() * ra_a.to_radians().sin(),

--- a/crates/p9-2022-des/src/survey_model.rs
+++ b/crates/p9-2022-des/src/survey_model.rs
@@ -9,7 +9,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use p9_core::analysis::surveys::poisson_binomial_tail;
+use p9_core::analysis::surveys::{limiting_magnitude, poisson_binomial_tail};
 use p9_core::coords::observer::{EarthProvider, EarthState, Time, Timescale};
 use p9_core::coords::sky::{
     apparent_position_deg, apparent_position_with_earth_deg, phase_angle_with_earth,
@@ -137,8 +137,7 @@ impl Default for DesSurvey {
             nights_per_band: 10,
             min_nights: 8,
             depth_g: 24.1,
-            depth_r: p9_core::analysis::surveys::limiting_magnitude("DES")
-                .expect("DES depth in p9-core survey table"),
+            depth_r: limiting_magnitude("DES").expect("DES depth in p9-core survey table"),
             depth_i: 23.3,
             depth_z: 22.6,
             night_usability: 0.29,

--- a/crates/p9-2022-iras-candidate/src/distance.rs
+++ b/crates/p9-2022-iras-candidate/src/distance.rs
@@ -18,6 +18,7 @@
 //! These are the scalings the paper's 225 AU / 3–5 M⊕ inference rests on.
 
 use p9_2025_iras_akari::thermal_model::P9ThermalParams;
+use p9_core::analysis::photometry::mass_radius_neptunian;
 
 /// 1 AU in metres (matches `p9_2025_iras_akari::thermal_model`).
 const AU_M: f64 = 1.495_978_707e11;
@@ -29,7 +30,7 @@ const JY: f64 = 1.0e-26;
 /// Physical radius (m) of a body of `mass_earth` Earth masses, from the
 /// shared Neptune-anchored mass-radius relation in `p9-core`.
 pub fn radius_m(mass_earth: f64) -> f64 {
-    p9_core::analysis::photometry::mass_radius_neptunian(mass_earth) * R_EARTH_M
+    mass_radius_neptunian(mass_earth) * R_EARTH_M
 }
 
 /// Implied heliocentric distance (AU) of a blackbody of effective

--- a/crates/p9-2024-neptune-crossing/src/observed_tnos.rs
+++ b/crates/p9-2024-neptune-crossing/src/observed_tnos.rs
@@ -215,7 +215,8 @@ pub fn element_snapshots() -> Vec<p9_core::data::refresh::ElementSnapshot> {
 pub fn refresh_from_sbdb(
     client: &p9_core::data::refresh::SbdbClient,
 ) -> Result<Vec<p9_core::data::refresh::EtnoDiff>, String> {
-    p9_core::data::refresh::refresh_table_from_sbdb(
+    use p9_core::data::refresh::refresh_table_from_sbdb;
+    refresh_table_from_sbdb(
         client,
         &element_snapshots(),
         &p9_core::data::refresh::Tolerances::full_precision(),

--- a/crates/p9-2024-panstarrs/src/combined_exclusion.rs
+++ b/crates/p9-2024-panstarrs/src/combined_exclusion.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 
 use p9_2022_des::color_models as des_colors;
 use p9_2022_des::survey_model::{DesBand, DesSurvey};
+use p9_core::analysis::surveys::combined_unique_exclusion;
 use p9_core::constants::DEG2RAD;
 use p9_core::coords::observer::{EarthProvider, EarthState};
 use p9_core::data::reference_population::{generate_reference_population, heliocentric_distance};
@@ -121,7 +122,7 @@ impl CombinedExclusion {
             ztf_frac: ztf,
             des_unique: des,
             ps1_unique: ps1,
-            combined: p9_core::analysis::surveys::combined_unique_exclusion(&[ztf, des, ps1]),
+            combined: combined_unique_exclusion(&[ztf, des, ps1]),
         }
     }
 }
@@ -129,8 +130,7 @@ impl CombinedExclusion {
 /// Combine *published unique* exclusion fractions (already disjoint by
 /// construction) via the shared p9-core helper.
 pub fn compute_combined(ztf_frac: f64, des_unique: f64, ps1_unique: f64) -> CombinedExclusion {
-    let combined =
-        p9_core::analysis::surveys::combined_unique_exclusion(&[ztf_frac, des_unique, ps1_unique]);
+    let combined = combined_unique_exclusion(&[ztf_frac, des_unique, ps1_unique]);
     CombinedExclusion {
         ztf_frac,
         des_unique,

--- a/crates/p9-2024-panstarrs/src/survey_model.rs
+++ b/crates/p9-2024-panstarrs/src/survey_model.rs
@@ -7,7 +7,7 @@
 //! cuts, and the measured 99.2% linking efficiency. The single-exposure
 //! depth comes from the shared `p9_core::analysis::surveys` table.
 
-use p9_core::analysis::surveys::poisson_binomial_tail;
+use p9_core::analysis::surveys::{limiting_magnitude, poisson_binomial_tail};
 use p9_core::coords::observer::{Time, Timescale};
 use serde::{Deserialize, Serialize};
 
@@ -50,8 +50,7 @@ pub struct Ps1Survey {
 impl Default for Ps1Survey {
     fn default() -> Self {
         Self {
-            depth_limit: p9_core::analysis::surveys::limiting_magnitude("PS1 3pi")
-                .expect("PS1 in shared survey table"),
+            depth_limit: limiting_magnitude("PS1 3pi").expect("PS1 in shared survey table"),
             dec_limit_deg: -30.0,
             n_epochs: 17,
             linking_threshold: 9,

--- a/crates/p9-2025-iras-akari/src/candidate_search.rs
+++ b/crates/p9-2025-iras-akari/src/candidate_search.rs
@@ -12,6 +12,7 @@
 //!
 //! The paper finds 13 pairs after step 4, and 1 good candidate after step 6.
 
+use p9_core::coords::candidate_pair::implied_distance;
 use serde::{Deserialize, Serialize};
 
 use crate::survey_model::{angular_separation_arcmin, FirSource};
@@ -134,7 +135,7 @@ pub fn search_candidates(
                 continue;
             }
 
-            let d = p9_core::coords::candidate_pair::implied_distance(sep, baseline_years);
+            let d = implied_distance(sep, baseline_years);
 
             candidates.push(CandidatePair {
                 iras_source: iras.clone(),

--- a/crates/p9-2025-iras-akari/src/plots.rs
+++ b/crates/p9-2025-iras-akari/src/plots.rs
@@ -360,6 +360,7 @@ pub fn separation_vs_distance_plot(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use p9_core::coords::candidate_pair::heliocentric_separation_arcmin;
 
     #[test]
     fn flux_plot_produces_valid_svg() {
@@ -379,9 +380,7 @@ mod tests {
         let distances: Vec<f64> = (200..=1000).step_by(50).map(|d| d as f64).collect();
         let seps: Vec<f64> = distances
             .iter()
-            .map(|d| {
-                p9_core::coords::candidate_pair::heliocentric_separation_arcmin(*d, *d, 0.0, 23.0)
-            })
+            .map(|d| heliocentric_separation_arcmin(*d, *d, 0.0, 23.0))
             .collect();
         let svg = separation_vs_distance_plot(&distances, &seps, 700, 450);
         assert!(svg.contains("<svg"));

--- a/crates/p9-2025-iras-akari/src/thermal_model.rs
+++ b/crates/p9-2025-iras-akari/src/thermal_model.rs
@@ -16,6 +16,7 @@
 //! 1.86 R⊕ at 10 M⊕ — a ~3.2× flux underestimate that pushed the paper's
 //! whole favorable corner below the IRAS detection limit.
 
+use p9_core::analysis::photometry::mass_radius_neptunian;
 use p9_core::analysis::thermal::{planck_bnu, solar_equilibrium_temp, thermal_flux_jy, C_LIGHT};
 
 use crate::survey_model::{AkariFisSurvey, IrasSurvey};
@@ -39,7 +40,7 @@ impl P9ThermalParams {
     /// `p9_core::analysis::photometry` (≈ 3.34 R⊕ at 10 M⊕; see module
     /// docs for sources).
     pub fn radius_m(&self) -> f64 {
-        p9_core::analysis::photometry::mass_radius_neptunian(self.mass_earth) * R_EARTH
+        mass_radius_neptunian(self.mass_earth) * R_EARTH
     }
 
     /// Planck function B_ν(T) in W/m²/Hz/sr at frequency `nu_hz`.

--- a/crates/p9-2025-ps1-holman/src/survey_model.rs
+++ b/crates/p9-2025-ps1-holman/src/survey_model.rs
@@ -13,6 +13,7 @@
 //! Detection probability is a logistic roll-off centered on `m_eff`,
 //! gated by the declination > -30 deg 3-pi footprint.
 
+use p9_core::analysis::surveys::limiting_magnitude;
 use serde::{Deserialize, Serialize};
 
 use crate::published;
@@ -36,7 +37,7 @@ pub struct Ps1StackSurvey {
 impl Default for Ps1StackSurvey {
     fn default() -> Self {
         Self {
-            single_epoch_depth: p9_core::analysis::surveys::limiting_magnitude("PS1 3pi")
+            single_epoch_depth: limiting_magnitude("PS1 3pi")
                 .expect("PS1 3pi in shared survey table"),
             stack_depth_gain: published::SHIFT_STACK_DEPTH_GAIN_MAG,
             dec_limit_deg: published::PS1_DEC_LIMIT_DEG,
@@ -84,12 +85,7 @@ mod tests {
         let s = Ps1StackSurvey::default();
         // PINNED: PS1 3-pi single-epoch r depth == 21.5 from p9-core.
         assert!((s.single_epoch_depth - 21.5).abs() < 1e-12);
-        assert!(
-            (s.single_epoch_depth
-                - p9_core::analysis::surveys::limiting_magnitude("PS1 3pi").unwrap())
-            .abs()
-                < 1e-12
-        );
+        assert!((s.single_epoch_depth - limiting_magnitude("PS1 3pi").unwrap()).abs() < 1e-12);
     }
 
     #[test]

--- a/crates/p9-survey/src/lib.rs
+++ b/crates/p9-survey/src/lib.rs
@@ -23,6 +23,7 @@ pub mod skymap;
 pub mod studies;
 pub mod telescope;
 
+use p9_core::data::ephemeris_constraint::brown_batygin_orbit;
 use schema::{Constraints, SkyGrid, SurveyDataset, TelescopeResult, SCHEMA_VERSION};
 
 /// The fixed RA/Dec grid used for every probability map: full RA, ±60° Dec, 3°
@@ -78,10 +79,7 @@ pub fn run_survey(n_samples: usize, seed: u64) -> SurveyDataset {
         favored_nu_hi_deg: nu_hi,
         // The favored-ν zone belongs to the orbit Fienga et al. actually fit
         // (the Brown & Batygin geometry), so map it through that orbit.
-        favored_arc: ephemeris::favored_arc(
-            &p9_core::data::ephemeris_constraint::brown_batygin_orbit(),
-            64,
-        ),
+        favored_arc: ephemeris::favored_arc(&brown_batygin_orbit(), 64),
     };
 
     SurveyDataset {


### PR DESCRIPTION
De-qualify inline p9_core call sites; import symbols per CLAUDE.md rule.