### PR TITLE
Add typed uom accessors to 2018-2020 survey crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,6 +1509,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1521,6 +1522,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1533,6 +1535,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1545,6 +1548,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1556,6 +1560,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1568,6 +1573,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1579,6 +1585,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]

--- a/crates/p9-2018-wise-search/Cargo.toml
+++ b/crates/p9-2018-wise-search/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2018-wise-search/src/exclusion.rs
+++ b/crates/p9-2018-wise-search/src/exclusion.rs
@@ -19,6 +19,7 @@ use crate::sky::galactic_latitude_deg;
 use crate::survey_model::WiseSurvey;
 use crate::thermal_model::P9Thermal;
 use p9_core::types::OrbitalElements;
+use p9_core::units::{au, earth_masses, Length, Mass};
 
 /// One reference Planet Nine realization: orbital elements, mass, and the
 /// heliocentric distance at its current mean anomaly.
@@ -27,6 +28,18 @@ pub struct ReferenceP9 {
     pub elements: OrbitalElements,
     pub mass_earth: f64,
     pub distance_au: f64,
+}
+
+impl ReferenceP9 {
+    /// Mass as a typed [`Mass`].
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+
+    /// Heliocentric distance as a typed [`Length`].
+    pub fn distance(&self) -> Length {
+        au(self.distance_au)
+    }
 }
 
 /// Result of the WISE exclusion analysis.
@@ -109,6 +122,35 @@ mod tests {
                 }
             })
             .collect()
+    }
+
+    #[test]
+    fn reference_typed_accessors_match_f64() {
+        use approx::assert_relative_eq;
+        use uom::si::length::astronomical_unit;
+        use uom::si::mass::kilogram;
+        let p = ReferenceP9 {
+            elements: OrbitalElements {
+                a: 500.0,
+                e: 0.2,
+                i: 0.3,
+                omega: 0.0,
+                omega_big: 0.0,
+                mean_anomaly: 0.0,
+            },
+            mass_earth: 6.2,
+            distance_au: 480.0,
+        };
+        assert_relative_eq!(
+            p.distance().get::<astronomical_unit>(),
+            480.0,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            p.mass().get::<kilogram>(),
+            6.2 * p9_core::units::EARTH_MASS_KG,
+            epsilon = 1e12
+        );
     }
 
     #[test]

--- a/crates/p9-2018-wise-search/src/survey_model.rs
+++ b/crates/p9-2018-wise-search/src/survey_model.rs
@@ -12,6 +12,7 @@
 use serde::{Deserialize, Serialize};
 
 use p9_core::analysis::surveys::limiting_magnitude;
+use p9_core::units::{degrees, Angle};
 
 /// Published WISE W1 single-exposure / shift-and-stack depth (Vega mag),
 /// kept as a labelled reference constant; the live value comes from the
@@ -59,6 +60,11 @@ impl WiseSurvey {
         galactic_lat_deg.abs() >= self.galactic_mask_deg
     }
 
+    /// Half-width of the masked galactic-plane band as a typed [`Angle`].
+    pub fn galactic_mask(&self) -> Angle {
+        degrees(self.galactic_mask_deg)
+    }
+
     /// Fraction of the celestial sphere covered: all-sky minus the masked
     /// galactic band |b| < galactic_mask. The unmasked solid-angle fraction
     /// is cos-weighted: f = 1 − sin(b_mask).
