### PR TITLE
Add typed uom accessors to 2017/2018 dynamics crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,6 +1430,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1441,6 +1442,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1451,6 +1453,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1463,6 +1466,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1474,6 +1478,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1486,6 +1491,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1497,6 +1503,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]

--- a/crates/p9-2017-resonance-hopping/Cargo.toml
+++ b/crates/p9-2017-resonance-hopping/Cargo.toml
@@ -10,3 +10,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2017-resonance-hopping/src/chain.rs
+++ b/crates/p9-2017-resonance-hopping/src/chain.rs
@@ -44,6 +44,7 @@
 //! `tno` module and REPRODUCTION_NOTES for the honest scale caveat.
 
 use p9_core::analysis::resonance::resonance_semi_major_axis;
+use p9_core::units::{au, Length};
 
 /// Published / reference constants for Becker, Adams et al. (2017).
 pub mod published {
@@ -94,6 +95,12 @@ impl P9Resonance {
         resonance_semi_major_axis(self.q, self.p, a9_au)
     }
 
+    /// Interior resonance semimajor axis as a typed [`Length`] (see
+    /// [`Self::semi_major_axis`]).
+    pub fn semi_major_axis_typed(&self, a9_au: f64) -> Length {
+        au(self.semi_major_axis(a9_au))
+    }
+
     /// Dimensionless ratio α = a_res / a9 (< 1 for interior resonances).
     pub fn alpha(&self) -> f64 {
         (self.q as f64 / self.p as f64).powf(2.0 / 3.0)
@@ -106,6 +113,12 @@ impl P9Resonance {
         let a_res = self.semi_major_axis(a9_au);
         let strength = resonance_strength(self.alpha(), e);
         a_res * ((16.0 / 3.0) * mu * strength).sqrt()
+    }
+
+    /// Pendulum libration half-width as a typed [`Length`] (see
+    /// [`Self::libration_half_width_au`]).
+    pub fn libration_half_width(&self, a9_au: f64, mu: f64, e: f64) -> Length {
+        au(self.libration_half_width_au(a9_au, mu, e))
     }
 }
 
@@ -179,6 +192,21 @@ impl OverlapLink {
     pub fn overlaps(&self) -> bool {
         self.k >= 1.0
     }
+
+    /// Mean semimajor axis of the pair as a typed [`Length`].
+    pub fn a_mid(&self) -> Length {
+        au(self.a_mid_au)
+    }
+
+    /// Separation between the two resonance centres as a typed [`Length`].
+    pub fn separation(&self) -> Length {
+        au(self.separation_au)
+    }
+
+    /// Sum of the two libration half-widths as a typed [`Length`].
+    pub fn width_sum(&self) -> Length {
+        au(self.width_sum_au)
+    }
 }
 
 /// Build the overlap links for an ordered (increasing-a) chain.
@@ -217,8 +245,44 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use p9_core::analysis::resonance::chirikov_overlap_parameter;
+    use uom::si::length::astronomical_unit;
 
     const A9: f64 = published::A9_AU;
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        let res = P9Resonance::new(5, 4);
+        let mu = mass_ratio(published::M9_EARTH);
+        assert_relative_eq!(
+            res.semi_major_axis_typed(A9).get::<astronomical_unit>(),
+            res.semi_major_axis(A9),
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            res.libration_half_width(A9, mu, 0.9)
+                .get::<astronomical_unit>(),
+            res.libration_half_width_au(A9, mu, 0.9),
+            epsilon = 1e-9
+        );
+
+        let chain = first_order_chain(2, 20);
+        let link = overlap_profile(&chain, A9, mu, published::TNO_E)[0];
+        assert_relative_eq!(
+            link.a_mid().get::<astronomical_unit>(),
+            link.a_mid_au,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            link.separation().get::<astronomical_unit>(),
+            link.separation_au,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            link.width_sum().get::<astronomical_unit>(),
+            link.width_sum_au,
+            epsilon = 1e-9
+        );
+    }
 
     #[test]
     fn resonance_locations_match_kepler_relation() {

--- a/crates/p9-2018-bp519/Cargo.toml
+++ b/crates/p9-2018-bp519/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2018-bp519/src/bp519.rs
+++ b/crates/p9-2018-bp519/src/bp519.rs
@@ -21,6 +21,7 @@
 
 use p9_core::constants::{DEG2RAD, TWO_PI};
 use p9_core::types::OrbitalElements;
+use p9_core::units::{radians, Angle, Length};
 
 /// A labelled orbit solution for 2015 BP519.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -67,6 +68,34 @@ impl Bp519 {
     /// Longitude of perihelion ϖ = ω + Ω in radians, wrapped to [0, 2π).
     pub fn longitude_of_perihelion(&self) -> f64 {
         ((self.omega_deg + self.omega_big_deg) * DEG2RAD).rem_euclid(TWO_PI)
+    }
+
+    /// Semi-major axis as a typed [`Length`] (via the core
+    /// [`OrbitalElements`] accessor).
+    pub fn semi_major_axis(&self) -> Length {
+        self.elements().semi_major_axis()
+    }
+
+    /// Inclination as a typed [`Angle`] (via the core [`OrbitalElements`]
+    /// accessor).
+    pub fn inclination(&self) -> Angle {
+        self.elements().inclination()
+    }
+
+    /// Perihelion distance as a typed [`Length`] (see [`Self::perihelion`]).
+    pub fn perihelion_typed(&self) -> Length {
+        self.elements().perihelion_typed()
+    }
+
+    /// Aphelion distance as a typed [`Length`] (see [`Self::aphelion`]).
+    pub fn aphelion_typed(&self) -> Length {
+        self.elements().aphelion_typed()
+    }
+
+    /// Longitude of perihelion as a typed [`Angle`] (see
+    /// [`Self::longitude_of_perihelion`]).
+    pub fn longitude_of_perihelion_typed(&self) -> Angle {
+        radians(self.longitude_of_perihelion())
     }
 }
 
