### PR TITLE
Adopt typed unit accessors in 2016 constraint crates

### DIFF
--- a/crates/p9-2016-cassini-ranging/src/lib.rs
+++ b/crates/p9-2016-cassini-ranging/src/lib.rs
@@ -50,8 +50,15 @@ pub mod perturbation;
 /// the Brown & Batygin reference orbit live in
 /// [`p9_core::data::ephemeris_constraint`].
 pub mod published {
+    use p9_core::units::{au, Length};
+
     /// Approximate P9 heliocentric distance at the preferred true anomaly (AU).
     pub const PREFERRED_HELIO_DISTANCE_AU: f64 = 600.0;
+
+    /// [`PREFERRED_HELIO_DISTANCE_AU`] as a typed [`Length`].
+    pub fn preferred_helio_distance() -> Length {
+        au(PREFERRED_HELIO_DISTANCE_AU)
+    }
 }
 
 pub use perturbation::{

--- a/crates/p9-2016-cassini-ranging/src/perturbation.rs
+++ b/crates/p9-2016-cassini-ranging/src/perturbation.rs
@@ -36,6 +36,7 @@ use p9_core::constants::{AU_KM, GM_SUN, TWO_PI};
 use p9_core::initial_conditions::planets::saturn_j2000;
 use p9_core::integrator::kepler_step::kepler_drift;
 use p9_core::types::P9Params;
+use p9_core::units::{km, radians, Angle, Length};
 
 use p9_core::types::position_at_true_anomaly as p9_position_at_true_anomaly;
 
@@ -332,6 +333,21 @@ impl RangePerturbationCurve {
             .copied()
             .fold(f64::NEG_INFINITY, f64::max)
     }
+
+    /// True anomaly that minimizes the range perturbation, as a typed [`Angle`].
+    pub fn argmin_true_anomaly_typed(&self) -> Angle {
+        radians(self.argmin_true_anomaly())
+    }
+
+    /// Minimum range-perturbation amplitude as a typed [`Length`].
+    pub fn min_amplitude(&self) -> Length {
+        km(self.min_amplitude_km())
+    }
+
+    /// Maximum range-perturbation amplitude as a typed [`Length`].
+    pub fn max_amplitude(&self) -> Length {
+        km(self.max_amplitude_km())
+    }
 }
 
 /// Compute the range-perturbation curve over `n` uniform samples of true
@@ -476,6 +492,28 @@ mod tests {
         // Doubling a roughly doubles distance → tidal ~1/r³ → factor several.
         let ratio = max_close / max_far;
         assert!(ratio > 4.0, "distance falloff too weak: ratio = {ratio:.2}");
+    }
+
+    #[test]
+    fn typed_curve_accessors_match_f64() {
+        use approx::assert_relative_eq;
+        let p = brown_batygin_orbit();
+        let curve = range_perturbation_curve(&p, 64);
+        assert_relative_eq!(
+            (curve.min_amplitude() / km(1.0)).value,
+            curve.min_amplitude_km(),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (curve.max_amplitude() / km(1.0)).value,
+            curve.max_amplitude_km(),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (curve.argmin_true_anomaly_typed() / radians(1.0)).value,
+            curve.argmin_true_anomaly(),
+            max_relative = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2016-commensurabilities/src/clustering.rs
+++ b/crates/p9-2016-commensurabilities/src/clustering.rs
@@ -14,6 +14,7 @@ use rand_distr::{Distribution, Uniform};
 use p9_core::analysis::circular::{circular_mean, mean_resultant_length, rayleigh_p_value};
 use p9_core::constants::{RAD2DEG, TWO_PI};
 use p9_core::data::etno::BROWN_2017_SAMPLE;
+use p9_core::units::{radians, Angle as UnitAngle};
 
 /// Which orbital angle to test for grouping.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -37,6 +38,13 @@ pub struct GroupingResult {
     pub rayleigh_p: f64,
     /// Number of objects.
     pub n: usize,
+}
+
+impl GroupingResult {
+    /// Mean direction of the grouped angle as a typed [`uom`] angle.
+    pub fn mean_direction_typed(&self) -> UnitAngle {
+        radians(self.mean_direction)
+    }
 }
 
 /// Collect one orbital angle (radians) for every object in the vetted sample.
@@ -181,6 +189,18 @@ mod tests {
             p_mc,
             obs.rayleigh_p,
             ratio
+        );
+    }
+
+    /// The typed mean-direction accessor matches its f64 (radian) source.
+    #[test]
+    fn test_mean_direction_typed_matches_f64() {
+        use approx::assert_relative_eq;
+        let g = observed_grouping(Angle::LongitudeOfPerihelion);
+        assert_relative_eq!(
+            (g.mean_direction_typed() / radians(1.0)).value,
+            g.mean_direction,
+            max_relative = 1e-12
         );
     }
 