@@ -84,6 +90,13 @@ mod tests {
         assert!(survey.detection_efficiency(14.0) > 0.99);
         assert!((survey.detection_efficiency(16.5) - 0.5).abs() < 1e-10);
         assert!(survey.detection_efficiency(19.0) < 0.01);
+    }
+
+    #[test]
+    fn galactic_mask_typed_matches_f64() {
+        use uom::si::angle::degree;
+        let survey = WiseSurvey::default();
+        assert!((survey.galactic_mask().get::<degree>() - survey.galactic_mask_deg).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/p9-2018-wise-search/src/thermal_model.rs
+++ b/crates/p9-2018-wise-search/src/thermal_model.rs
@@ -36,6 +36,7 @@ use p9_core::analysis::thermal::{
     effective_temp, flux_to_magnitude, reflected_flux_jy, solar_equilibrium_temp, thermal_flux_jy,
     C_LIGHT,
 };
+use p9_core::units::{au, earth_masses, meters, Length, Mass};
 
 /// Earth radius (m).
 const R_EARTH_M: f64 = 6.371e6;
@@ -89,6 +90,21 @@ impl P9Thermal {
     /// Physical radius in meters (Neptune-anchored mass-radius relation).
     pub fn radius_m(&self) -> f64 {
         mass_radius_neptunian(self.mass_earth) * R_EARTH_M
+    }
+
+    /// Mass as a typed [`Mass`].
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+
+    /// Heliocentric distance as a typed [`Length`].
+    pub fn distance(&self) -> Length {
+        au(self.distance_au)
+    }
+
+    /// Physical radius as a typed [`Length`].
+    pub fn radius(&self) -> Length {
+        meters(self.radius_m())
     }
 
     /// Solar equilibrium temperature (K) for a fast rotator radiating from
@@ -145,6 +161,16 @@ pub fn w1_magnitude(mass_earth: f64, distance_au: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn typed_accessors_match_f64() {
+        use uom::si::length::{astronomical_unit, meter};
+        use uom::si::mass::kilogram;
+        let p = P9Thermal::new(10.0, 500.0);
+        assert!((p.distance().get::<astronomical_unit>() - 500.0).abs() < 1e-9);
+        assert!((p.radius().get::<meter>() - p.radius_m()).abs() < 1e-6);
+        assert!((p.mass().get::<kilogram>() - 10.0 * p9_core::units::EARTH_MASS_KG).abs() < 1e12);
+    }
 
     #[test]
     fn radius_matches_ice_giant_models() {

--- a/crates/p9-2019-clustering/Cargo.toml
+++ b/crates/p9-2019-clustering/Cargo.toml
@@ -10,3 +10,6 @@ rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 approx = { workspace = true }
+
+[dev-dependencies]
+uom = "0.38.0"

--- a/crates/p9-2019-clustering/src/clustering_analysis.rs
+++ b/crates/p9-2019-clustering/src/clustering_analysis.rs
@@ -26,6 +26,7 @@ use crate::poincare_variables::*;
 
 use p9_core::constants::{DEG2RAD, TWO_PI};
 use p9_core::types::OrbitalElements;
+use p9_core::units::{radians, Angle};
 
 /// Null hypothesis model for the angle draws.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -60,6 +61,18 @@ pub struct ClusteringResult {
     pub p_combined: f64,
     /// Number of Monte Carlo iterations
     pub n_iterations: usize,
+}
+
+impl ClusteringResult {
+    /// Mean perihelion-longitude clustering direction as a typed [`Angle`].
+    pub fn mean_varpi_angle(&self) -> Angle {
+        radians(self.mean_varpi)
+    }
+
+    /// Mean pole (longitude-of-node) clustering direction as a typed [`Angle`].
+    pub fn mean_omega_angle(&self) -> Angle {
+        radians(self.mean_omega)
+    }
 }
 
 /// Ecliptic longitude and latitude (radians) of the perihelion direction
@@ -221,6 +234,15 @@ mod tests {
         // Observed clustering should be positive (non-zero)
         assert!(r_peri > 0.0, "Perihelion clustering = {:.3}", r_peri);
         assert!(r_pole > 0.0, "Pole clustering = {:.3}", r_pole);
+    }
+
+    #[test]
+    fn test_mean_direction_typed_accessors_match_f64() {
+        use uom::si::angle::radian;
+        let kbos = kbo_sample::paper_sample_a230();
+        let result = monte_carlo_clustering(&kbos, 100, 42, NullModel::Uniform);
+        assert!((result.mean_varpi_angle().get::<radian>() - result.mean_varpi).abs() < 1e-12);
+        assert!((result.mean_omega_angle().get::<radian>() - result.mean_omega).abs() < 1e-12);
     }
 
     #[test]

--- a/crates/p9-2019-ossos-scattering/Cargo.toml
+++ b/crates/p9-2019-ossos-scattering/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2019-ossos-scattering/src/boundary.rs
+++ b/crates/p9-2019-ossos-scattering/src/boundary.rs
@@ -13,6 +13,7 @@
 //! module maps the boundary curve and classifies orbits with it.
 
 use p9_core::analysis::resonance::{chirikov_overlap_parameter, critical_perihelion, is_chaotic};
+use p9_core::units::{au, Length};
 
 /// Dynamical state of a TNO relative to the Neptune-scattering region.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -47,6 +48,18 @@ pub fn boundary_perihelion(a_au: f64) -> f64 {
 pub struct BoundaryPoint {
     pub a_au: f64,
     pub q_crit_au: f64,
+}
+
+impl BoundaryPoint {
+    /// Semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_au)
+    }
+
+    /// Critical perihelion as a typed [`Length`].
+    pub fn critical_perihelion(&self) -> Length {
+        au(self.q_crit_au)
+    }
 }
 
 /// Sample the scattering/detached boundary q_crit(a) on a logarithmic grid in
@@ -147,6 +160,22 @@ mod tests {
         for w in nonzero.windows(2) {
             assert!(w[1] >= w[0] - 1e-9, "q_crit not monotone: {w:?}");
         }
+    }
+
+    #[test]
+    fn boundary_point_typed_accessors_match_f64() {
+        use uom::si::length::astronomical_unit;
+        let p = boundary_curve(50.0, 1000.0, 10)[5];
+        assert_relative_eq!(
+            p.semi_major_axis().get::<astronomical_unit>(),
+            p.a_au,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            p.critical_perihelion().get::<astronomical_unit>(),
+            p.q_crit_au,
+            epsilon = 1e-9
+        );
     }
 
     #[test]

--- a/crates/p9-2019-ossos-scattering/src/planet_nine.rs
+++ b/crates/p9-2019-ossos-scattering/src/planet_nine.rs
@@ -34,6 +34,7 @@
 use p9_core::analysis::secular::numerical_secular_hamiltonian;
 use p9_core::constants::{EARTH_MASS_SOLAR, GM_SUN, TWO_PI};
 use p9_core::forces::j2_secular::combined_j2_jsu;
+use p9_core::units::{au, earth_masses, gm_from_au3_day2, GravitationalParameter, Length, Mass};
 
 /// Planet Nine orbital/mass parameters. Defaults are the Batygin & Brown
 /// (2021) nominal P9: 6.2 M⊕, a₉ = 380 AU, e₉ = 0.2.
@@ -62,6 +63,21 @@ impl PlanetNine {
     /// Heliocentric gravitational parameter GM₉ (AU³/day²).
     pub fn gm(&self) -> f64 {
         self.mass_earth * EARTH_MASS_SOLAR * GM_SUN
+    }
+
+    /// Mass as a typed [`Mass`].
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+
+    /// Semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_au)
+    }
+
+    /// Gravitational parameter GM₉ as a typed [`GravitationalParameter`].
+    pub fn gm_typed(&self) -> GravitationalParameter {
+        gm_from_au3_day2(self.gm())
     }
 }
 
@@ -253,6 +269,29 @@ mod tests {
             nominal.gm(),
             6.2 * EARTH_MASS_SOLAR * GM_SUN,
             epsilon = 1e-18
+        );
+    }
+
+    #[test]
+    fn planet_nine_typed_accessors_match_f64() {
+        use uom::si::length::astronomical_unit;
+        use uom::si::mass::kilogram;
+        let p9 = PlanetNine::default();
+        assert_relative_eq!(
+            p9.semi_major_axis().get::<astronomical_unit>(),
+            p9.a_au,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            p9.mass().get::<kilogram>(),
+            p9.mass_earth * p9_core::units::EARTH_MASS_KG,
+            epsilon = 1e12
+        );
+        // GM round-trips from AU³/day² to SI base via the core converter.
+        assert_relative_eq!(
+            p9.gm_typed().value,
+            gm_from_au3_day2(p9.gm()).value,
+            epsilon = 1e-30
         );
     }
 

--- a/crates/p9-2019-ossos-scattering/src/population.rs
+++ b/crates/p9-2019-ossos-scattering/src/population.rs
@@ -15,6 +15,7 @@
 use crate::boundary::{classify, DynamicalClass};
 use crate::planet_nine::{perihelion_lift, PlanetNine};
 use p9_core::constants::A_NEPTUNE_AU;
+use p9_core::units::{au, Length};
 use rand::SeedableRng;
 use rand_distr::{Distribution, Uniform};
 
@@ -23,6 +24,18 @@ use rand_distr::{Distribution, Uniform};
 pub struct ScatteringTno {
     pub a_au: f64,
     pub q_au: f64,
+}
+
+impl ScatteringTno {
+    /// Semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_au)
+    }
+
+    /// Perihelion distance as a typed [`Length`].
+    pub fn perihelion(&self) -> Length {
+        au(self.q_au)
+    }
 }
 
 /// Draw `n` synthetic actively-scattering TNOs (seeded).