@@ -135,5 +164,37 @@ mod tests {
         let el = bp.elements();
         assert_relative_eq!(el.i, 54.0 * DEG2RAD, epsilon = 1e-12);
         assert_relative_eq!(el.a, 449.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        use uom::si::angle::radian;
+        use uom::si::length::astronomical_unit;
+        let bp = discovery_2018();
+        assert_relative_eq!(
+            bp.semi_major_axis().get::<astronomical_unit>(),
+            bp.a,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            bp.inclination().get::<radian>(),
+            bp.i_deg * DEG2RAD,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            bp.perihelion_typed().get::<astronomical_unit>(),
+            bp.perihelion(),
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            bp.aphelion_typed().get::<astronomical_unit>(),
+            bp.aphelion(),
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            bp.longitude_of_perihelion_typed().get::<radian>(),
+            bp.longitude_of_perihelion(),
+            epsilon = 1e-9
+        );
     }
 }

--- a/crates/p9-2018-bp519/src/pumping.rs
+++ b/crates/p9-2018-bp519/src/pumping.rs
@@ -44,6 +44,7 @@ use p9_core::analysis::secular::numerical_secular_hamiltonian;
 use p9_core::constants::GM_SUN;
 use p9_core::forces::j2_secular::combined_j2_jsu;
 use p9_core::types::P9Params;
+use p9_core::units::{degrees, Angle};
 
 /// Slowly-varying secular state of a test particle (semi-major axis is a
 /// secular invariant and carried separately).
@@ -276,6 +277,18 @@ impl PumpingHistory {
         *self.inclination_deg.last().unwrap()
     }
 
