### PR TITLE
Add typed units accessors to 2016-2017 crate boundaries

### DIFF
--- a/crates/p9-2016-resonance-prediction/src/prediction.rs
+++ b/crates/p9-2016-resonance-prediction/src/prediction.rs
@@ -14,6 +14,7 @@
 //! low-order ratios.
 
 use p9_core::data::etno::{Etno, BROWN_2017_SAMPLE};
+use p9_core::units::{au, julian_year, Length, Time};
 
 /// Malhotra, Volk & Wang (2016) best-fit Planet Nine semi-major axis (AU).
 pub const MALHOTRA_2016_A9_AU: f64 = 665.0;
@@ -111,6 +112,19 @@ pub struct A9Score {
     pub residual: f64,
     /// Number of ETNOs that were interior to a9 (and so contributed).
     pub n_constraints: usize,
+}
+
+impl A9Score {
+    /// Candidate Planet Nine semi-major axis as a dimension-checked [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a9_au)
+    }
+
+    /// Candidate Planet Nine orbital period as a dimension-checked [`Time`]
+    /// (the stored value is in Julian years).
+    pub fn period(&self) -> Time {
+        self.period_yr * julian_year()
+    }
 }
 
 /// Score a single candidate a9 against a set of ETNO semi-major axes: the mean
@@ -306,6 +320,21 @@ mod tests {
         );
         // Every ETNO in the distant set constrained the fit.
         assert_eq!(best.n_constraints, distant_set().len());
+    }
+
+    #[test]
+    fn typed_a9_score_accessors_match_f64() {
+        let score = score_a9(665.0, &distant_set(), DEFAULT_P_MAX, DEFAULT_Q_MAX, false);
+        assert_relative_eq!(
+            (score.semi_major_axis() / au(1.0)).value,
+            score.a9_au,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            (score.period() / julian_year()).value,
+            score.period_yr,
+            epsilon = 1e-6
+        );
     }
 
     #[test]

--- a/crates/p9-2016-secular-resonance/src/hamiltonian.rs
+++ b/crates/p9-2016-secular-resonance/src/hamiltonian.rs
@@ -29,6 +29,7 @@
 use p9_core::analysis::secular::numerical_secular_hamiltonian;
 use p9_core::constants::{GM_SUN, TWO_PI};
 use p9_core::types::P9Params;
+use p9_core::units::{au, gm_from_au3_day2, GravitationalParameter, Length};
 
 /// A coplanar secular model: a fixed test-particle semi-major axis under a
 /// fixed (eccentric) Planet Nine. The perturber defines the reference frame,
@@ -67,6 +68,22 @@ impl SecularModel {
     pub fn with_gm_p(mut self, gm_p: f64) -> Self {
         self.gm_p = gm_p;
         self
+    }
+
+    /// Test-particle semi-major axis as a dimension-checked [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
+    }
+
+    /// Planet Nine semi-major axis as a dimension-checked [`Length`].
+    pub fn perturber_semi_major_axis(&self) -> Length {
+        au(self.a_p)
+    }
+
+    /// Planet Nine gravitational parameter as a dimension-checked
+    /// [`GravitationalParameter`] (the stored value is in AU³/day²).
+    pub fn gm_p_typed(&self) -> GravitationalParameter {
+        gm_from_au3_day2(self.gm_p)
     }
 
     /// The conserved secular Hamiltonian `H(e, Δϖ)` (AU²/day², up to the