--- a/crates/p9-2016-commensurabilities/src/commensurability.rs
+++ b/crates/p9-2016-commensurabilities/src/commensurability.rs
@@ -30,6 +30,7 @@ use rand::SeedableRng;
 use rand_distr::{Distribution, Uniform};
 
 use p9_core::data::etno::semi_major_axes;
+use p9_core::units::{julian_year, Time};
 
 /// Highest integer considered on either side of a small-integer period ratio
 /// p/q. de la Fuente Marcos et al. emphasize low-order commensurabilities.
@@ -41,6 +42,12 @@ pub const DEFAULT_MAX_INTEGER: u32 = 9;
 /// argument.
 pub fn orbital_period_years(a_au: f64) -> f64 {
     a_au.powf(1.5)
+}
+
+/// Heliocentric orbital period as a typed [`Time`] from semi-major axis (AU):
+/// the [`orbital_period_years`] value scaled into Julian years.
+pub fn orbital_period(a_au: f64) -> Time {
+    julian_year() * orbital_period_years(a_au)
 }
 
 /// Distance of a period ratio `ratio` (≥ 1) to the nearest small-integer ratio
@@ -356,6 +363,18 @@ mod tests {
         let p2 =
             pairwise_control_exceedance(obs, a.len(), 228.0, 506.0, 5000, 99, DEFAULT_MAX_INTEGER);
         assert_eq!(p1, p2);
+    }
+
+    #[test]
+    fn test_orbital_period_typed_matches_f64() {
+        // The typed period (Julian years) matches the f64 Kepler value.
+        for &a in &[300.0, 500.0, 700.0] {
+            assert_relative_eq!(
+                (orbital_period(a) / julian_year()).value,
+                orbital_period_years(a),
+                max_relative = 1e-12
+            );
+        }
     }
 
     #[test]

--- a/crates/p9-2016-constraints/src/detection_limits.rs
+++ b/crates/p9-2016-constraints/src/detection_limits.rs
@@ -11,6 +11,7 @@ use std::f64::consts::PI;
 use p9_core::analysis::photometry;
 use p9_core::constants::EARTH_RADIUS_KM;
 use p9_core::types::P9Params;
+use p9_core::units::{km, Length};
 
 /// Predict V-band apparent magnitude of Planet Nine at a given true anomaly,
 /// using the shared p9-core photometry (H from diameter and albedo, then the
@@ -28,6 +29,12 @@ pub fn predicted_v_magnitude(p9: &P9Params, true_anomaly: f64, albedo: f64, radi
 /// optimistic).
 pub fn estimate_radius_km(mass_earth: f64) -> f64 {
     photometry::mass_radius_neptunian(mass_earth) * EARTH_RADIUS_KM
+}
+
+/// Planet Nine's physical radius as a typed [`Length`] (the [`estimate_radius_km`]
+/// value, in kilometers).
+pub fn estimate_radius(mass_earth: f64) -> Length {
+    km(estimate_radius_km(mass_earth))
 }
 
 /// Compute the sky position (ecliptic longitude, latitude) of Planet Nine
@@ -128,6 +135,18 @@ mod tests {
             "Perihelion V={:.1} out of expected range",
             v_peri
         );
+    }
+
+    #[test]
+    fn test_estimate_radius_typed_matches_km() {
+        use approx::assert_relative_eq;
+        for &m in &[1.0, 10.0, 20.0] {
+            assert_relative_eq!(
+                (estimate_radius(m) / km(1.0)).value,
+                estimate_radius_km(m),
+                max_relative = 1e-12
+            );
+        }
     }
 
     #[test]