@@ -130,6 +143,23 @@ mod tests {
             assert_eq!(classify(t.a_au, t.q_au), DynamicalClass::Scattering);
             assert!(t.q_au > A_NEPTUNE_AU);
         }
+    }
+
+    #[test]
+    fn tno_typed_accessors_match_f64() {
+        use approx::assert_relative_eq;
+        use uom::si::length::astronomical_unit;
+        let t = standard_population()[0];
+        assert_relative_eq!(
+            t.semi_major_axis().get::<astronomical_unit>(),
+            t.a_au,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            t.perihelion().get::<astronomical_unit>(),
+            t.q_au,
+            epsilon = 1e-9
+        );
     }
 
     #[test]

--- a/crates/p9-2019-review/Cargo.toml
+++ b/crates/p9-2019-review/Cargo.toml
@@ -10,3 +10,6 @@ rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 approx = { workspace = true }
+
+[dev-dependencies]
+uom = "0.38.0"

--- a/crates/p9-2019-review/src/detection_prospects.rs
+++ b/crates/p9-2019-review/src/detection_prospects.rs
@@ -10,6 +10,7 @@ use p9_core::analysis::photometry;
 use p9_core::analysis::surveys::limiting_magnitude;
 use p9_core::constants::*;
 use p9_core::types::P9Params;