@@ -152,6 +169,26 @@ mod tests {
     use super::*;
     use crate::published;
     use approx::assert_relative_eq;
+
+    #[test]
+    fn typed_secular_model_accessors_match_f64() {
+        let m = SecularModel::new(250.0, &published::nominal_p9());
+        assert_relative_eq!(
+            (m.semi_major_axis() / au(1.0)).value,
+            m.a,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (m.perturber_semi_major_axis() / au(1.0)).value,
+            m.a_p,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (m.gm_p_typed() / gm_from_au3_day2(1.0)).value,
+            m.gm_p,
+            max_relative = 1e-9
+        );
+    }
 
     #[test]
     fn action_is_monotone_and_invertible() {

--- a/crates/p9-2016-secular-resonance/src/libration.rs
+++ b/crates/p9-2016-secular-resonance/src/libration.rs
@@ -15,6 +15,7 @@
 //! the stable apse librates; one launched far off-resonance circulates.
 
 use crate::portrait::ResonantHamiltonian;
+use p9_core::units::{radians, Angle};
 use std::f64::consts::PI;
 
 /// Outcome of following a resonant trajectory.
@@ -52,6 +53,16 @@ impl Trajectory {
     pub fn amplitude(&self) -> f64 {
         let (lo, hi) = self.bounds();
         0.5 * (hi - lo)
+    }
+
+    /// Libration center as a dimension-checked [`Angle`].
+    pub fn center_typed(&self) -> Angle {
+        radians(self.center())
+    }
+
+    /// Libration amplitude as a dimension-checked [`Angle`].
+    pub fn amplitude_typed(&self) -> Angle {
+        radians(self.amplitude())
     }
 
     fn bounds(&self) -> (f64, f64) {
@@ -155,6 +166,7 @@ mod tests {
     use crate::hamiltonian::SecularModel;
     use crate::portrait::{libration_island, ResonantHamiltonian};
     use crate::published;
+    use approx::assert_relative_eq;
 
     // A representative distant-ETNO semi-major axis with a robust, well-isolated
     // resonance (2015 RX245 sits at a ≈ 430 AU; 2007 TG422 at ≈ 500 AU).
@@ -180,6 +192,17 @@ mod tests {
             island.e_center,
             dt,
             steps,
+        );
+        // Typed angle accessors mirror the f64 center/amplitude.
+        assert_relative_eq!(
+            (lib.center_typed() / radians(1.0)).value,
+            lib.center(),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (lib.amplitude_typed() / radians(1.0)).value,
+            lib.amplitude(),
+            max_relative = 1e-12
         );
         assert_eq!(
             lib.kind,

--- a/crates/p9-2016-secular-resonance/src/portrait.rs
+++ b/crates/p9-2016-secular-resonance/src/portrait.rs
@@ -36,6 +36,7 @@
 
 use crate::hamiltonian::SecularModel;
 use p9_core::constants::GM_SUN;
+use p9_core::units::{days, radians, Angle, AngularVelocity, Time};
 use std::f64::consts::PI;
 
 /// The 1-DOF resonant pendulum built from the secular Hamiltonian's apsidal
@@ -93,6 +94,24 @@ pub struct Island {
     pub suggested_dt: f64,
     /// Suggested step count (covers several libration periods).
     pub suggested_steps: usize,
+}
+
+impl Island {
+    /// Stable libration angle as a dimension-checked [`Angle`].
+    pub fn center_dvarpi_typed(&self) -> Angle {
+        radians(self.center_dvarpi)
+    }
+
+    /// Small-oscillation libration frequency as a dimension-checked
+    /// [`AngularVelocity`] (the stored value is in rad/day).
+    pub fn omega_lib_typed(&self) -> AngularVelocity {
+        (radians(self.omega_lib) / days(1.0)).into()
+    }
+
+    /// Suggested integration timestep as a dimension-checked [`Time`].
+    pub fn suggested_dt_typed(&self) -> Time {
+        days(self.suggested_dt)
+    }
 }
 
 impl ResonantHamiltonian {
@@ -159,6 +178,12 @@ impl ResonantHamiltonian {
     pub fn with_external_rate(mut self, g_p: f64) -> Self {
         self.g_p = g_p;
         self
+    }
+
+    /// Planet Nine apsidal precession rate `g₉` as a dimension-checked
+    /// [`AngularVelocity`] (the stored value is in rad/day).
+    pub fn g_p_typed(&self) -> AngularVelocity {
+        (radians(self.g_p) / days(1.0)).into()
     }
 
     /// Span [min, max] of the free precession rate over the eccentricity grid.
@@ -316,7 +341,37 @@ pub fn libration_island(model: &SecularModel) -> Option<Island> {
 mod tests {
     use super::*;
     use crate::published;
+    use approx::assert_relative_eq;
     use p9_core::types::P9Params;
+
+    #[test]
+    fn typed_island_and_rate_accessors_match_f64() {
+        let p9 = published::nominal_p9();
+        let m = SecularModel::new(published::REPRESENTATIVE_ETNO_A_AU, &p9);
+        let island = libration_island(&m).expect("nominal P9 should have an island");
+        assert_relative_eq!(
+            (island.center_dvarpi_typed() / radians(1.0)).value,
+            island.center_dvarpi,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (island.omega_lib_typed() * days(1.0) / radians(1.0)).value,
+            island.omega_lib,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (island.suggested_dt_typed() / days(1.0)).value,
+            island.suggested_dt,
+            max_relative = 1e-12
+        );
+
+        let rh = ResonantHamiltonian::new(m, island.e_center).with_external_rate(island.omega_lib);
+        assert_relative_eq!(
+            (rh.g_p_typed() * days(1.0) / radians(1.0)).value,
+            rh.g_p,
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn island_exists_for_nominal_p9_and_is_anti_aligned() {

--- a/crates/p9-2016-sheppard-etnos/src/clustering.rs
+++ b/crates/p9-2016-sheppard-etnos/src/clustering.rs
@@ -13,6 +13,7 @@ use p9_core::analysis::circular::{
 };
 use p9_core::constants::{DEG2RAD, RAD2DEG};
 use p9_core::data::etno::{Etno, BROWN_2017_SAMPLE};
+use p9_core::units::{degrees, Angle};
 
 use crate::discoveries::{clustering_subset, SHEPPARD_2016_DISCOVERIES};
 
@@ -29,6 +30,19 @@ pub struct ClusterStats {
     pub std_deg: f64,
     /// Rayleigh test p-value (vs uniformity, small-n corrected).
     pub rayleigh_p: f64,
+}
+
+impl ClusterStats {
+    /// Circular mean as a dimension-checked [`Angle`]. `None` when the
+    /// resultant vanishes (mirrors [`ClusterStats::mean_deg`]).
+    pub fn mean(&self) -> Option<Angle> {
+        self.mean_deg.map(degrees)
+    }
+
+    /// Circular standard deviation as a dimension-checked [`Angle`].
+    pub fn std(&self) -> Angle {
+        degrees(self.std_deg)
+    }
 }
 
 /// Compute the circular summary of a set of angles given in radians.
@@ -139,6 +153,21 @@ mod tests {
         }
         // The outer Oort cloud body is excluded even though its q > 35 AU.
         assert!(!names.contains(&OUTER_OORT_NAME));
+    }
+
+    #[test]
+    fn typed_cluster_stats_accessors_match_f64() {
+        let stats = headline().omega_combined;
+        assert_relative_eq!(
+            (stats.std() / degrees(1.0)).value,
+            stats.std_deg,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (stats.mean().unwrap() / degrees(1.0)).value,
+            stats.mean_deg.unwrap(),
+            max_relative = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2016-wise-coadd/src/band.rs
+++ b/crates/p9-2016-wise-coadd/src/band.rs
@@ -21,6 +21,7 @@ use p9_core::analysis::thermal::{
     flux_to_magnitude, reflected_flux_jy as p9_core_reflected_flux,
     thermal_flux_jy as p9_core_thermal_flux, C_LIGHT,
 };
+use p9_core::units::{meters, Length};
 
 /// A WISE photometric band: effective wavelength and Vega zero-point flux
 /// density (Wright et al. 2010, Table 1).
@@ -32,6 +33,13 @@ pub struct WiseBand {
     pub wavelength_m: f64,
     /// Vega zero-point flux density in Jansky (0.0 mag source).
     pub zero_point_jy: f64,
+}
+
+impl WiseBand {
+    /// Effective wavelength as a dimension-checked [`Length`].
+    pub fn wavelength(&self) -> Length {
+        meters(self.wavelength_m)
+    }
 }
 
 /// WISE W1 (3.3526 µm, F_ν0 = 309.540 Jy; Wright et al. 2010, Table 1).
@@ -107,6 +115,17 @@ mod tests {
     fn brighter_with_mass_and_fainter_with_distance_in_w2() {
         assert!(band_magnitude(15.0, 500.0, W2) < band_magnitude(5.0, 500.0, W2));
         assert!(band_magnitude(10.0, 800.0, W2) > band_magnitude(10.0, 400.0, W2));
+    }
+
+    #[test]
+    fn typed_wavelength_matches_f64() {
+        for band in [W1, W2] {
+            assert_relative_eq!(
+                (band.wavelength() / meters(1.0)).value,
+                band.wavelength_m,
+                max_relative = 1e-12
+            );
+        }
     }
 
     #[test]

--- a/crates/p9-2016-wise-coadd/src/exclusion.rs
+++ b/crates/p9-2016-wise-coadd/src/exclusion.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 use p9_2018_wise_search::sky::galactic_latitude_deg;
 use p9_2018_wise_search::survey_model::WiseSurvey;
 use p9_core::types::OrbitalElements;
+use p9_core::units::{au, earth_masses, Length, Mass};
 
 use crate::band::{band_magnitude, WiseBand};
 use crate::coadd::{coadd_depth, single_frame_depth};
@@ -29,6 +30,18 @@ pub struct ReferenceP9 {
     pub elements: OrbitalElements,
     pub mass_earth: f64,
     pub distance_au: f64,
+}
+
+impl ReferenceP9 {
+    /// Planet Nine mass as a dimension-checked [`Mass`].
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+
+    /// Current heliocentric distance as a dimension-checked [`Length`].
+    pub fn distance(&self) -> Length {
+        au(self.distance_au)
+    }
 }
 
 /// Result of the coadd exclusion analysis.
@@ -99,6 +112,7 @@ pub fn compute_exclusion(
 mod tests {
     use super::*;
     use crate::band::{W1, W2};
+    use approx::assert_relative_eq;
     use p9_core::constants::DEG2RAD;
 
     /// A seeded synthetic reference population spread over mass/distance and
@@ -135,6 +149,21 @@ mod tests {
                 }
             })
             .collect()
+    }
+
+    #[test]
+    fn typed_reference_accessors_match_f64() {
+        let p9 = &population(1, 2016)[0];
+        assert_relative_eq!(
+            (p9.mass() / earth_masses(1.0)).value,
+            p9.mass_earth,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (p9.distance() / au(1.0)).value,
+            p9.distance_au,
+            max_relative = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2017-bias/src/bias_function.rs
+++ b/crates/p9-2017-bias/src/bias_function.rs
@@ -38,6 +38,7 @@ use std::f64::consts::PI;
 
 use p9_core::analysis::photometry::{apparent_magnitude, opposition_delta};
 use p9_core::constants::{DEG2RAD, TWO_PI};
+use p9_core::units::{radians, Angle};
 
 /// Ecliptic longitudes (radians) where the galactic plane crosses the
 /// ecliptic: λ ≈ 95° (toward the galactic center side) and 275°.
@@ -72,6 +73,27 @@ pub struct BiasParams {
     /// marginalization. The observed a > 230 AU sample has i ≲ 30°; the
     /// physical prior range is [0, i_max], not [0, π].
     pub i_max: f64,
+}
+
+impl BiasParams {
+    /// Ecliptic-latitude cutoff as a dimension-checked [`Angle`].
+    pub fn latitude_cutoff_typed(&self) -> Angle {
+        radians(self.latitude_cutoff)
+    }
+
+    /// Maximum population inclination as a dimension-checked [`Angle`].
+    pub fn i_max_typed(&self) -> Angle {
+        radians(self.i_max)
+    }
+
+    /// Galactic-plane longitude suppression 1σ widths as dimension-checked
+    /// [`Angle`]s (same ordering as [`BiasParams::galactic_lon_sigmas`]).
+    pub fn galactic_lon_sigmas_typed(&self) -> [Angle; 2] {
+        [
+            radians(self.galactic_lon_sigmas[0]),
+            radians(self.galactic_lon_sigmas[1]),
+        ]
+    }
 }
 
 impl Default for BiasParams {
@@ -259,6 +281,28 @@ pub fn bias_max(a: f64, e: f64, h_mag: f64, i: f64, params: &BiasParams) -> f64 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn typed_bias_param_angles_match_f64() {
+        let p = BiasParams::default();
+        assert_relative_eq!(
+            (p.latitude_cutoff_typed() / radians(1.0)).value,
+            p.latitude_cutoff,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (p.i_max_typed() / radians(1.0)).value,
+            p.i_max,
+            max_relative = 1e-12
+        );
+        let sig = p.galactic_lon_sigmas_typed();
+        assert_relative_eq!(
+            (sig[1] / radians(1.0)).value,
+            p.galactic_lon_sigmas[1],
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn test_detectable_fraction_limits() {

--- a/crates/p9-2017-dynamics/src/hamiltonian.rs
+++ b/crates/p9-2017-dynamics/src/hamiltonian.rs
@@ -25,6 +25,10 @@ use p9_core::constants::{
     EARTH_MASS_SOLAR, GM_SUN, MASS_JUPITER_SOLAR, MASS_NEPTUNE_SOLAR, MASS_SATURN_SOLAR,
     MASS_URANUS_SOLAR, TWO_PI, YEAR_DAYS,
 };
+use p9_core::units::{
+    au, days, gm_from_au3_day2, radians, solar_masses, AngularVelocity, GravitationalParameter,
+    Length, Mass,
+};
 use serde::{Deserialize, Serialize};
 
 /// Parameters for the doubly-averaged secular Hamiltonian.
@@ -69,6 +73,28 @@ impl SecularHamiltonianParams {
     /// Planet Nine GM in AU³/day².
     pub fn gm9(&self) -> f64 {
         self.m9_solar * GM_SUN
+    }
+
+    /// Planet Nine semi-major axis as a dimension-checked [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a9)
+    }
+
+    /// Planet Nine mass as a dimension-checked [`Mass`] (stored in solar masses).
+    pub fn mass(&self) -> Mass {
+        solar_masses(self.m9_solar)
+    }
+
+    /// Planet Nine gravitational parameter as a dimension-checked
+    /// [`GravitationalParameter`] (AU³/day² source).
+    pub fn gm9_typed(&self) -> GravitationalParameter {
+        gm_from_au3_day2(self.gm9())
+    }
+
+    /// Planet Nine apsidal precession rate as a dimension-checked
+    /// [`AngularVelocity`] (the stored value is in rad/day).
+    pub fn precession_rate_9_typed(&self) -> AngularVelocity {
+        (radians(self.precession_rate_9) / days(1.0)).into()
     }
 }
 
@@ -175,7 +201,28 @@ pub fn high_inclination_action(e: f64, i: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use p9_core::constants::DEG2RAD;
+
+    #[test]
+    fn typed_secular_param_accessors_match_f64() {
+        let p = SecularHamiltonianParams::default_paper();
+        assert_relative_eq!(
+            (p.semi_major_axis() / au(1.0)).value,
+            p.a9,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (p.mass() / solar_masses(1.0)).value,
+            p.m9_solar,
+            max_relative = 1e-9
+        );
+        assert_relative_eq!(
+            (p.gm9_typed() / gm_from_au3_day2(1.0)).value,
+            p.gm9(),
+            max_relative = 1e-9
+        );
+    }
 
     #[test]
     fn test_j2_effective_positive() {

--- a/crates/p9-2017-dynamics/src/phase_space.rs
+++ b/crates/p9-2017-dynamics/src/phase_space.rs
@@ -15,6 +15,7 @@
 //!    (ω = (Δϖ − θ)/2).
 
 use p9_core::constants::DEG2RAD;
+use p9_core::units::{au, radians, Angle, Length};
 use serde::{Deserialize, Serialize};
 
 use crate::hamiltonian::{secular_hamiltonian, SecularHamiltonianParams};
@@ -30,6 +31,18 @@ pub struct PhasePoint {
     pub i: f64,
     /// Hamiltonian value at this point
     pub h_value: f64,
+}
+
+impl PhasePoint {
+    /// Δϖ as a dimension-checked [`Angle`] (stored in radians).
+    pub fn delta_varpi_typed(&self) -> Angle {
+        radians(self.delta_varpi)
+    }
+
+    /// Implied inclination as a dimension-checked [`Angle`] (stored in radians).
+    pub fn inclination(&self) -> Angle {
+        radians(self.i)
+    }
 }
 
 /// Configuration for phase portrait generation.
@@ -90,6 +103,11 @@ impl PhasePortraitConfig {
     /// Inclination implied by H_z at eccentricity e.
     pub fn inclination_at(&self, e: f64) -> f64 {
         (self.h_z / (1.0 - e * e).sqrt()).clamp(-1.0, 1.0).acos()
+    }
+
+    /// Test-particle semi-major axis as a dimension-checked [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
     }
 }
 
@@ -234,7 +252,30 @@ pub fn find_equilibria(
 mod tests {
     use super::*;
     use crate::hamiltonian::{high_inclination_action, SecularHamiltonianParams};
+    use approx::assert_relative_eq;
     use std::f64::consts::PI;
+
+    #[test]
+    fn typed_phase_space_accessors_match_f64() {
+        let config = PhasePortraitConfig::low_inclination();
+        assert_relative_eq!(
+            (config.semi_major_axis() / au(1.0)).value,
+            config.a,
+            max_relative = 1e-12
+        );
+        let params = SecularHamiltonianParams::default_paper();
+        let p = &compute_phase_portrait(&config, &params)[0];
+        assert_relative_eq!(
+            (p.delta_varpi_typed() / radians(1.0)).value,
+            p.delta_varpi,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (p.inclination() / radians(1.0)).value,
+            p.i,
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn test_phase_portrait_size() {

--- a/crates/p9-2017-dynamics/src/resonance.rs
+++ b/crates/p9-2017-dynamics/src/resonance.rs
@@ -15,6 +15,7 @@
 use p9_core::analysis::hansen::{hansen_coefficient, mean_to_true_anomaly};
 use p9_core::analysis::resonance::resonant_angle;
 use p9_core::constants::{EARTH_MASS_SOLAR, GM_SUN, TWO_PI};
+use p9_core::units::{au, Length};
 use serde::{Deserialize, Serialize};
 use std::f64::consts::PI;
 
@@ -33,6 +34,16 @@ pub struct Resonance {
 }
 
 impl Resonance {
+    /// Nominal semi-major axis as a dimension-checked [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_nominal)
+    }
+
+    /// Pendulum half-width in semi-major axis as a dimension-checked [`Length`].
+    pub fn delta_semi_major_axis(&self) -> Length {
+        au(self.delta_a)
+    }
+
     /// Compute the nominal semi-major axis for a p:q resonance given a_9.
     pub fn nominal_semimajor(p: i64, q: i64, a9: f64) -> f64 {
         a9 * (q as f64 / p as f64).powf(2.0 / 3.0)
@@ -287,6 +298,22 @@ pub fn adiabatic_deviation(libration_amplitude: f64, resonance_width: f64) -> f6
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn typed_resonance_lengths_match_f64() {
+        let r = &key_resonances_700()[0];
+        assert_relative_eq!(
+            (r.semi_major_axis() / au(1.0)).value,
+            r.a_nominal,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (r.delta_semi_major_axis() / au(1.0)).value,
+            r.delta_a,
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn test_nominal_semimajor_1_1() {

--- a/crates/p9-2017-dynamics/src/simulation.rs
+++ b/crates/p9-2017-dynamics/src/simulation.rs
@@ -19,6 +19,7 @@ use p9_core::forces::ExtraForce;
 use p9_core::initial_conditions::planets;
 use p9_core::integrator::whm::WhmIntegrator;
 use p9_core::types::{cartesian_to_elements, OrbitalElements, P9Params, SimConfig as CoreConfig};
+use p9_core::units::{au, days, degrees, radians, Angle, Length, Time};
 use rand::Rng;
 use rand_distr::{Distribution, Uniform};
 use serde::{Deserialize, Serialize};
@@ -101,6 +102,51 @@ impl SimConfig {
         config.p9.mass_earth = 20.0;
         config
     }
+
+    /// Total integration time as a dimension-checked [`Time`] (stored in Gyr).
+    pub fn integration_time(&self) -> Time {
+        days(self.t_gyr * GYR_DAYS)
+    }
+
+    /// Integration timestep as a dimension-checked [`Time`] (stored in days).
+    pub fn timestep(&self) -> Time {
+        days(self.dt)
+    }
+
+    /// Snapshot interval as a dimension-checked [`Time`] (stored in days).
+    pub fn snapshot_interval_typed(&self) -> Time {
+        days(self.snapshot_interval)
+    }
+
+    /// Minimum initial semi-major axis as a dimension-checked [`Length`].
+    pub fn a_min_typed(&self) -> Length {
+        au(self.a_min)
+    }
+
+    /// Maximum initial semi-major axis as a dimension-checked [`Length`].
+    pub fn a_max_typed(&self) -> Length {
+        au(self.a_max)
+    }
+
+    /// Minimum initial perihelion distance as a dimension-checked [`Length`].
+    pub fn q_min_typed(&self) -> Length {
+        au(self.q_min)
+    }
+
+    /// Maximum initial perihelion distance as a dimension-checked [`Length`].
+    pub fn q_max_typed(&self) -> Length {
+        au(self.q_max)
+    }
+
+    /// Inner removal boundary as a dimension-checked [`Length`].
+    pub fn r_remove_inner_typed(&self) -> Length {
+        au(self.r_remove_inner)
+    }
+
+    /// Outer removal boundary as a dimension-checked [`Length`].
+    pub fn r_remove_outer_typed(&self) -> Length {
+        au(self.r_remove_outer)
+    }
 }
 
 /// Observability selection criteria from the paper.
@@ -119,6 +165,16 @@ impl ObservabilityCriteria {
 
     pub fn is_observable(&self, q: f64, i_deg: f64) -> bool {
         q <= self.q_max && i_deg <= self.i_max_deg
+    }
+
+    /// Maximum observable perihelion distance as a dimension-checked [`Length`].
+    pub fn q_max_typed(&self) -> Length {
+        au(self.q_max)
+    }
+
+    /// Maximum observable inclination as a dimension-checked [`Angle`].
+    pub fn i_max_typed(&self) -> Angle {
+        degrees(self.i_max_deg)
     }
 }
 
@@ -182,6 +238,21 @@ impl TestParticle {
 
     pub fn inclination_deg(&self) -> f64 {
         self.i / DEG2RAD
+    }
+
+    /// Semi-major axis as a dimension-checked [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
+    }
+
+    /// Inclination as a dimension-checked [`Angle`] (stored in radians).
+    pub fn inclination(&self) -> Angle {
+        radians(self.i)
+    }
+
+    /// Perihelion distance `q = a(1 − e)` as a dimension-checked [`Length`].
+    pub fn perihelion_typed(&self) -> Length {
+        au(self.perihelion())
     }
 
     fn elements(&self) -> OrbitalElements {
@@ -310,6 +381,52 @@ pub fn quick_test_simulation(config: &SimConfig) -> Vec<TestParticle> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+
+    #[test]
+    fn typed_sim_config_accessors_match_f64() {
+        let c = SimConfig::default_paper();
+        assert_relative_eq!(
+            (c.a_min_typed() / au(1.0)).value,
+            c.a_min,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (c.q_max_typed() / au(1.0)).value,
+            c.q_max,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!((c.timestep() / days(1.0)).value, c.dt, max_relative = 1e-12);
+        assert_relative_eq!(
+            (c.integration_time() / days(1.0)).value,
+            c.t_gyr * GYR_DAYS,
+            max_relative = 1e-12
+        );
+        let obs = ObservabilityCriteria::default_paper();
+        assert_relative_eq!(
+            (obs.i_max_typed() / degrees(1.0)).value,
+            obs.i_max_deg,
+            max_relative = 1e-12
+        );
+        let tp = TestParticle {
+            a: 500.0,
+            e: 0.8,
+            i: 0.3,
+            omega: 0.1,
+            omega_big: 0.2,
+            mean_anomaly: 0.0,
+        };
+        assert_relative_eq!(
+            (tp.perihelion_typed() / au(1.0)).value,
+            tp.perihelion(),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (tp.inclination() / radians(1.0)).value,
+            tp.i,
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn test_default_config() {

--- a/crates/p9-2017-ossos-bias/src/detection.rs
+++ b/crates/p9-2017-ossos-bias/src/detection.rs
@@ -32,6 +32,7 @@ use p9_core::analysis::surveys::limiting_magnitude;
 use p9_core::constants::{DEG2RAD, GM_SUN, TWO_PI};
 use p9_core::coords::sky::ecliptic_vec_declination;
 use p9_core::types::OrbitalElements;
+use p9_core::units::{radians, Angle};
 
 use crate::population::SyntheticEtno;
 
@@ -45,6 +46,16 @@ pub struct LongitudeWindow {
 }
 
 impl LongitudeWindow {
+    /// Window centre as a dimension-checked [`Angle`].
+    pub fn center_typed(&self) -> Angle {
+        radians(self.center)
+    }
+
+    /// Half-width as a dimension-checked [`Angle`].
+    pub fn half_width_typed(&self) -> Angle {
+        radians(self.half_width)
+    }
+
     fn contains(&self, lon: f64) -> bool {
         let mut d = (lon - self.center).rem_euclid(TWO_PI);
         if d > std::f64::consts::PI {
@@ -67,6 +78,18 @@ pub struct SurveyModel {
     pub ecliptic_lat_band: f64,
     /// Covered discovery-longitude windows in ecliptic longitude.
     pub windows: Vec<LongitudeWindow>,
+}
+
+impl SurveyModel {
+    /// Declination floor as a dimension-checked [`Angle`].
+    pub fn dec_min_typed(&self) -> Angle {
+        radians(self.dec_min)
+    }
+
+    /// Ecliptic-latitude half-band as a dimension-checked [`Angle`].
+    pub fn ecliptic_lat_band_typed(&self) -> Angle {
+        radians(self.ecliptic_lat_band)
+    }
 }
 
 impl Default for SurveyModel {
@@ -171,8 +194,30 @@ pub fn detected_subsample(pop: &[SyntheticEtno], model: &SurveyModel) -> Vec<Syn
 mod tests {
     use super::*;
     use crate::population::{generate_population, PopulationParams};
+    use approx::assert_relative_eq;
     use rand::rngs::StdRng;
     use rand::SeedableRng;
+
+    #[test]
+    fn typed_survey_angles_match_f64() {
+        let m = SurveyModel::default();
+        assert_relative_eq!(
+            (m.dec_min_typed() / radians(1.0)).value,
+            m.dec_min,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (m.ecliptic_lat_band_typed() / radians(1.0)).value,
+            m.ecliptic_lat_band,
+            max_relative = 1e-12
+        );
+        let w = &m.windows[0];
+        assert_relative_eq!(
+            (w.half_width_typed() / radians(1.0)).value,
+            w.half_width,
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn test_faint_distant_object_rejected() {

--- a/crates/p9-2017-ossos-bias/src/population.rs
+++ b/crates/p9-2017-ossos-bias/src/population.rs
@@ -28,6 +28,7 @@
 
 use p9_core::constants::{DEG2RAD, TWO_PI};
 use p9_core::types::OrbitalElements;
+use p9_core::units::{au, radians, Angle, Length};
 use rand::Rng;
 use rand_distr::{Distribution, Exp};
 
@@ -44,6 +45,11 @@ impl SyntheticEtno {
     pub fn longitude_of_perihelion(&self) -> f64 {
         (self.elements.omega_big + self.elements.omega).rem_euclid(TWO_PI)
     }
+
+    /// Longitude of perihelion as a dimension-checked [`Angle`].
+    pub fn longitude_of_perihelion_typed(&self) -> Angle {
+        radians(self.longitude_of_perihelion())
+    }
 }
 
 /// Parameters of the intrinsic population.
@@ -59,6 +65,23 @@ pub struct PopulationParams {
     pub h_scale: f64,
     /// Bright-end cutoff of the H distribution.
     pub h_min: f64,
+}
+
+impl PopulationParams {
+    /// Semi-major-axis range as dimension-checked [`Length`]s.
+    pub fn a_range_typed(&self) -> (Length, Length) {
+        (au(self.a_range.0), au(self.a_range.1))
+    }
+
+    /// Perihelion-distance range as dimension-checked [`Length`]s.
+    pub fn q_range_typed(&self) -> (Length, Length) {
+        (au(self.q_range.0), au(self.q_range.1))
+    }
+
+    /// Inclination-distribution 1σ as a dimension-checked [`Angle`].
+    pub fn i_sigma_typed(&self) -> Angle {
+        radians(self.i_sigma)
+    }
 }
 
 impl Default for PopulationParams {
@@ -125,9 +148,32 @@ pub fn longitudes_of_perihelion(pop: &[SyntheticEtno]) -> Vec<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use p9_core::analysis::circular::{mean_resultant_length, rayleigh_p_value};
     use rand::rngs::StdRng;
     use rand::SeedableRng;
+
+    #[test]
+    fn typed_population_accessors_match_f64() {
+        let p = PopulationParams::default();
+        assert_relative_eq!(
+            (p.i_sigma_typed() / radians(1.0)).value,
+            p.i_sigma,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            (p.a_range_typed().1 / au(1.0)).value,
+            p.a_range.1,
+            max_relative = 1e-12
+        );
+        let mut rng = StdRng::seed_from_u64(7);
+        let o = generate_population(1, &p, &mut rng)[0];
+        assert_relative_eq!(
+            (o.longitude_of_perihelion_typed() / radians(1.0)).value,
+            o.longitude_of_perihelion(),
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn test_population_within_ranges() {


### PR DESCRIPTION
Additively adopts the `p9_core::units` (`uom`) typed boundary across the
2016–2017 batch. No existing `f64` fields, signatures, or published/reference
values changed; every addition is a new public accessor returning a
dimension-checked `uom` quantity, each pinned against its `f64` source with an
`assert_relative_eq!` test.

## Per-crate changes

- **p9-2016-resonance-prediction**: `A9Score::{semi_major_axis() -> Length, period() -> Time}`.
- **p9-2016-secular-resonance**: `SecularModel::{semi_major_axis(), perturber_semi_major_axis(), gm_p_typed()}`; `Trajectory::{center_typed(), amplitude_typed()}` (Angle); `Island::{center_dvarpi_typed() -> Angle, omega_lib_typed() -> AngularVelocity, suggested_dt_typed() -> Time}`; `ResonantHamiltonian::g_p_typed() -> AngularVelocity`.
- **p9-2016-sheppard-etnos**: `ClusterStats::{mean() -> Option<Angle>, std() -> Angle}` over the circular-statistics degrees fields.
- **p9-2016-wise-coadd**: `WiseBand::wavelength() -> Length`; `ReferenceP9::{mass() -> Mass, distance() -> Length}`.
- **p9-2017-bias**: `BiasParams::{latitude_cutoff_typed(), i_max_typed(), galactic_lon_sigmas_typed()}` (Angle).
- **p9-2017-dynamics**: `Resonance::{semi_major_axis(), delta_semi_major_axis()}`; `TestParticle::{semi_major_axis(), inclination(), perihelion_typed()}`; `SimConfig` typed length/time accessors; `ObservabilityCriteria::{q_max_typed(), i_max_typed()}`; `SecularHamiltonianParams::{semi_major_axis(), mass(), gm9_typed(), precession_rate_9_typed()}`; `PhasePortraitConfig::semi_major_axis()`; `PhasePoint::{delta_varpi_typed(), inclination()}`.
- **p9-2017-ossos-bias**: `SyntheticEtno::longitude_of_perihelion_typed()`; `PopulationParams::{a_range_typed(), q_range_typed(), i_sigma_typed()}`; `LongitudeWindow::{center_typed(), half_width_typed()}`; `SurveyModel::{dec_min_typed(), ecliptic_lat_band_typed()}`.

## Skipped

None of the seven crates were fully skipped — each exposed at least one
dimensional public scalar. Purely dimensionless surfaces within these crates
(Rayleigh p-values, mean resultant lengths, exclusion fractions, magnitudes /
depths, Hamiltonian energies and Delaunay actions with no named `uom` quantity,
`nalgebra` vectors) were intentionally left untouched.

`cargo build`/`cargo test` pass for all seven crates; `cargo fmt` applied.