--- a/crates/p9-2016-constraints/src/inclination_survey.rs
+++ b/crates/p9-2016-constraints/src/inclination_survey.rs
@@ -9,6 +9,7 @@
 
 use p9_core::constants::*;
 use p9_core::types::P9Params;
+use p9_core::units::{radians, Angle};
 
 /// Inclination survey grid point.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
@@ -17,6 +18,18 @@ pub struct InclinationGridPoint {
     pub i_p9: f64,
     /// Planet Nine argument of perihelion (radians)
     pub omega_p9: f64,
+}
+
+impl InclinationGridPoint {
+    /// Planet Nine inclination as a typed [`Angle`].
+    pub fn inclination(&self) -> Angle {
+        radians(self.i_p9)
+    }
+
+    /// Planet Nine argument of perihelion as a typed [`Angle`].
+    pub fn argument_of_perihelion(&self) -> Angle {
+        radians(self.omega_p9)
+    }
 }
 
 /// Generate the inclination survey grid.
@@ -156,6 +169,25 @@ mod tests {
         assert!((p9.i - 30.0 * DEG2RAD).abs() < 1e-10);
         assert!((p9.omega - 150.0 * DEG2RAD).abs() < 1e-10);
         assert!((p9.mass_earth - 10.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_grid_point_typed_angles_match_f64() {
+        use approx::assert_relative_eq;
+        let point = InclinationGridPoint {
+            i_p9: 30.0 * DEG2RAD,
+            omega_p9: 150.0 * DEG2RAD,
+        };
+        assert_relative_eq!(
+            (point.inclination() / radians(1.0)).value,
+            point.i_p9,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (point.argument_of_perihelion() / radians(1.0)).value,
+            point.omega_p9,
+            max_relative = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2016-constraints/src/parameter_grid.rs
+++ b/crates/p9-2016-constraints/src/parameter_grid.rs
@@ -17,6 +17,7 @@
 use p9_core::constants::*;
 use p9_core::initial_conditions::scattered_disk_sim::{run_scattered_disk, DiskSimConfig};
 use p9_core::types::P9Params;
+use p9_core::units::{au, earth_masses, Length, Mass};
 use rayon::prelude::*;
 
 use crate::clustering_metric::{evaluate_clustering, observed_etno_r_bar};
@@ -31,6 +32,21 @@ pub struct GridPoint {
 }
 
 impl GridPoint {
+    /// Planet Nine mass as a typed [`Mass`] (from the Earth-mass field).
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+
+    /// Semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
+    }
+
+    /// Perihelion distance as a typed [`Length`].
+    pub fn perihelion_typed(&self) -> Length {
+        au(self.perihelion)
+    }
+
     pub fn to_p9_params(&self) -> P9Params {
         P9Params {
             mass_earth: self.mass_earth,
@@ -291,6 +307,32 @@ mod tests {
         assert!(!evaluate_acceptance(r_obs - 0.2, 0.1, 10));
         // No detached production
         assert!(!evaluate_acceptance(r_obs + 0.05, 0.0, 10));
+    }
+
+    #[test]
+    fn test_grid_point_typed_accessors_match_f64() {
+        use approx::assert_relative_eq;
+        let point = GridPoint {
+            mass_earth: 10.0,
+            a: 700.0,
+            e: 0.6,
+            perihelion: 280.0,
+        };
+        assert_relative_eq!(
+            (point.mass() / earth_masses(1.0)).value,
+            point.mass_earth,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (point.semi_major_axis() / au(1.0)).value,
+            point.a,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (point.perihelion_typed() / au(1.0)).value,
+            point.perihelion,
+            max_relative = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2016-cowan-thermal/src/sed.rs
+++ b/crates/p9-2016-cowan-thermal/src/sed.rs
@@ -32,6 +32,7 @@
 
 use p9_core::analysis::photometry::mass_radius_neptunian;
 use p9_core::analysis::thermal::{planck_bnu, reflected_flux_jy, thermal_flux_jy, C_LIGHT, JY};
+use p9_core::units::{au, earth_masses, meters, Length, Mass};
 
 /// Wien displacement-law constant b for the wavelength of peak B_λ (m·K).
 pub const WIEN_B_M_K: f64 = 2.897_771_955e-3;
@@ -115,6 +116,21 @@ impl P9Sed {
         mass_radius_neptunian(self.mass_earth) * R_EARTH_M
     }
 
+    /// Mass as a typed [`Mass`] (from the Earth-mass field).
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+
+    /// Heliocentric distance as a typed [`Length`].
+    pub fn distance(&self) -> Length {
+        au(self.distance_au)
+    }
+
+    /// Physical radius as a typed [`Length`].
+    pub fn radius(&self) -> Length {
+        meters(self.radius_m())
+    }
+
     /// Planck function B_ν(T) in W/m²/Hz/sr at frequency `nu_hz`.
     pub fn planck_bnu(t: f64, nu_hz: f64) -> f64 {
         planck_bnu(t, nu_hz)
@@ -124,6 +140,11 @@ impl P9Sed {
     /// λ_peak = b / T (metres).
     pub fn wien_peak_wavelength_m(&self) -> f64 {
         WIEN_B_M_K / self.temp_k
+    }
+
+    /// Wavelength of peak spectral radiance as a typed [`Length`].
+    pub fn wien_peak_wavelength(&self) -> Length {
+        meters(self.wien_peak_wavelength_m())
     }
 
     /// Thermal flux density at wavelength `lambda_m` (W/m²/Hz), a blackbody of
@@ -191,6 +212,12 @@ impl P9Sed {
         Some((lo * hi).sqrt())
     }
 
+    /// Crossover wavelength as a typed [`Length`], when one exists (see
+    /// [`crossover_wavelength_m`](Self::crossover_wavelength_m)).
+    pub fn crossover_wavelength(&self) -> Option<Length> {
+        self.crossover_wavelength_m().map(meters)
+    }
+
     /// Detectability margin in a band: flux density (mJy) divided by a
     /// representative point-source sensitivity (mJy). >1 means detectable; a
     /// larger value is "more favorable relative to the limit".
@@ -207,6 +234,39 @@ mod tests {
 
     /// WISE W1 effective wavelength (m).
     const W1_M: f64 = 3.3526e-6;
+
+    #[test]
+    fn typed_accessors_match_f64() {
+        let p = P9Sed::cowan_fiducial();
+        assert_relative_eq!(
+            (p.mass() / earth_masses(1.0)).value,
+            p.mass_earth,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (p.distance() / au(1.0)).value,
+            p.distance_au,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (p.radius() / meters(1.0)).value,
+            p.radius_m(),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (p.wien_peak_wavelength() / meters(1.0)).value,
+            p.wien_peak_wavelength_m(),
+            max_relative = 1e-12
+        );
+        let xover = p
+            .crossover_wavelength()
+            .expect("crossover exists for a cold body");
+        assert_relative_eq!(
+            (xover / meters(1.0)).value,
+            p.crossover_wavelength_m().unwrap(),
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn radius_is_ice_giant_scale() {

--- a/crates/p9-2016-evidence/src/kbo_elements.rs
+++ b/crates/p9-2016-evidence/src/kbo_elements.rs
@@ -12,6 +12,7 @@ use p9_core::forces::ExtraForce;
 use p9_core::initial_conditions::planets::neptune_only_j2000;
 use p9_core::integrator::whm::WhmIntegrator;
 use p9_core::types::{cartesian_to_elements, OrbitalElements, SimConfig};
+use p9_core::units::{days, Time};
 
 /// Assumed 1σ dispersions for clone generation. These are *assumptions*
 /// standing in for the per-object orbit-fit covariances (not transcribed
@@ -63,6 +64,13 @@ pub struct CloneStabilityResult {
     pub seed: u64,
     /// Integration horizon (days).
     pub t_total: f64,
+}
+
+impl CloneStabilityResult {
+    /// Integration horizon as a typed [`Time`] (days).
+    pub fn integration_time(&self) -> Time {
+        days(self.t_total)
+    }
 }
 
 /// Stability screen: a clone counts as stable when its semi-major axis
@@ -325,6 +333,18 @@ mod tests {
             result.p_joint > 5e-6 && result.p_joint < 1e-3,
             "p_joint = {:.2e} (paper ~7e-5)",
             result.p_joint
+        );
+    }
+
+    #[test]
+    fn test_integration_time_typed_matches_f64() {
+        use approx::assert_relative_eq;
+        let kbos = stable_kbos();
+        let result = clone_stability_screen(&kbos[0], 2, 1e5 * YEAR_DAYS, 3000.0, 11);
+        assert_relative_eq!(
+            (result.integration_time() / days(1.0)).value,
+            result.t_total,
+            max_relative = 1e-12
         );
     }
 

--- a/crates/p9-2016-evidence/src/phase_portrait.rs
+++ b/crates/p9-2016-evidence/src/phase_portrait.rs
@@ -16,6 +16,7 @@ use p9_core::analysis::circular::wrap_to_pi;
 use p9_core::constants::*;
 use p9_core::integrator::whm::WhmIntegrator;
 use p9_core::types::*;
+use p9_core::units::{au, days, radians, Angle, Length, Time};
 
 use p9_core::initial_conditions::scattered_disk_sim::j2_jsun_force;
 
@@ -26,6 +27,23 @@ pub struct TrajectoryPoint {
     pub e: f64,
     pub delta_varpi: f64,
     pub a: f64,
+}
+
+impl TrajectoryPoint {
+    /// Sample time as a typed [`Time`] (days).
+    pub fn time(&self) -> Time {
+        days(self.t)
+    }
+
+    /// Apsidal offset Δϖ from Planet Nine as a typed [`Angle`].
+    pub fn delta_varpi_typed(&self) -> Angle {
+        radians(self.delta_varpi)
+    }
+
+    /// Semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
+    }
 }
 
 /// Run an N-body phase-space portrait for a single semi-major axis.
@@ -245,6 +263,28 @@ mod tests {
         let _ = nbody_phase_portrait(250.0, &p9, &mut bodies, 2, 1e5, 300.0, 5e4, 1);
         // bodies restored
         assert!(bodies.is_empty());
+    }
+
+    #[test]
+    fn test_trajectory_point_typed_accessors_match_f64() {
+        use approx::assert_relative_eq;
+        let p = TrajectoryPoint {
+            t: 1.234e6,
+            e: 0.5,
+            delta_varpi: 2.5,
+            a: 300.0,
+        };
+        assert_relative_eq!((p.time() / days(1.0)).value, p.t, max_relative = 1e-12);
+        assert_relative_eq!(
+            (p.delta_varpi_typed() / radians(1.0)).value,
+            p.delta_varpi,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (p.semi_major_axis() / au(1.0)).value,
+            p.a,
+            max_relative = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2016-fortney-thermal/src/lib.rs
+++ b/crates/p9-2016-fortney-thermal/src/lib.rs
@@ -53,6 +53,7 @@ use std::f64::consts::PI;
 use p9_core::analysis::photometry::{mass_radius_neptunian, ALBEDO_NEPTUNE};
 use p9_core::analysis::thermal::{planck_bnu, thermal_flux_jy, C_LIGHT};
 use p9_core::constants::AU_M;
+use p9_core::units::{au, earth_masses, meters, Length, Mass};
 
 pub mod published;
 
@@ -123,6 +124,21 @@ impl P9Thermal {
         mass_radius_neptunian(self.mass_earth) * R_EARTH_M
     }
 
+    /// Mass as a typed [`Mass`] (from the Earth-mass field).
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+
+    /// Heliocentric distance as a typed [`Length`].
+    pub fn distance(&self) -> Length {
+        au(self.distance_au)
+    }
+
+    /// Physical radius as a typed [`Length`].
+    pub fn radius(&self) -> Length {
+        meters(self.radius_m())
+    }
+
     /// Internal luminosity (W) at this mass: the reference value scaled by
     /// `(M / M_ref)^L_INT_MASS_INDEX`.
     pub fn internal_luminosity_w(&self) -> f64 {
@@ -162,6 +178,11 @@ impl P9Thermal {
     /// temperature: λ_peak = b / T.
     pub fn sed_peak_wavelength_m(&self) -> f64 {
         WIEN_B_M_K / self.effective_temp()
+    }
+
+    /// SED peak wavelength as a typed [`Length`].
+    pub fn sed_peak_wavelength(&self) -> Length {
+        meters(self.sed_peak_wavelength_m())
     }
 
     /// Planck function B_ν(T) in W/m²/Hz/sr at frequency `nu_hz`.
@@ -311,6 +332,31 @@ mod tests {
         let l_rad = 4.0 * PI * r * r * SIGMA_SB * p.effective_temp().powi(4);
         let l_tot = p.internal_luminosity_w() + p.absorbed_sunlight_w();
         assert_relative_eq!(l_rad, l_tot, max_relative = 1e-12);
+    }
+
+    #[test]
+    fn typed_accessors_match_f64() {
+        let p = P9Thermal::new(10.0, 500.0);
+        assert_relative_eq!(
+            (p.mass() / earth_masses(1.0)).value,
+            p.mass_earth,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (p.distance() / au(1.0)).value,
+            p.distance_au,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (p.radius() / meters(1.0)).value,
+            p.radius_m(),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (p.sed_peak_wavelength() / meters(1.0)).value,
+            p.sed_peak_wavelength_m(),
+            max_relative = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2016-holman-payne/src/exclusion.rs
+++ b/crates/p9-2016-holman-payne/src/exclusion.rs
@@ -9,6 +9,7 @@
 //! excluded, distant or light ones survive.
 
 use p9_core::types::P9Params;
+use p9_core::units::{au, earth_masses, meters, Length, Mass};
 
 use crate::published::CASSINI_RANGE_PRECISION_M;
 use crate::signal::range_residual_m;
@@ -29,6 +30,12 @@ pub fn peak_range_residual_m(params: &P9Params) -> f64 {
         peak = peak.max(range_residual_m(params, nu));
     }
     peak
+}
+
+/// The strongest range residual P9 can produce anywhere on its orbit, as a
+/// typed [`Length`] — the [`peak_range_residual_m`] value in metres.
+pub fn peak_range_residual(params: &P9Params) -> Length {
+    meters(peak_range_residual_m(params))
 }
 
 /// Verdict for a candidate Planet Nine.
@@ -64,6 +71,12 @@ pub fn max_allowed_mass_earth(template: &P9Params, a_au: f64) -> f64 {
     CASSINI_RANGE_PRECISION_M / peak_per_earth_mass
 }
 
+/// Largest allowed P9 mass at semi-major axis `a_au` as a typed [`Mass`] — the
+/// [`max_allowed_mass_earth`] value in Earth masses.
+pub fn max_allowed_mass(template: &P9Params, a_au: f64) -> Mass {
+    earth_masses(max_allowed_mass_earth(template, a_au))
+}
+
 /// A sampled mass–distance exclusion map over a grid of semi-major axes.
 #[derive(Debug, Clone)]
 pub struct ExclusionMap {
@@ -89,6 +102,19 @@ impl ExclusionMap {
             a_au,
             max_allowed_mass_earth,
         }
+    }
+
+    /// Sampled semi-major axes as typed [`Length`]s.
+    pub fn semi_major_axes(&self) -> Vec<Length> {
+        self.a_au.iter().map(|&a| au(a)).collect()
+    }
+
+    /// The exclusion-boundary masses as typed [`Mass`]es.
+    pub fn max_allowed_masses(&self) -> Vec<Mass> {
+        self.max_allowed_mass_earth
+            .iter()
+            .map(|&m| earth_masses(m))
+            .collect()
     }
 }
 
@@ -150,6 +176,38 @@ mod tests {
         let lo = map.max_allowed_mass_earth.first().copied().unwrap();
         let hi = map.max_allowed_mass_earth.last().copied().unwrap();
         assert!(hi / lo > 10.0, "boundary growth too weak: {}", hi / lo);
+    }
+
+    #[test]
+    fn typed_exclusion_accessors_match_f64() {
+        use approx::assert_relative_eq;
+        let template = brown_batygin_orbit();
+        assert_relative_eq!(
+            (peak_range_residual(&template) / meters(1.0)).value,
+            peak_range_residual_m(&template),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (max_allowed_mass(&template, 500.0) / earth_masses(1.0)).value,
+            max_allowed_mass_earth(&template, 500.0),
+            max_relative = 1e-12
+        );
+        let map = ExclusionMap::build(&template, 300.0, 1500.0, 5);
+        let axes = map.semi_major_axes();
+        let masses = map.max_allowed_masses();
+        for (k, (&a, &m)) in map
+            .a_au
+            .iter()
+            .zip(map.max_allowed_mass_earth.iter())
+            .enumerate()
+        {
+            assert_relative_eq!((axes[k] / au(1.0)).value, a, max_relative = 1e-12);
+            assert_relative_eq!(
+                (masses[k] / earth_masses(1.0)).value,
+                m,
+                max_relative = 1e-12
+            );
+        }
     }
 
     #[test]

--- a/crates/p9-2016-holman-payne/src/signal.rs
+++ b/crates/p9-2016-holman-payne/src/signal.rs
@@ -8,6 +8,7 @@
 //! units Holman & Payne use (metres) and expose the favored-zone selection.
 
 use p9_core::types::P9Params;
+use p9_core::units::{meters, Length};
 
 use p9_2016_cassini_ranging::perturbation::{
     favored_true_anomaly as sibling_favored, range_perturbation_amplitude,
@@ -25,6 +26,13 @@ const M_PER_KM: f64 = 1_000.0;
 /// with P9 heliocentric distance — the two scalings Holman & Payne emphasize.
 pub fn range_residual_m(params: &P9Params, nu: f64) -> f64 {
     range_perturbation_amplitude(params, nu) * M_PER_KM
+}
+
+/// Post-fit Earth–Saturn range-residual amplitude as a typed [`Length`], for P9
+/// at true anomaly `nu` (radians) on the orbit `params` — the [`range_residual_m`]
+/// value in metres.
+pub fn range_residual(params: &P9Params, nu: f64) -> Length {
+    meters(range_residual_m(params, nu))
 }
 
 /// The favored true anomaly (radians) on the near (post-perihelion) arc — the
@@ -84,6 +92,18 @@ mod tests {
         let nu = 30.0_f64.to_radians();
         let km = range_perturbation_amplitude(&p, nu);
         assert!((range_residual_m(&p, nu) - km * 1000.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn typed_range_residual_matches_metres() {
+        use approx::assert_relative_eq;
+        let p = brown_batygin_orbit();
+        let nu = 30.0_f64.to_radians();
+        assert_relative_eq!(
+            (range_residual(&p, nu) / meters(1.0)).value,
+            range_residual_m(&p, nu),
+            max_relative = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2016-holman-payne/src/sky.rs
+++ b/crates/p9-2016-holman-payne/src/sky.rs
@@ -13,6 +13,7 @@ use nalgebra::Vector3;
 use p9_core::constants::DEG2RAD;
 use p9_core::coords::sky::{angular_distance, ecliptic_vec_to_equatorial_deg};
 use p9_core::types::{position_at_true_anomaly, P9Params};
+use p9_core::units::{au, degrees, radians, Angle, Length};
 
 use crate::signal::favored_true_anomaly;
 
@@ -46,6 +47,26 @@ impl SkyPosition {
             distance_au: 1.0,
         };
         angular_distance(&self.unit_vector(), &other.unit_vector()).to_degrees()
+    }
+
+    /// Right ascension as a typed [`Angle`].
+    pub fn right_ascension(&self) -> Angle {
+        degrees(self.ra_deg)
+    }
+
+    /// Declination as a typed [`Angle`].
+    pub fn declination(&self) -> Angle {
+        degrees(self.dec_deg)
+    }
+
+    /// True anomaly of P9 as a typed [`Angle`].
+    pub fn true_anomaly_typed(&self) -> Angle {
+        radians(self.true_anomaly)
+    }
+
+    /// Heliocentric distance as a typed [`Length`].
+    pub fn distance(&self) -> Length {
+        au(self.distance_au)
     }
 }
 
@@ -86,6 +107,33 @@ mod tests {
             (300.0..900.0).contains(&sky.distance_au),
             "favored distance {:.0} AU not in the expected few-hundred-AU zone",
             sky.distance_au
+        );
+    }
+
+    #[test]
+    fn typed_sky_accessors_match_f64() {
+        use approx::assert_relative_eq;
+        let p = brown_batygin_orbit();
+        let sky = favored_sky_position(&p, 720);
+        assert_relative_eq!(
+            (sky.right_ascension() / degrees(1.0)).value,
+            sky.ra_deg,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (sky.declination() / degrees(1.0)).value,
+            sky.dec_deg,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (sky.true_anomaly_typed() / radians(1.0)).value,
+            sky.true_anomaly,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (sky.distance() / au(1.0)).value,
+            sky.distance_au,
+            max_relative = 1e-12
         );
     }
 


### PR DESCRIPTION
Additively adopts the `p9_core::units` (`uom`) typed boundary on the public
surface of the 2016-paper reproduction crates. No existing `f64` fields,
signatures, or test reference values change — every addition is a new typed
accessor/sibling that wraps the existing f64 source, pinned by a new test
using the `(quantity / unit(1.0)).value` round-trip (the same pattern the core
`units` tests use), so no direct `uom` dependency is added.

Per-crate changes:

- **p9-2016-cassini-ranging** — `RangePerturbationCurve::{min_amplitude, max_amplitude}` (Length), `argmin_true_anomaly_typed` (Angle); `published::preferred_helio_distance()` (Length).
- **p9-2016-commensurabilities** — `GroupingResult::mean_direction_typed` (Angle); `orbital_period()` typed sibling of `orbital_period_years` (Time).
- **p9-2016-constraints** — `GridPoint::{mass, semi_major_axis, perihelion_typed}` (Mass/Length); `InclinationGridPoint::{inclination, argument_of_perihelion}` (Angle); `estimate_radius()` sibling of `estimate_radius_km` (Length).
- **p9-2016-cowan-thermal** — `P9Sed::{mass, distance, radius, wien_peak_wavelength, crossover_wavelength}` (Mass/Length). Temperatures and flux densities left as-is (no temperature/flux constructor in the units API).
- **p9-2016-evidence** — `TrajectoryPoint::{time, delta_varpi_typed, semi_major_axis}` (Time/Angle/Length); `CloneStabilityResult::integration_time` (Time). Octupole Hamiltonian / probability / count surfaces left untyped (no matching quantity).
- **p9-2016-fortney-thermal** — `P9Thermal::{mass, distance, radius, sed_peak_wavelength}` (Mass/Length). Temperatures/luminosities/flux left untyped.
- **p9-2016-holman-payne** — `SkyPosition::{right_ascension, declination, true_anomaly_typed, distance}` (Angle/Length); `ExclusionMap::{semi_major_axes, max_allowed_masses}` (Vec<Length>/Vec<Mass>); `peak_range_residual` (Length) and `max_allowed_mass` (Mass) siblings; `signal::range_residual` (Length) sibling.

No crate was skipped wholesale; dimensionless surfaces within them (Rayleigh
p-values, mean resultant lengths, survivor counts/fractions, commensurability
distances, magnitudes, SVG plotting, and `nalgebra::Vector3<f64>` quantities
that cannot carry units) were deliberately left untyped.

`cargo build` and `cargo test` pass for all seven crates; `cargo fmt` clean.