+use p9_core::units::{earth_masses, km, Length, Mass};
 
 /// Physical properties of Planet Nine for brightness estimation.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -21,6 +22,11 @@ pub struct P9PhysicalProperties {
 }
 
 impl P9PhysicalProperties {
+    /// Physical radius as a typed [`Length`] (Earth radii × Earth radius).
+    pub fn radius(&self) -> Length {
+        km(self.radius_earth * EARTH_RADIUS_KM)
+    }
+
     /// Conservative estimate for 5 M_Earth.
     pub fn five_me_conservative() -> Self {
         Self {
@@ -116,6 +122,13 @@ pub struct BrightnessEstimate {
     pub v_aphelion_faint: f64,
 }
 
+impl BrightnessEstimate {
+    /// Planet Nine mass as a typed [`Mass`].
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+}
+
 /// Compute brightness estimates for the paper's best-fit parameters.
 pub fn brightness_table() -> Vec<BrightnessEstimate> {
     use crate::revised_parameters::{best_fit_10me, best_fit_5me};
@@ -196,6 +209,22 @@ mod tests {
             v_peri > 15.0 && v_peri < 25.0,
             "V perihelion = {:.1}",
             v_peri
+        );
+    }
+
+    #[test]
+    fn test_typed_accessors_match_f64() {
+        use uom::si::length::kilometer;
+        use uom::si::mass::kilogram;
+        let phys = P9PhysicalProperties::five_me_optimistic();
+        assert!(
+            (phys.radius().get::<kilometer>() - phys.radius_earth * EARTH_RADIUS_KM).abs() < 1e-6
+        );
+        let entry = &brightness_table()[0];
+        assert!(
+            (entry.mass().get::<kilogram>() - entry.mass_earth * p9_core::units::EARTH_MASS_KG)
+                .abs()
+                < 1e12
         );
     }
 

--- a/crates/p9-2019-review/src/parameter_survey.rs
+++ b/crates/p9-2019-review/src/parameter_survey.rs
@@ -21,6 +21,7 @@ use p9_core::analysis::secular::numerical_secular_hamiltonian;
 use p9_core::constants::*;
 use p9_core::forces::j2_secular::combined_j2_jsu;
 use p9_core::types::P9Params;
+use p9_core::units::{au, degrees, earth_masses, Angle, Length, Mass};
 
 /// Statistical success criterion for the survey: the critical semi-major
 /// axis should fall in the observed transition range (200, 300) AU
@@ -49,6 +50,13 @@ pub struct SimulationScore {
     pub passes: bool,
 }
 
+impl SimulationScore {
+    /// Critical semi-major axis as a typed [`Length`], if an island exists.
+    pub fn a_c_length(&self) -> Option<Length> {
+        self.a_c.map(au)
+    }
+}
+
 /// Summary of P9 parameters for serialization.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct P9ParamsSummary {
@@ -56,6 +64,23 @@ pub struct P9ParamsSummary {
     pub a: f64,
     pub e: f64,
     pub i_deg: f64,
+}
+
+impl P9ParamsSummary {
+    /// Planet Nine mass as a typed [`Mass`].
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+
+    /// Semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
+    }
+
+    /// Inclination as a typed [`Angle`].
+    pub fn inclination(&self) -> Angle {
+        degrees(self.i_deg)
+    }
 }
 
 impl From<&P9Params> for P9ParamsSummary {
@@ -277,6 +302,27 @@ mod tests {
     fn test_no_island_well_inside() {
         let p9 = P9Params::revised_2019();
         assert!(!has_anti_aligned_island(100.0, &p9, 48));
+    }
+
+    #[test]
+    fn test_typed_accessors_match_f64() {
+        use uom::si::angle::degree;
+        use uom::si::length::astronomical_unit;
+        use uom::si::mass::kilogram;
+        let score = evaluate_params(
+            &P9Params::revised_2019(),
+            &SuccessCriteria::paper_defaults(),
+        );
+        let s = &score.params;
+        assert!((s.semi_major_axis().get::<astronomical_unit>() - s.a).abs() < 1e-9);
+        assert!((s.inclination().get::<degree>() - s.i_deg).abs() < 1e-9);
+        assert!(
+            (s.mass().get::<kilogram>() - s.mass_earth * p9_core::units::EARTH_MASS_KG).abs()
+                < 1e12
+        );
+        if let Some(a_c) = score.a_c {
+            assert!((score.a_c_length().unwrap().get::<astronomical_unit>() - a_c).abs() < 1e-9);
+        }
     }
 
     #[test]

--- a/crates/p9-2019-selfgrav-disk/Cargo.toml
+++ b/crates/p9-2019-selfgrav-disk/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2019-selfgrav-disk/src/disk.rs
+++ b/crates/p9-2019-selfgrav-disk/src/disk.rs
@@ -7,6 +7,7 @@
 //! prescribed eccentricity profile e_d(a). Such a disk is what the paper shows
 //! can SHEPHERD test ETNOs into apsidal anti-alignment without a planet.
 
+use p9_core::units::{au, radians, solar_masses, Angle, Length, Mass};
 use serde::{Deserialize, Serialize};
 use std::f64::consts::PI;
 
@@ -80,6 +81,26 @@ impl DiskProfile {
         self.mass_solar / p9_core::constants::EARTH_MASS_SOLAR
     }
 
+    /// Inner edge as a typed [`Length`].
+    pub fn inner_radius(&self) -> Length {
+        au(self.a_in)
+    }
+
+    /// Outer edge as a typed [`Length`].
+    pub fn outer_radius(&self) -> Length {
+        au(self.a_out)
+    }
+
+    /// Total disk mass as a typed [`Mass`].
+    pub fn mass(&self) -> Mass {
+        solar_masses(self.mass_solar)
+    }
+
+    /// Disk longitude of perihelion as a typed [`Angle`].
+    pub fn varpi_disk_angle(&self) -> Angle {
+        radians(self.varpi_disk)
+    }
+
     /// A single confocal eccentric ring of the discretized disk.
     fn ring(&self, k: usize) -> Ring {
         // Log-spaced ring semi-major axes (the disk spans a decade in a).
@@ -129,6 +150,23 @@ pub struct Ring {
     pub mass_solar: f64,
 }
 
+impl Ring {
+    /// Ring semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
+    }
+
+    /// Ring apse as a typed [`Angle`].
+    pub fn varpi_angle(&self) -> Angle {
+        radians(self.varpi)
+    }
+
+    /// Ring mass as a typed [`Mass`].
+    pub fn mass(&self) -> Mass {
+        solar_masses(self.mass_solar)
+    }
+}
+
 /// Disk surface density Sigma(a) (solar masses / AU^2), for documentation/plots.
 pub fn surface_density(profile: &DiskProfile, a: f64) -> f64 {
     if a < profile.a_in || a > profile.a_out {
@@ -155,6 +193,45 @@ mod tests {
         let d = DiskProfile::fiducial(10.0);
         let total: f64 = d.rings().iter().map(|r| r.mass_solar).sum();
         assert_relative_eq!(total, d.mass_solar, epsilon = 1e-12 * d.mass_solar);
+    }
+
+    #[test]
+    fn test_typed_accessors_match_f64() {
+        use uom::si::angle::radian;
+        use uom::si::length::astronomical_unit;
+        use uom::si::mass::kilogram;
+        let d = DiskProfile::fiducial(10.0);
+        assert_relative_eq!(
+            d.inner_radius().get::<astronomical_unit>(),
+            d.a_in,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            d.outer_radius().get::<astronomical_unit>(),
+            d.a_out,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            d.mass().get::<kilogram>(),
+            d.mass_solar * p9_core::units::SOLAR_MASS_KG,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            d.varpi_disk_angle().get::<radian>(),
+            d.varpi_disk,
+            epsilon = 1e-12
+        );
+        let r = d.rings()[0];
+        assert_relative_eq!(
+            r.semi_major_axis().get::<astronomical_unit>(),
+            r.a,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            r.mass().get::<kilogram>(),
+            r.mass_solar * p9_core::units::SOLAR_MASS_KG,
+            max_relative = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2019-selfgrav-disk/src/secular.rs
+++ b/crates/p9-2019-selfgrav-disk/src/secular.rs
@@ -44,6 +44,7 @@ use crate::disk::DiskProfile;
 use crate::laplace::softened_laplace;
 use p9_core::analysis::circular::wrap_to_pi;
 use p9_core::constants::GM_SUN;
+use p9_core::units::{days, radians, Angle, AngularVelocity, Time};
 use std::f64::consts::PI;
 
 const N_LAPLACE_QUAD: usize = 512;
@@ -73,6 +74,31 @@ impl SecularSolution {
     /// (-pi, pi]). 0 means aligned with the disk apse, +-pi anti-aligned.
     pub fn forced_delta_varpi(&self) -> f64 {
         wrap_to_pi(self.varpi_forced - self.varpi_disk)
+    }
+
+    /// Free/self precession rate A as a typed [`AngularVelocity`] (rad/day).
+    pub fn precession_rate(&self) -> AngularVelocity {
+        (radians(self.a_coeff) / days(1.0)).into()
+    }
+
+    /// Secular precession period as a typed [`Time`].
+    pub fn precession_period(&self) -> Time {
+        days((2.0 * PI / self.a_coeff).abs())
+    }
+
+    /// Forced longitude of perihelion as a typed [`Angle`].
+    pub fn varpi_forced_angle(&self) -> Angle {
+        radians(self.varpi_forced)
+    }
+
+    /// Disk apse as a typed [`Angle`].
+    pub fn varpi_disk_angle(&self) -> Angle {
+        radians(self.varpi_disk)
+    }
+
+    /// Forced Delta varpi relative to the disk apse as a typed [`Angle`].
+    pub fn forced_delta_varpi_angle(&self) -> Angle {
+        radians(self.forced_delta_varpi())
     }
 }
 
@@ -225,6 +251,35 @@ pub fn apsidal_mode(a: f64, disk: &DiskProfile, e0: f64, dphi0: f64) -> ApsidalM
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
+
+    #[test]
+    fn test_typed_accessors_match_f64() {
+        use p9_core::constants::{DAY_S, YEAR_DAYS};
+        use uom::si::angle::radian;
+        use uom::si::angular_velocity::radian_per_second;
+        use uom::si::time::day;
+        let sol = solve(250.0, &DiskProfile::fiducial(10.0));
+        assert_relative_eq!(
+            sol.precession_rate().get::<radian_per_second>(),
+            sol.a_coeff / DAY_S,
+            epsilon = 1e-30
+        );
+        assert_relative_eq!(
+            sol.precession_period().get::<day>(),
+            sol.precession_period_yr() * YEAR_DAYS,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            sol.varpi_forced_angle().get::<radian>(),
+            sol.varpi_forced,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            sol.forced_delta_varpi_angle().get::<radian>(),
+            sol.forced_delta_varpi(),
+            epsilon = 1e-12
+        );
+    }
 
     #[test]
     fn test_precession_scales_linearly_with_disk_mass() {

--- a/crates/p9-2019-tess-yield/Cargo.toml
+++ b/crates/p9-2019-tess-yield/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2019-tess-yield/src/yield_grid.rs
+++ b/crates/p9-2019-tess-yield/src/yield_grid.rs
@@ -18,6 +18,7 @@
 use serde::{Deserialize, Serialize};
 
 use p9_core::analysis::photometry::planet_apparent_magnitude;
+use p9_core::units::{au, earth_masses, Length, Mass};
 
 use crate::tess::TessStack;
 
@@ -56,6 +57,19 @@ impl Default for ReferenceBox {
 }
 
 impl ReferenceBox {
+    /// Mass range `[min, max]` as typed [`Mass`] values.
+    pub fn mass_range(&self) -> (Mass, Mass) {
+        (
+            earth_masses(self.mass_earth.0),
+            earth_masses(self.mass_earth.1),
+        )
+    }
+
+    /// Heliocentric distance range `[min, max]` as typed [`Length`] values.
+    pub fn distance_range(&self) -> (Length, Length) {
+        (au(self.distance_au.0), au(self.distance_au.1))
+    }
+
     fn mass_at(&self, j: usize) -> f64 {
         let (lo, hi) = self.mass_earth;
         if self.n_mass <= 1 {
@@ -114,6 +128,23 @@ pub fn p9_apparent_magnitude(mass_earth: f64, distance_au: f64, albedo: f64) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reference_box_typed_ranges_match_f64() {
+        use uom::si::length::astronomical_unit;
+        use uom::si::mass::kilogram;
+        let bx = ReferenceBox::default();
+        let (m_lo, m_hi) = bx.mass_range();
+        assert!(
+            (m_lo.get::<kilogram>() - bx.mass_earth.0 * p9_core::units::EARTH_MASS_KG).abs() < 1e12
+        );
+        assert!(
+            (m_hi.get::<kilogram>() - bx.mass_earth.1 * p9_core::units::EARTH_MASS_KG).abs() < 1e12
+        );
+        let (d_lo, d_hi) = bx.distance_range();
+        assert!((d_lo.get::<astronomical_unit>() - bx.distance_au.0).abs() < 1e-9);
+        assert!((d_hi.get::<astronomical_unit>() - bx.distance_au.1).abs() < 1e-9);
+    }
 
     #[test]
     fn detectable_fraction_is_a_probability() {

--- a/crates/p9-2020-clement-precession/Cargo.toml
+++ b/crates/p9-2020-clement-precession/Cargo.toml
@@ -11,3 +11,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2020-clement-precession/src/lib.rs
+++ b/crates/p9-2020-clement-precession/src/lib.rs
@@ -22,6 +22,9 @@
 pub mod precession;
 pub mod resonance;
 
+use p9_core::constants::GYR_DAYS;
+use p9_core::units::{au, days, radians, AngularVelocity, Length, Time};
+
 /// Convenience summary of the two headline results for a test ETNO and a
 /// nominal Planet Nine. Returned as plain numbers so callers (and the binary
 /// report below) can serialize or print them.
@@ -41,6 +44,35 @@ pub struct Summary {
     pub combined_period_gyr: f64,
     /// Nearest-resonance matches for the clustered sample.
     pub matches: Vec<resonance::EtnoResonance>,
+}
+
+impl Summary {
+    /// Test ETNO semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_au)
+    }
+
+    /// Giant-planet-induced apsidal precession rate as a typed
+    /// [`AngularVelocity`] (from rad/day).
+    pub fn giant_precession_rate(&self) -> AngularVelocity {
+        (radians(self.giant_rate) / days(1.0)).into()
+    }
+
+    /// Combined giant-planet + P9 apsidal precession rate as a typed
+    /// [`AngularVelocity`] (from rad/day).
+    pub fn combined_precession_rate(&self) -> AngularVelocity {
+        (radians(self.combined_rate) / days(1.0)).into()
+    }
+
+    /// Giant-planet precession period as a typed [`Time`] (from Gyr).
+    pub fn giant_period(&self) -> Time {
+        days(self.giant_period_gyr * GYR_DAYS)
+    }
+
+    /// Combined precession period as a typed [`Time`] (from Gyr).
+    pub fn combined_period(&self) -> Time {
+        days(self.combined_period_gyr * GYR_DAYS)
+    }
 }
 
 /// Build the [`Summary`] for an ETNO at (a, e) and a Planet Nine.
@@ -76,6 +108,44 @@ mod tests {
         assert_eq!(
             s.matches.len(),
             p9_core::data::etno::BROWN_2017_SAMPLE.len()
+        );
+    }
+
+    #[test]
+    fn test_typed_accessors_match_f64() {
+        use approx::assert_relative_eq;
+        use p9_core::constants::{DAY_S, GYR_DAYS};
+        use uom::si::angular_velocity::radian_per_second;
+        use uom::si::length::astronomical_unit;
+        use uom::si::time::day;
+
+        let a = 250.0;
+        let e = 1.0 - 40.0 / a;
+        let s = summarize(a, e, &P9Params::nominal_2016());
+        assert_relative_eq!(
+            s.semi_major_axis().get::<astronomical_unit>(),
+            s.a_au,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            s.giant_precession_rate().get::<radian_per_second>(),
+            s.giant_rate / DAY_S,
+            epsilon = 1e-30
+        );
+        assert_relative_eq!(
+            s.combined_precession_rate().get::<radian_per_second>(),
+            s.combined_rate / DAY_S,
+            epsilon = 1e-30
+        );
+        assert_relative_eq!(
+            s.giant_period().get::<day>(),
+            s.giant_period_gyr * GYR_DAYS,
+            epsilon = 1e-3
+        );
+        assert_relative_eq!(
+            s.combined_period().get::<day>(),
+            s.combined_period_gyr * GYR_DAYS,
+            epsilon = 1e-3
         );
     }
 }

--- a/crates/p9-2020-clement-precession/src/precession.rs
+++ b/crates/p9-2020-clement-precession/src/precession.rs
@@ -40,12 +40,25 @@ use p9_core::constants::{
     YEAR_DAYS,
 };
 use p9_core::types::P9Params;
+use p9_core::units::{au, solar_masses, Length, Mass};
 
 /// An interior perturbing ring: semi-major axis (AU) and mass (solar masses).
 #[derive(Debug, Clone, Copy)]
 pub struct Perturber {
     pub a_au: f64,
     pub mass_solar: f64,
+}
+
+impl Perturber {
+    /// Perturber semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_au)
+    }
+
+    /// Perturber mass as a typed [`Mass`].
+    pub fn mass(&self) -> Mass {
+        solar_masses(self.mass_solar)
+    }
 }
 
 /// The four known giant planets as interior secular perturbers.
@@ -176,6 +189,23 @@ mod tests {
 
     fn e_test() -> f64 {
         1.0 - Q_TEST / A_TEST
+    }
+
+    #[test]
+    fn test_perturber_typed_accessors_match_f64() {
+        use uom::si::length::astronomical_unit;
+        use uom::si::mass::kilogram;
+        let neptune = giant_planets()[3];
+        assert_relative_eq!(
+            neptune.semi_major_axis().get::<astronomical_unit>(),
+            neptune.a_au,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            neptune.mass().get::<kilogram>(),
+            neptune.mass_solar * p9_core::units::SOLAR_MASS_KG,
+            epsilon = 1e15
+        );
     }
 
     #[test]

--- a/crates/p9-2020-clement-precession/src/resonance.rs
+++ b/crates/p9-2020-clement-precession/src/resonance.rs
@@ -15,6 +15,7 @@
 use p9_core::analysis::resonance::resonance_semi_major_axis;
 use p9_core::constants::A_NEPTUNE_AU;
 use p9_core::data::etno::{Etno, BROWN_2017_SAMPLE};
+use p9_core::units::{au, Length};
 
 /// A located Neptune exterior resonance.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -39,6 +40,11 @@ impl Resonance {
     /// "n:m" label, e.g. "5:1".
     pub fn label(&self) -> String {
         format!("{}:{}", self.n, self.m)
+    }
+
+    /// Resonance semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_au)
     }
 }
 
@@ -95,6 +101,18 @@ pub struct EtnoResonance {
     /// Signed offset a_etno − a_res (AU); negative means interior to the
     /// resonance.
     pub offset_au: f64,
+}
+
+impl EtnoResonance {
+    /// ETNO semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_au)
+    }
+
+    /// Signed offset from the nearest resonance as a typed [`Length`].
+    pub fn offset(&self) -> Length {
+        au(self.offset_au)
+    }
 }
 
 /// Match every member of the Brown (2017) clustered sample to its nearest
@@ -159,6 +177,28 @@ mod tests {
         for w in all.windows(2) {
             assert!(w[0].a_au <= w[1].a_au, "catalog must be a-sorted");
         }
+    }
+
+    #[test]
+    fn test_typed_accessors_match_f64() {
+        use uom::si::length::astronomical_unit;
+        let matches = match_sample_to_resonances();
+        let m = &matches[0];
+        assert_relative_eq!(
+            m.semi_major_axis().get::<astronomical_unit>(),
+            m.a_au,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            m.offset().get::<astronomical_unit>(),
+            m.offset_au,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            m.resonance.semi_major_axis().get::<astronomical_unit>(),
+            m.resonance.a_au,
+            epsilon = 1e-9
+        );
     }
 
     #[test]


### PR DESCRIPTION
Adopts the `p9_core::units` typed boundary additively across batch 5 crates. Every change is a NEW typed accessor returning a `uom` quantity alongside the existing `f64` field/method; no existing signatures, fields, or test reference values were touched. Each new accessor is pinned against its `f64` source with a unit test. `uom 0.38.0` added as a dev-dependency in each crate for the `.get::<unit>()` assertions.

Per crate:
- **p9-2018-wise-search** — `ReferenceP9::{mass, distance}`, `P9Thermal::{mass, distance, radius}`, `WiseSurvey::galactic_mask` (Angle).
- **p9-2019-clustering** — `ClusteringResult::{mean_varpi_angle, mean_omega_angle}` (Angle). Clustering distances / p-values are dimensionless and left alone.
- **p9-2019-ossos-scattering** — `BoundaryPoint::{semi_major_axis, critical_perihelion}`, `ScatteringTno::{semi_major_axis, perihelion}`, `PlanetNine::{mass, semi_major_axis, gm_typed}`.
- **p9-2019-review** — `P9PhysicalProperties::radius`, `BrightnessEstimate::mass`, `P9ParamsSummary::{mass, semi_major_axis, inclination}`, `SimulationScore::a_c_length`. V-band magnitudes and the generic `ParameterRange` container are dimensionless/ambiguous and left alone.
- **p9-2019-selfgrav-disk** — `SecularSolution::{precession_rate (AngularVelocity), precession_period (Time), varpi_forced_angle, varpi_disk_angle, forced_delta_varpi_angle}`, `DiskProfile::{inner_radius, outer_radius, mass, varpi_disk_angle}`, `Ring::{semi_major_axis, varpi_angle, mass}`. No nalgebra vectors converted.
- **p9-2019-tess-yield** — `ReferenceBox::{mass_range, distance_range}` (typed pairs). `TessStack` is pure magnitudes (dimensionless) — skipped.
- **p9-2020-clement-precession** — `Summary::{semi_major_axis, giant_precession_rate, combined_precession_rate (AngularVelocity), giant_period, combined_period (Time)}`, `Resonance::semi_major_axis`, `EtnoResonance::{semi_major_axis, offset}`, `Perturber::{semi_major_axis, mass}`.

No crate was fully skipped; the dimensionless surfaces noted above were intentionally left as-is.

`cargo build` / `cargo test` pass for all seven crates; `cargo fmt` clean.