+    /// Maximum inclination over the history as a typed [`Angle`] (see
+    /// [`Self::max_inclination_deg`]).
+    pub fn max_inclination(&self) -> Angle {
+        degrees(self.max_inclination_deg())
+    }
+
+    /// Inclination at the end of the history as a typed [`Angle`] (see
+    /// [`Self::final_inclination_deg`]).
+    pub fn final_inclination(&self) -> Angle {
+        degrees(self.final_inclination_deg())
+    }
+
     /// Maximum eccentricity reached.
     pub fn max_eccentricity(&self) -> f64 {
         self.eccentricity
@@ -383,6 +396,24 @@ mod tests {
     /// a = 700 AU, e = 0.6, i₉ = 30°.
     fn inclined_p9() -> P9Params {
         P9Params::nominal_2016()
+    }
+
+    #[test]
+    fn typed_inclination_accessors_match_degrees() {
+        use approx::assert_relative_eq;
+        use uom::si::angle::degree;
+        let p = scattered_particle(250.0, 0.85, 40.0);
+        let hist = integrate(p, &inclined_p9(), PumpConfig::fast());
+        assert_relative_eq!(
+            hist.max_inclination().get::<degree>(),
+            hist.max_inclination_deg(),
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            hist.final_inclination().get::<degree>(),
+            hist.final_inclination_deg(),
+            epsilon = 1e-9
+        );
     }
 
     #[test]

--- a/crates/p9-2018-chaotic-dynamics/Cargo.toml
+++ b/crates/p9-2018-chaotic-dynamics/Cargo.toml
@@ -11,3 +11,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2018-chaotic-dynamics/src/chaos.rs
+++ b/crates/p9-2018-chaotic-dynamics/src/chaos.rs
@@ -28,6 +28,7 @@
 
 use p9_core::analysis::resonance::resonance_semi_major_axis;
 use p9_core::constants::EARTH_MASS_SOLAR;
+use p9_core::units::{au, Length};
 
 /// Dimensionless prefactor in the first-order resonance-overlap width
 /// Δa/a_p = C μ^{2/7} (circular limit). Wisdom (1980) / Duncan et al. (1989)
@@ -69,6 +70,12 @@ pub fn j_one_location(j: i64, a9_au: f64) -> f64 {
     resonance_semi_major_axis(1, j as u32, a9_au)
 }
 
+/// Interior j:1 resonance location as a typed [`Length`] (see
+/// [`j_one_location`]).
+pub fn j_one_location_typed(j: i64, a9_au: f64) -> Length {
+    au(j_one_location(j, a9_au))
+}
+
 /// Inward extent (AU) of the overlapped resonance zone from Planet Nine, for a
 /// particle of eccentricity `e`:
 ///
@@ -80,6 +87,12 @@ pub fn j_one_location(j: i64, a9_au: f64) -> f64 {
 pub fn overlap_zone_width(e: f64, a9_au: f64, m9_earth: f64) -> f64 {
     let mu = m9_earth * EARTH_MASS_SOLAR;
     OVERLAP_PREFACTOR * mu.powf(2.0 / 7.0) * e.powf(0.2) * a9_au
+}
+
+/// Inward extent of the overlapped resonance zone as a typed [`Length`] (see
+/// [`overlap_zone_width`]).
+pub fn overlap_zone_width_typed(e: f64, a9_au: f64, m9_earth: f64) -> Length {
+    au(overlap_zone_width(e, a9_au, m9_earth))
 }
 
 /// Resonance-overlap parameter K at (a, e) for a Planet Nine of semi-major
@@ -211,6 +224,21 @@ mod tests {
             let core = chirikov_overlap_parameter(a, q);
             assert_relative_eq!(ours, core, max_relative = 1e-12);
         }
+    }
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        use uom::si::length::astronomical_unit;
+        assert_relative_eq!(
+            j_one_location_typed(5, A9).get::<astronomical_unit>(),
+            j_one_location(5, A9),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            overlap_zone_width_typed(0.7, A9, M9).get::<astronomical_unit>(),
+            overlap_zone_width(0.7, A9, M9),
+            max_relative = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2018-chaotic-dynamics/src/width.rs
+++ b/crates/p9-2018-chaotic-dynamics/src/width.rs
@@ -15,6 +15,7 @@
 use p9_core::analysis::hansen::hansen_coefficient;
 use p9_core::analysis::resonance::resonance_semi_major_axis;
 use p9_core::constants::EARTH_MASS_SOLAR;
+use p9_core::units::{au, Length};
 
 /// Quadrupole-limit pendulum half-width (AU) of the interior j:1 resonance at
 /// particle eccentricity `e`, for a Planet Nine of mass `m9_earth` (Earth
@@ -35,9 +36,20 @@ pub fn libration_half_width(j: i64, e: f64, m9_earth: f64, a9_au: f64, _e9: f64)
     a_j * ((16.0 / 3.0) * m9_solar * alpha.powi(j as i32 + 1) * x).sqrt()
 }
 
+/// Quadrupole-limit pendulum half-width as a typed [`Length`] (see
+/// [`libration_half_width`]).
+pub fn libration_half_width_typed(j: i64, e: f64, m9_earth: f64, a9_au: f64, e9: f64) -> Length {
+    au(libration_half_width(j, e, m9_earth, a9_au, e9))
+}
+
 /// Full libration width (AU) — twice the half-width — of the j:1 resonance.
 pub fn libration_width(j: i64, e: f64, m9_earth: f64, a9_au: f64, e9: f64) -> f64 {
     2.0 * libration_half_width(j, e, m9_earth, a9_au, e9)
+}
+
+/// Full libration width as a typed [`Length`] (see [`libration_width`]).
+pub fn libration_width_typed(j: i64, e: f64, m9_earth: f64, a9_au: f64, e9: f64) -> Length {
+    au(libration_width(j, e, m9_earth, a9_au, e9))
 }
 
 /// Libration half-width as a function of mass over a list of Planet Nine
@@ -82,6 +94,21 @@ mod tests {
         let w2 = libration_half_width(3, 0.7, 40.0, A9, E9);
         // 4x mass -> 2x width.
         assert_relative_eq!(w2 / w1, 2.0, max_relative = 1e-6);
+    }
+
+    #[test]
+    fn typed_width_accessors_match_f64_sources() {
+        use uom::si::length::astronomical_unit;
+        assert_relative_eq!(
+            libration_half_width_typed(3, 0.7, 10.0, A9, E9).get::<astronomical_unit>(),
+            libration_half_width(3, 0.7, 10.0, A9, E9),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            libration_width_typed(3, 0.7, 10.0, A9, E9).get::<astronomical_unit>(),
+            libration_width(3, 0.7, 10.0, A9, E9),
+            max_relative = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2018-kuiper-belt/Cargo.toml
+++ b/crates/p9-2018-kuiper-belt/Cargo.toml
@@ -10,3 +10,6 @@ rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 approx = { workspace = true }
+
+[dev-dependencies]
+uom = "0.38.0"

--- a/crates/p9-2018-kuiper-belt/src/population_analysis.rs
+++ b/crates/p9-2018-kuiper-belt/src/population_analysis.rs
@@ -16,6 +16,7 @@
 use std::f64::consts::PI;
 
 use p9_core::analysis::circular::{circular_mean, mean_resultant_length};
+use p9_core::units::{au, Length};
 
 use crate::simulation::{delta_varpi_series, perihelion_distances, SimulationResult};
 
@@ -46,6 +47,28 @@ pub struct PopulationStats {
     pub mean_q: f64,
     pub min_q: f64,
     pub max_q: f64,
+}
+
+impl PopulationStats {
+    /// Median perihelion distance as a typed [`Length`] (see [`Self::median_q`]).
+    pub fn median_perihelion(&self) -> Length {
+        au(self.median_q)
+    }
+
+    /// Mean perihelion distance as a typed [`Length`] (see [`Self::mean_q`]).
+    pub fn mean_perihelion(&self) -> Length {
+        au(self.mean_q)
+    }
+
+    /// Minimum perihelion distance as a typed [`Length`] (see [`Self::min_q`]).
+    pub fn min_perihelion(&self) -> Length {
+        au(self.min_q)
+    }
+
+    /// Maximum perihelion distance as a typed [`Length`] (see [`Self::max_q`]).
+    pub fn max_perihelion(&self) -> Length {
+        au(self.max_q)
+    }
 }
 
 /// Result of population classification.
@@ -388,5 +411,32 @@ mod tests {
         // Even count
         let stats = compute_stats(&[10.0, 20.0, 30.0, 40.0]);
         assert!((stats.median_q - 25.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn typed_perihelion_accessors_match_f64_sources() {
+        use approx::assert_relative_eq;
+        use uom::si::length::astronomical_unit;
+        let stats = compute_stats(&[10.0, 20.0, 30.0, 40.0]);
+        assert_relative_eq!(
+            stats.median_perihelion().get::<astronomical_unit>(),
+            stats.median_q,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            stats.mean_perihelion().get::<astronomical_unit>(),
+            stats.mean_q,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            stats.min_perihelion().get::<astronomical_unit>(),
+            stats.min_q,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            stats.max_perihelion().get::<astronomical_unit>(),
+            stats.max_q,
+            epsilon = 1e-9
+        );
     }
 }

--- a/crates/p9-2018-kuiper-belt/src/simulation.rs
+++ b/crates/p9-2018-kuiper-belt/src/simulation.rs
@@ -23,6 +23,7 @@ use p9_core::initial_conditions::planets;
 use p9_core::initial_conditions::scattered_disk::{generate_scattered_disk, ScatteredDiskConfig};
 use p9_core::integrator::hybrid::hybrid_step;
 use p9_core::types::*;
+use p9_core::units::{days, Time};
 
 /// Configuration for the Kuiper Belt generation simulation.
 #[derive(Debug, Clone)]
@@ -118,6 +119,13 @@ pub struct KbSnapshot {
     pub elements: Vec<Option<OrbitalElements>>,
     pub active_count: usize,
     pub total_count: usize,
+}
+
+impl KbSnapshot {
+    /// Snapshot epoch as a typed [`Time`] (see [`Self::t`], in days).
+    pub fn time(&self) -> Time {
+        days(self.t)
+    }
 }
 
 /// Result of the full simulation.
@@ -383,6 +391,18 @@ mod tests {
                 assert!((-PI..=PI).contains(&dv));
             }
         }
+    }
+
+    #[test]
+    fn typed_snapshot_time_matches_days() {
+        use uom::si::time::day;
+        let snapshot = KbSnapshot {
+            t: 1234.5,
+            elements: vec![],
+            active_count: 0,
+            total_count: 0,
+        };
+        assert!((snapshot.time().get::<day>() - snapshot.t).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/p9-2018-low-perihelion/Cargo.toml
+++ b/crates/p9-2018-low-perihelion/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2018-low-perihelion/src/confinement.rs
+++ b/crates/p9-2018-low-perihelion/src/confinement.rs
@@ -43,6 +43,7 @@
 
 use p9_core::analysis::secular::numerical_secular_hamiltonian;
 use p9_core::constants::{EARTH_MASS_SOLAR, GM_SUN};
+use p9_core::units::{au, radians, Angle, Length};
 use std::f64::consts::PI;
 
 /// Quadrature nodes per anomaly for the Gauss-ring average (n² evaluations).
@@ -101,6 +102,17 @@ impl Confinement {
     /// island exists AND a real apsidal well is present.
     pub fn is_confined(&self) -> bool {
         self.libration_half_width < PI - 1e-3 && self.well_depth > 1e-6
+    }
+
+    /// Planet Nine perihelion q9 as a typed [`Length`] (see [`Self::q9_au`]).
+    pub fn q9(&self) -> Length {
+        au(self.q9_au)
+    }
+
+    /// Δϖ libration-island half-width as a typed [`Angle`] (see
+    /// [`Self::libration_half_width`]).
+    pub fn libration_half_width_angle(&self) -> Angle {
+        radians(self.libration_half_width)
     }
 }
 
@@ -264,6 +276,19 @@ mod tests {
         assert!(c.torque_amplitude > 0.0);
         assert!(c.well_depth > 0.0);
         assert_relative_eq!(c.q9_au, 280.0, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        use uom::si::angle::radian;
+        use uom::si::length::astronomical_unit;
+        let c = analyze(TEST_ETNO_A_AU, BB_A9_AU, BB_E9, P9_MASS_EARTH);
+        assert_relative_eq!(c.q9().get::<astronomical_unit>(), c.q9_au, epsilon = 1e-9);
+        assert_relative_eq!(
+            c.libration_half_width_angle().get::<radian>(),
+            c.libration_half_width,
+            epsilon = 1e-9
+        );
     }
 
     #[test]

--- a/crates/p9-2018-low-perihelion/src/sweep.rs
+++ b/crates/p9-2018-low-perihelion/src/sweep.rs
@@ -10,6 +10,7 @@
 
 use crate::confinement::{analyze, Confinement};
 use crate::reference::{E9_SWEEP_HI, E9_SWEEP_LO};
+use p9_core::units::{au, Length};
 
 /// One row of the q9 sweep.
 #[derive(Debug, Clone, Copy)]
@@ -17,6 +18,13 @@ pub struct SweepRow {
     pub e9: f64,
     pub q9_au: f64,
     pub confinement: Confinement,
+}
+
+impl SweepRow {
+    /// Planet Nine perihelion q9 as a typed [`Length`] (see [`Self::q9_au`]).
+    pub fn q9(&self) -> Length {
+        au(self.q9_au)
+    }
 }
 
 /// Sweep e9 ∈ [E9_SWEEP_LO, E9_SWEEP_HI] at fixed `a9` (so q9 = a9(1−e9)
@@ -54,6 +62,15 @@ mod tests {
 
     fn run() -> Vec<SweepRow> {
         sweep_q9(TEST_ETNO_A_AU, BB_A9_AU, P9_MASS_EARTH, 7)
+    }
+
+    #[test]
+    fn typed_q9_matches_f64_source() {
+        use uom::si::length::astronomical_unit;
+        let rows = run();
+        for r in &rows {
+            assert!((r.q9().get::<astronomical_unit>() - r.q9_au).abs() < 1e-9);
+        }
     }
 
     #[test]

--- a/crates/p9-2018-resonance/Cargo.toml
+++ b/crates/p9-2018-resonance/Cargo.toml
@@ -10,3 +10,6 @@ rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 approx = { workspace = true }
+
+[dev-dependencies]
+uom = "0.38.0"

--- a/crates/p9-2018-resonance/src/probability_analysis.rs
+++ b/crates/p9-2018-resonance/src/probability_analysis.rs
@@ -15,6 +15,7 @@
 //! every implied-a₉ peak by tens of AU).
 
 use crate::resonance_catalog::{extended_catalog, farey_f5, Resonance};
+use p9_core::units::{au, Length};
 
 /// Names of the 6 clustered ETNOs of Batygin & Brown (2016) — the sample
 /// Millholland & Laughlin (2017) and Bailey+ (2018) analyze ("all 6 KBOs").
@@ -68,6 +69,11 @@ pub fn p_all_simple(p_simple: f64, n_kbos: usize) -> f64 {
 ///   a₉ = a_kbo / (q/p)^(2/3) = a_kbo * (p/q)^(2/3)
 pub fn implied_a9(a_kbo: f64, res: &Resonance) -> f64 {
     a_kbo * (res.p as f64 / res.q as f64).powf(2.0 / 3.0)
+}
+
+/// Implied a₉ as a typed [`Length`] (see [`implied_a9`]).
+pub fn implied_a9_typed(a_kbo: f64, res: &Resonance) -> Length {
+    au(implied_a9(a_kbo, res))
 }
 
 /// Explicit, honest prior on a₉ and the kernel model for the
@@ -253,6 +259,20 @@ pub struct DistributionComparison {
     pub ext_distribution: A9Distribution,
 }
 
+impl DistributionComparison {
+    /// Peak a₉ of the F5 distribution as a typed [`Length`] (see
+    /// [`Self::f5_peak_a9`]).
+    pub fn f5_peak(&self) -> Length {
+        au(self.f5_peak_a9)
+    }
+
+    /// Peak a₉ of the extended distribution as a typed [`Length`] (see
+    /// [`Self::ext_peak_a9`]).
+    pub fn ext_peak(&self) -> Length {
+        au(self.ext_peak_a9)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -263,6 +283,20 @@ mod tests {
         // a₉ = 378 * (2/1)^(2/3) = 378 * 1.587 ≈ 600
         let a9 = implied_a9(378.0, &Resonance::new(2, 1));
         assert!((a9 - 600.0).abs() < 5.0, "Implied a₉ = {:.1}", a9);
+    }
+
+    #[test]
+    fn typed_length_accessors_match_f64_sources() {
+        use uom::si::length::astronomical_unit;
+        let res = Resonance::new(2, 1);
+        assert!(
+            (implied_a9_typed(378.0, &res).get::<astronomical_unit>() - implied_a9(378.0, &res))
+                .abs()
+                < 1e-9
+        );
+        let cmp = compare_distributions(&observed_kbo_axes());
+        assert!((cmp.f5_peak().get::<astronomical_unit>() - cmp.f5_peak_a9).abs() < 1e-9);
+        assert!((cmp.ext_peak().get::<astronomical_unit>() - cmp.ext_peak_a9).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/p9-2018-resonance/src/resonance_catalog.rs
+++ b/crates/p9-2018-resonance/src/resonance_catalog.rs
@@ -19,6 +19,7 @@
 use p9_core::analysis::resonance as core_resonance;
 use p9_core::constants::TWO_PI;
 use p9_core::types::OrbitalElements;
+use p9_core::units::{au, Length};
 
 /// A mean-motion resonance specification.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
@@ -43,6 +44,12 @@ impl Resonance {
     /// a_res = a_p9 * (q/p)^(2/3)
     pub fn semimajor_axis(&self, a_p9: f64) -> f64 {
         a_p9 * self.period_ratio().powf(2.0 / 3.0)
+    }
+
+    /// Resonance semi-major axis as a typed [`Length`] (see
+    /// [`Self::semimajor_axis`]).
+    pub fn semimajor_axis_typed(&self, a_p9: f64) -> Length {
+        au(self.semimajor_axis(a_p9))
     }
 
     /// Whether this is an N/1 period ratio (integer period ratio, p=1).
@@ -244,6 +251,18 @@ mod tests {
         let a = res.semimajor_axis(700.0);
         // 2:1 → a = 700 * (1/2)^(2/3) ≈ 441
         assert!((a - 441.0).abs() < 1.0, "2:1 at {:.1} AU", a);
+    }
+
+    #[test]
+    fn typed_semimajor_axis_matches_f64_source() {
+        use uom::si::length::astronomical_unit;
+        let res = Resonance::new(2, 1);
+        assert!(
+            (res.semimajor_axis_typed(700.0).get::<astronomical_unit>()
+                - res.semimajor_axis(700.0))
+            .abs()
+                < 1e-9
+        );
     }
 
     #[test]

--- a/crates/p9-2018-resonance/src/simulation.rs
+++ b/crates/p9-2018-resonance/src/simulation.rs
@@ -24,6 +24,7 @@ use p9_core::forces::ExtraForce;
 use p9_core::initial_conditions::scattered_disk::{generate_scattered_disk, ScatteredDiskConfig};
 use p9_core::integrator::whm::WhmIntegrator;
 use p9_core::types::*;
+use p9_core::units::{au, radians, Angle, Length};
 
 use crate::resonance_catalog::{
     extended_catalog, is_librating, resonant_angle_from_angles, Resonance,
@@ -109,6 +110,23 @@ pub struct AngleSample {
     pub varpi: f64,
     /// Osculating semi-major axis (AU)
     pub a: f64,
+}
+
+impl AngleSample {
+    /// Mean longitude λ as a typed [`Angle`] (see [`Self::lambda`]).
+    pub fn mean_longitude(&self) -> Angle {
+        radians(self.lambda)
+    }
+
+    /// Longitude of perihelion ϖ as a typed [`Angle`] (see [`Self::varpi`]).
+    pub fn longitude_of_perihelion(&self) -> Angle {
+        radians(self.varpi)
+    }
+
+    /// Osculating semi-major axis as a typed [`Length`] (see [`Self::a`]).
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
+    }
 }
 
 /// Result of one planar run: final elements plus the recorded angle series
@@ -391,6 +409,20 @@ pub struct ResonanceTypeStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn typed_angle_sample_accessors_match_f64() {
+        use uom::si::angle::radian;
+        use uom::si::length::astronomical_unit;
+        let s = AngleSample {
+            lambda: 1.23,
+            varpi: 2.34,
+            a: 345.6,
+        };
+        assert!((s.mean_longitude().get::<radian>() - s.lambda).abs() < 1e-9);
+        assert!((s.longitude_of_perihelion().get::<radian>() - s.varpi).abs() < 1e-9);
+        assert!((s.semi_major_axis().get::<astronomical_unit>() - s.a).abs() < 1e-9);
+    }
 
     #[test]
     fn test_config_for_eccentricity() {

--- a/crates/p9-2018-secular-dynamics/Cargo.toml
+++ b/crates/p9-2018-secular-dynamics/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2018-secular-dynamics/src/secular_model.rs
+++ b/crates/p9-2018-secular-dynamics/src/secular_model.rs
@@ -44,6 +44,7 @@ use p9_core::analysis::secular::numerical_secular_hamiltonian;
 use p9_core::constants::{EARTH_MASS_SOLAR, GM_SUN};
 use p9_core::forces::j2_secular::combined_j2_jsu;
 use p9_core::types::P9Params;
+use p9_core::units::{au, days, radians, AngularVelocity, Length};
 use std::f64::consts::PI;
 
 /// Nominal Planet Nine for the Li et al. (2018) coplanar study: 10 M⊕,
@@ -127,6 +128,12 @@ pub fn free_precession_rate(a: f64, e: f64) -> f64 {
     // dϖ/dt = +(√(1−e²)/(n a² e)) · ∂R/∂e with the disturbing function R = −H,
     // so the giants' apsidal precession comes out prograde (> 0).
     -(1.0 - e * e).sqrt() / (n * a * a * e) * dh
+}
+
+/// Free (giants-only) apsidal precession rate as a typed [`AngularVelocity`]
+/// (see [`free_precession_rate`], in rad/day).
+pub fn free_precession_rate_typed(a: f64, e: f64) -> AngularVelocity {
+    (radians(free_precession_rate(a, e)) / days(1.0)).into()
 }
 
 /// The linear secular coefficients `(B, A)` of the eccentricity-vector
@@ -256,6 +263,12 @@ pub fn critical_semimajor_axis(p9: &P9Params, a_lo: f64, a_hi: f64) -> Option<f6
     Some(0.5 * (lo + hi))
 }
 
+/// Critical semi-major axis as a typed [`Length`] (see
+/// [`critical_semimajor_axis`]).
+pub fn critical_semimajor_axis_typed(p9: &P9Params, a_lo: f64, a_hi: f64) -> Option<Length> {
+    critical_semimajor_axis(p9, a_lo, a_hi).map(au)
+}
+
 /// Analytic-vs-numerical cross-check helper: the secular apsidal precession
 /// rate from the giants' J2 term computed by finite difference of the p9-core
 /// J2 energy (`free_precession_rate`) against the closed-form
@@ -276,6 +289,35 @@ pub fn precession_cross_check(a: f64, e: f64) -> (f64, f64) {
 mod tests {
     use super::*;
     use p9_core::analysis::secular::coplanar_quadrupole;
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        use approx::assert_relative_eq;
+        use uom::si::angular_velocity::radian_per_second;
+        use uom::si::length::astronomical_unit;
+        use uom::si::time::second;
+
+        // The typed rate stores rad/s; convert back to rad/day to compare with
+        // the f64 source (which is in rad/day).
+        let seconds_per_day = days(1.0).get::<second>();
+        let rate = free_precession_rate(250.0, 0.2);
+        let typed = free_precession_rate_typed(250.0, 0.2);
+        assert_relative_eq!(
+            typed.get::<radian_per_second>() * seconds_per_day,
+            rate,
+            max_relative = 1e-9
+        );
+
+        let p9 = nominal_p9();
+        if let Some(a_crit) = critical_semimajor_axis(&p9, 50.0, 400.0) {
+            let typed_a = critical_semimajor_axis_typed(&p9, 50.0, 400.0).unwrap();
+            assert_relative_eq!(
+                typed_a.get::<astronomical_unit>(),
+                a_crit,
+                max_relative = 1e-9
+            );
+        }
+    }
 
     /// The giants' J2 secular precession computed by finite-differencing the
     /// p9-core J2 energy must match the classical closed form (3/2) n J2 (R/a)²


### PR DESCRIPTION
Adopts the `p9_core::units` typed (uom) boundary additively across seven
reproduction crates. No existing `f64` field/signature/test value changed;
every crate adds dimension-checked accessor methods/sibling functions and
tests pinning each against its `f64` source. `uom` was added as a dev-dependency
to each crate for the round-trip tests.

## Per-crate changes
- **p9-2017-resonance-hopping** — `P9Resonance::{semi_major_axis_typed, libration_half_width}` (Length); `OverlapLink::{a_mid, separation, width_sum}` (Length).
- **p9-2018-bp519** — `Bp519::{semi_major_axis, inclination, perihelion_typed, aphelion_typed, longitude_of_perihelion_typed}` (Length/Angle, via core `OrbitalElements` accessors); `PumpingHistory::{max_inclination, final_inclination}` (Angle). `clustering` skipped (circular statistics: concentrations are dimensionless, offsets are derived statistics).
- **p9-2018-chaotic-dynamics** — `j_one_location_typed`, `overlap_zone_width_typed` (Length); `width::{libration_half_width_typed, libration_width_typed}` (Length).
- **p9-2018-kuiper-belt** — `PopulationStats::{median,mean,min,max}_perihelion` (Length); `KbSnapshot::time` (Time). `population_analysis` classification (alignment/counts/fractions) is dimensionless and untouched.
- **p9-2018-low-perihelion** — `Confinement::{q9, libration_half_width_angle}` (Length/Angle); `SweepRow::q9` (Length). `torque_amplitude` left as f64 (AU²/day² has no named uom type).
- **p9-2018-resonance** — `Resonance::semimajor_axis_typed` (Length); `AngleSample::{mean_longitude, longitude_of_perihelion, semi_major_axis}` (Angle/Length); `implied_a9_typed` (Length); `DistributionComparison::{f5_peak, ext_peak}` (Length). Probability/commensurability scans are dimensionless and untouched.
- **p9-2018-secular-dynamics** — `free_precession_rate_typed` (AngularVelocity); `critical_semimajor_axis_typed` (Length). Energies (AU²/day²) and the dimensionless forced-eccentricity left as f64.

## Gate
`cargo build` and `cargo test` pass for all seven crates; `cargo fmt` clean.