### PR TITLE
Typed uom boundary accessors for 2016 obliquity/dynamics crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1285,6 +1286,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1296,6 +1298,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1306,6 +1309,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1317,6 +1321,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1328,6 +1333,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1339,6 +1345,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]

--- a/crates/p9-2016-inclination-instability/Cargo.toml
+++ b/crates/p9-2016-inclination-instability/Cargo.toml
@@ -11,3 +11,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2016-inclination-instability/src/growth.rs
+++ b/crates/p9-2016-inclination-instability/src/growth.rs
@@ -29,6 +29,7 @@
 
 use p9_core::constants::{GM_SUN, GYR_DAYS, TWO_PI, YEAR_DAYS};
 use p9_core::types::OrbitalElements;
+use p9_core::units::{days, radians, AngularVelocity, Time};
 
 /// Dimensionless secular-eigenvalue prefactor in gamma = (M_d/M_sun) n /
 /// C_GROWTH, equivalently tau = (C_GROWTH/2pi) * t_sec with t_sec = (M_sun/M_d)P.
@@ -95,10 +96,80 @@ pub fn efolding_time_gyr(m_disk_solar: f64, a: f64) -> f64 {
     efolding_time_days(m_disk_solar, a) / GYR_DAYS
 }
 
+// ---- typed (uom) boundary: dimension-checked views of the rates/times above ----
+
+/// Mean motion [`n`](mean_motion) as a typed [`AngularVelocity`].
+pub fn mean_motion_typed(a: f64) -> AngularVelocity {
+    (radians(mean_motion(a)) / days(1.0)).into()
+}
+
+/// Orbital period [`P`](orbital_period) as a typed [`Time`].
+pub fn orbital_period_typed(a: f64) -> Time {
+    days(orbital_period(a))
+}
+
+/// Disc secular precession frequency [`omega_sec`](secular_frequency) as a
+/// typed [`AngularVelocity`].
+pub fn secular_frequency_typed(m_disk_solar: f64, a: f64) -> AngularVelocity {
+    (radians(secular_frequency(m_disk_solar, a)) / days(1.0)).into()
+}
+
+/// Disc secular time [`t_sec`](secular_time_days) as a typed [`Time`].
+pub fn secular_time_typed(m_disk_solar: f64, a: f64) -> Time {
+    days(secular_time_days(m_disk_solar, a))
+}
+
+/// Linear-theory growth rate [`gamma`](growth_rate) as a typed
+/// [`AngularVelocity`].
+pub fn growth_rate_typed(m_disk_solar: f64, a: f64) -> AngularVelocity {
+    (radians(growth_rate(m_disk_solar, a)) / days(1.0)).into()
+}
+
+/// E-folding time [`tau`](efolding_time_days) as a typed [`Time`].
+pub fn efolding_time_typed(m_disk_solar: f64, a: f64) -> Time {
+    days(efolding_time_days(m_disk_solar, a))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use p9_core::constants::EARTH_MASS_SOLAR;
+    use uom::si::angular_velocity::radian_per_second;
+    use uom::si::time::day;
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        let m = 20.0 * EARTH_MASS_SOLAR;
+        let a = 250.0;
+        // rates: rad/day -> compare in rad/s
+        let per_day_to_per_s = 1.0 / 86_400.0;
+        assert_relative_eq!(
+            mean_motion_typed(a).get::<radian_per_second>(),
+            mean_motion(a) * per_day_to_per_s,
+            epsilon = 1e-30
+        );
+        assert_relative_eq!(
+            secular_frequency_typed(m, a).get::<radian_per_second>(),
+            secular_frequency(m, a) * per_day_to_per_s,
+            epsilon = 1e-30
+        );
+        assert_relative_eq!(
+            growth_rate_typed(m, a).get::<radian_per_second>(),
+            growth_rate(m, a) * per_day_to_per_s,
+            epsilon = 1e-30
+        );
+        // times: days
+        assert_relative_eq!(orbital_period_typed(a).get::<day>(), orbital_period(a));
+        assert_relative_eq!(
+            secular_time_typed(m, a).get::<day>(),
+            secular_time_days(m, a)
+        );
+        assert_relative_eq!(
+            efolding_time_typed(m, a).get::<day>(),
+            efolding_time_days(m, a)
+        );
+    }
 
     /// Madigan & McCourt's fiducial disc: ~tens of Earth masses spread over
     /// a few hundred AU. We use 20 M_earth at a = 250 AU as a fiducial massive

--- a/crates/p9-2016-inclination-instability/src/suppression.rs
+++ b/crates/p9-2016-inclination-instability/src/suppression.rs
@@ -33,6 +33,7 @@
 
 use p9_core::constants::{A_NEPTUNE_AU, EARTH_MASS_SOLAR, MASS_NEPTUNE_SOLAR};
 use p9_core::forces::j2_secular::{combined_j2_jsu, effective_j2};
+use p9_core::units::{days, radians, solar_masses, AngularVelocity, Mass};
 
 use crate::growth::{mean_motion, secular_frequency};
 
@@ -67,6 +68,17 @@ pub fn critical_mass_earth(a: f64, e: f64) -> f64 {
     critical_mass_solar(a, e) / EARTH_MASS_SOLAR
 }
 
+/// Giant-planet precession rate [`g`](giant_planet_precession_rate) as a typed
+/// [`AngularVelocity`].
+pub fn giant_planet_precession_rate_typed(a: f64, e: f64) -> AngularVelocity {
+    (radians(giant_planet_precession_rate(a, e)) / days(1.0)).into()
+}
+
+/// Critical disc mass [`M_crit`](critical_mass_solar) as a typed [`Mass`].
+pub fn critical_mass(a: f64, e: f64) -> Mass {
+    solar_masses(critical_mass_solar(a, e))
+}
+
 /// Stability verdict for a disc of mass `m_disk_solar` at (a, e).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Stability {
@@ -91,9 +103,27 @@ pub fn classify(m_disk_solar: f64, a: f64, e: f64) -> Stability {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+    use p9_core::units::SOLAR_MASS_KG;
+    use uom::si::angular_velocity::radian_per_second;
+    use uom::si::mass::kilogram;
 
     const A_AU: f64 = 250.0;
     const E_DISK: f64 = 0.6;
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        assert_relative_eq!(
+            giant_planet_precession_rate_typed(A_AU, E_DISK).get::<radian_per_second>(),
+            giant_planet_precession_rate(A_AU, E_DISK) / 86_400.0,
+            epsilon = 1e-30
+        );
+        assert_relative_eq!(
+            critical_mass(A_AU, E_DISK).get::<kilogram>(),
+            critical_mass_solar(A_AU, E_DISK) * SOLAR_MASS_KG,
+            epsilon = 1e10
+        );
+    }
 
     #[test]
     fn test_critical_mass_is_positive() {

--- a/crates/p9-2016-inclined-tnos/Cargo.toml
+++ b/crates/p9-2016-inclined-tnos/Cargo.toml
@@ -15,3 +15,4 @@ rayon = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2016-inclined-tnos/src/simulation.rs
+++ b/crates/p9-2016-inclined-tnos/src/simulation.rs
@@ -12,6 +12,7 @@ use p9_core::initial_conditions::planets;
 use p9_core::initial_conditions::scattered_disk::{generate_scattered_disk, ScatteredDiskConfig};
 use p9_core::integrator::hybrid::hybrid_step;
 use p9_core::types::*;
+use p9_core::units::{au, days, radians, Angle, Length, Time};
 
 use crate::kozai_lidov::ParticleHistory;
 
@@ -76,6 +77,41 @@ impl InclinedTnoConfig {
             snapshot_interval: 5e3 * YEAR_DAYS,
         }
     }
+
+    // ---- typed (uom) boundary: dimension-checked views of the f64 fields ----
+
+    /// Minimum semi-major axis as a [`Length`].
+    pub fn semi_major_axis_min(&self) -> Length {
+        au(self.a_min)
+    }
+    /// Maximum semi-major axis as a [`Length`].
+    pub fn semi_major_axis_max(&self) -> Length {
+        au(self.a_max)
+    }
+    /// Minimum perihelion distance as a [`Length`].
+    pub fn perihelion_min(&self) -> Length {
+        au(self.q_min)
+    }
+    /// Maximum perihelion distance as a [`Length`].
+    pub fn perihelion_max(&self) -> Length {
+        au(self.q_max)
+    }
+    /// Inclination dispersion as an [`Angle`].
+    pub fn inclination_dispersion(&self) -> Angle {
+        radians(self.sigma_i)
+    }
+    /// Total integration time as a [`Time`].
+    pub fn total_time(&self) -> Time {
+        days(self.t_total)
+    }
+    /// Integration timestep as a [`Time`].
+    pub fn timestep(&self) -> Time {
+        days(self.dt)
+    }
+    /// Snapshot interval as a [`Time`].
+    pub fn snapshot_interval_typed(&self) -> Time {
+        days(self.snapshot_interval)
+    }
 }
 
 /// Snapshot of particle state at a given time.
@@ -88,6 +124,13 @@ pub struct TnoSnapshot {
     pub ids: Vec<usize>,
     pub active_count: usize,
     pub total_count: usize,
+}
+
+impl TnoSnapshot {
+    /// Snapshot time as a [`Time`].
+    pub fn time(&self) -> Time {
+        days(self.t)
+    }
 }
 
 /// Result of the full simulation.
@@ -360,6 +403,26 @@ pub fn density_map_qi(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+    use uom::si::angle::radian;
+    use uom::si::length::astronomical_unit;
+    use uom::si::time::day;
+
+    #[test]
+    fn typed_config_accessors_match_f64_fields() {
+        let c = InclinedTnoConfig::nominal();
+        assert_relative_eq!(c.semi_major_axis_min().get::<astronomical_unit>(), c.a_min);
+        assert_relative_eq!(c.semi_major_axis_max().get::<astronomical_unit>(), c.a_max);
+        assert_relative_eq!(c.perihelion_min().get::<astronomical_unit>(), c.q_min);
+        assert_relative_eq!(c.perihelion_max().get::<astronomical_unit>(), c.q_max);
+        assert_relative_eq!(c.inclination_dispersion().get::<radian>(), c.sigma_i);
+        assert_relative_eq!(c.total_time().get::<day>(), c.t_total);
+        assert_relative_eq!(c.timestep().get::<day>(), c.dt);
+        assert_relative_eq!(
+            c.snapshot_interval_typed().get::<day>(),
+            c.snapshot_interval
+        );
+    }
 
     #[test]
     fn test_quick_simulation_runs() {

--- a/crates/p9-2016-iorio-precession/Cargo.toml
+++ b/crates/p9-2016-iorio-precession/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2016-iorio-precession/src/lib.rs
+++ b/crates/p9-2016-iorio-precession/src/lib.rs
@@ -59,6 +59,7 @@ use serde::{Deserialize, Serialize};
 
 use p9_core::analysis::secular::perturber_perihelion_precession;
 use p9_core::constants::GM_SUN;
+use p9_core::units::{arcseconds, au, days, julian_centuries, radians, AngularVelocity, Length};
 
 // Reuse the 2026 sibling's perturber model and consistency check verbatim.
 pub use p9_2026_iorio_precession::{
@@ -88,6 +89,24 @@ impl PlanetBound {
     /// Keplerian mean motion n = sqrt(GM_sun / a^3) in radians/day.
     pub fn mean_motion_rad_per_day(&self) -> f64 {
         (GM_SUN / self.a_au.powi(3)).sqrt()
+    }
+
+    // ---- typed (uom) boundary: dimension-checked views of the f64 fields ----
+
+    /// Semi-major axis as a [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_au)
+    }
+
+    /// Adopted anomalous-precession bound as a typed [`AngularVelocity`]
+    /// (arcseconds per Julian century).
+    pub fn bound(&self) -> AngularVelocity {
+        (arcseconds(self.bound_arcsec_per_cy) / julian_centuries(1.0)).into()
+    }
+
+    /// Keplerian mean motion as a typed [`AngularVelocity`].
+    pub fn mean_motion(&self) -> AngularVelocity {
+        (radians(self.mean_motion_rad_per_day()) / days(1.0)).into()
     }
 }
 
@@ -172,6 +191,14 @@ pub fn planet_perihelion_precession_arcsec_per_cy(planet: &PlanetBound, p9: &Per
     perturber_perihelion_precession(planet.a_au, planet.e, p9.mass_solar(), p9.a_au, p9.e)
 }
 
+/// Predicted perihelion precession of `planet` induced by `p9`, as a typed
+/// [`AngularVelocity`] (the dimension-checked view of
+/// [`planet_perihelion_precession_arcsec_per_cy`]).
+pub fn planet_perihelion_precession(planet: &PlanetBound, p9: &Perturber) -> AngularVelocity {
+    (arcseconds(planet_perihelion_precession_arcsec_per_cy(planet, p9)) / julian_centuries(1.0))
+        .into()
+}
+
 /// True if this perturber's predicted precession of `planet` exceeds the
 /// planet's adopted ephemeris bound (and is therefore *excluded* by that
 /// planet's ranging).
@@ -209,6 +236,12 @@ pub fn critical_distance_au(planet: &PlanetBound, p9: &Perturber) -> f64 {
     p9.a_au * (rate / planet.bound_arcsec_per_cy).cbrt()
 }
 
+/// Critical perturber distance as a typed [`Length`] (the dimension-checked
+/// view of [`critical_distance_au`]).
+pub fn critical_distance(planet: &PlanetBound, p9: &Perturber) -> Length {
+    au(critical_distance_au(planet, p9))
+}
+
 /// The three P9 hypotheses, re-exported from the 2026 sibling
 /// (`Perturber::planet_nine / planet_x / planet_y`).
 pub fn hypotheses() -> [Perturber; 3] {
@@ -226,6 +259,38 @@ mod tests {
 
     fn saturn() -> PlanetBound {
         bound_for("Saturn").unwrap()
+    }
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        use uom::si::angular_velocity::radian_per_second;
+        use uom::si::length::astronomical_unit;
+
+        let s = saturn();
+        let p9 = Perturber::planet_nine();
+        // arcsec/century -> rad/s
+        let arcsec = std::f64::consts::PI / (180.0 * 3600.0);
+        let cy_s = 36_525.0 * 86_400.0;
+        assert_relative_eq!(s.semi_major_axis().get::<astronomical_unit>(), s.a_au);
+        assert_relative_eq!(
+            s.bound().get::<radian_per_second>(),
+            s.bound_arcsec_per_cy * arcsec / cy_s,
+            epsilon = 1e-30
+        );
+        assert_relative_eq!(
+            s.mean_motion().get::<radian_per_second>(),
+            s.mean_motion_rad_per_day() / 86_400.0,
+            epsilon = 1e-30
+        );
+        assert_relative_eq!(
+            planet_perihelion_precession(&s, &p9).get::<radian_per_second>(),
+            planet_perihelion_precession_arcsec_per_cy(&s, &p9) * arcsec / cy_s,
+            epsilon = 1e-30
+        );
+        assert_relative_eq!(
+            critical_distance(&s, &p9).get::<astronomical_unit>(),
+            critical_distance_au(&s, &p9)
+        );
     }
 
     #[test]

--- a/crates/p9-2016-linder-evolution/Cargo.toml
+++ b/crates/p9-2016-linder-evolution/Cargo.toml
@@ -10,3 +10,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2016-linder-evolution/src/lib.rs
+++ b/crates/p9-2016-linder-evolution/src/lib.rs
@@ -37,6 +37,7 @@ pub mod reference;
 pub mod thermal;
 
 use p9_core::analysis::photometry::planet_apparent_magnitude;
+use p9_core::units::{au, earth_masses, Length, Mass};
 
 /// Neptune-like geometric albedo used for the reflected-light channel, matching
 /// the workspace default (`p9_core::analysis::photometry::ALBEDO_NEPTUNE`).
@@ -65,6 +66,19 @@ pub struct MagnitudeRow {
     pub v_mag: f64,
     /// Thermal apparent magnitude in the most-favorable mid-IR band (WISE W4).
     pub mid_ir_mag: f64,
+}
+
+impl MagnitudeRow {
+    // ---- typed (uom) boundary: dimension-checked views of the f64 fields ----
+
+    /// Planet mass as a [`Mass`].
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+    /// Heliocentric distance as a [`Length`].
+    pub fn distance(&self) -> Length {
+        au(self.distance_au)
+    }
 }
 
 /// Build a [`MagnitudeRow`] for the given mass and distance.
@@ -102,6 +116,20 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use p9_core::analysis::surveys::limiting_magnitude;
+    use p9_core::units::EARTH_MASS_KG;
+    use uom::si::length::astronomical_unit;
+    use uom::si::mass::kilogram;
+
+    #[test]
+    fn typed_row_accessors_match_f64_fields() {
+        let row = magnitude_row(10.0, 700.0);
+        assert_relative_eq!(
+            row.mass().get::<kilogram>(),
+            row.mass_earth * EARTH_MASS_KG,
+            epsilon = 1.0
+        );
+        assert_relative_eq!(row.distance().get::<astronomical_unit>(), row.distance_au);
+    }
 
     #[test]
     fn ten_earth_mass_at_700au_matches_published_v() {

--- a/crates/p9-2016-linder-evolution/src/thermal.rs
+++ b/crates/p9-2016-linder-evolution/src/thermal.rs
@@ -35,6 +35,7 @@
 use p9_core::analysis::photometry::mass_radius_neptunian;
 use p9_core::analysis::thermal::{flux_to_magnitude, thermal_flux_jy, C_LIGHT};
 use p9_core::constants::EARTH_RADIUS_KM;
+use p9_core::units::{au, earth_masses, meters, Length, Mass};
 
 /// Earth radius in meters (from the shared `EARTH_RADIUS_KM`).
 const R_EARTH_M: f64 = EARTH_RADIUS_KM * 1.0e3;
@@ -87,6 +88,11 @@ impl Band {
         micron * 1.0e-6
     }
 
+    /// Effective wavelength as a typed [`Length`].
+    pub fn wavelength(self) -> Length {
+        meters(self.wavelength_m())
+    }
+
     /// Vega-system zero-point flux density in Jansky (a 0.0-mag source).
     pub fn zero_point_jy(self) -> f64 {
         match self {
@@ -119,6 +125,21 @@ impl P9 {
     /// shared with the reflected-light channel).
     pub fn radius_m(&self) -> f64 {
         mass_radius_neptunian(self.mass_earth) * R_EARTH_M
+    }
+
+    // ---- typed (uom) boundary: dimension-checked views ----
+
+    /// Planet mass as a [`Mass`].
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+    /// Heliocentric distance as a [`Length`].
+    pub fn distance(&self) -> Length {
+        au(self.distance_au)
+    }
+    /// Physical radius as a typed [`Length`].
+    pub fn radius(&self) -> Length {
+        meters(self.radius_m())
     }
 
     /// Post-evolution effective temperature (K): the internal-heat floor scaled
@@ -160,6 +181,29 @@ impl P9 {
 mod tests {
     use super::*;
     use crate::reference;
+    use approx::assert_relative_eq;
+    use p9_core::units::EARTH_MASS_KG;
+    use uom::si::length::{astronomical_unit, meter};
+    use uom::si::mass::kilogram;
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        let p = P9 {
+            mass_earth: 10.0,
+            distance_au: 700.0,
+        };
+        assert_relative_eq!(
+            p.mass().get::<kilogram>(),
+            10.0 * EARTH_MASS_KG,
+            epsilon = 1.0
+        );
+        assert_relative_eq!(p.distance().get::<astronomical_unit>(), p.distance_au);
+        assert_relative_eq!(p.radius().get::<meter>(), p.radius_m(), epsilon = 1e-3);
+        assert_relative_eq!(
+            Band::W4.wavelength().get::<meter>(),
+            Band::W4.wavelength_m()
+        );
+    }
 
     fn nominal() -> P9 {
         P9 {

--- a/crates/p9-2016-obliquity-gomes/Cargo.toml
+++ b/crates/p9-2016-obliquity-gomes/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2016-obliquity-gomes/src/lib.rs
+++ b/crates/p9-2016-obliquity-gomes/src/lib.rs
@@ -39,6 +39,7 @@ pub mod precession_model;
 /// Published reference constants from Gomes, Deienno & Morbidelli (2016).
 pub mod reference {
     use p9_core::constants::DEG2RAD;
+    use p9_core::units::{degrees, Angle};
 
     /// Observed solar obliquity: the tilt of the Sun's equator relative to the
     /// invariable (giant-planet) plane, ≈ 6° (degrees).
@@ -47,6 +48,11 @@ pub mod reference {
     /// Observed solar obliquity in radians.
     pub fn observed_solar_obliquity_rad() -> f64 {
         OBSERVED_SOLAR_OBLIQUITY_DEG * DEG2RAD
+    }
+
+    /// Observed solar obliquity as a typed [`Angle`].
+    pub fn observed_solar_obliquity() -> Angle {
+        degrees(OBSERVED_SOLAR_OBLIQUITY_DEG)
     }
 
     /// Nominal Planet Nine mass adopted by Gomes et al. (Earth masses).

--- a/crates/p9-2016-obliquity-gomes/src/precession_model.rs
+++ b/crates/p9-2016-obliquity-gomes/src/precession_model.rs
@@ -42,6 +42,7 @@ use std::f64::consts::PI;
 
 use p9_core::constants::*;
 use p9_core::initial_conditions::giant_planets;
+use p9_core::units::{au, days, earth_masses, radians, Angle, AngularVelocity, Length, Mass, Time};
 
 /// Parameters of the Gomes precession model.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
@@ -77,6 +78,21 @@ impl GomesParams {
     pub fn epsilon_9(&self) -> f64 {
         (1.0 - self.e9 * self.e9).sqrt()
     }
+
+    // ---- typed (uom) boundary: dimension-checked views of the f64 fields ----
+
+    /// Planet Nine mass as a [`Mass`].
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.m9_earth)
+    }
+    /// Planet Nine semi-major axis as a [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a9)
+    }
+    /// Planet Nine inclination as an [`Angle`].
+    pub fn inclination(&self) -> Angle {
+        radians(self.i9)
+    }
 }
 
 /// Giant-planet orbital angular momentum magnitude (M_sun·AU²/day).
@@ -109,6 +125,11 @@ pub fn forced_inclination(p: &GomesParams) -> f64 {
     let l9 = l_p9(p);
     let ltot = l_total(p);
     ((l9 / ltot) * p.i9.sin()).clamp(-1.0, 1.0).asin()
+}
+
+/// [`forced_inclination`] as a typed [`Angle`].
+pub fn forced_inclination_typed(p: &GomesParams) -> Angle {
+    radians(forced_inclination(p))
 }
 
 /// Quadrupole secular coupling constant of two coplanar wires of mass m1, m2
@@ -149,9 +170,19 @@ pub fn precession_rate(p: &GomesParams) -> f64 {
     (3.0 * c * p.i9.cos() * ltot / (lp * l9)).abs()
 }
 
+/// [`precession_rate`] as a typed [`AngularVelocity`].
+pub fn precession_rate_typed(p: &GomesParams) -> AngularVelocity {
+    (radians(precession_rate(p)) / days(1.0)).into()
+}
+
 /// Precession period of the planetary plane about L_tot (days).
 pub fn precession_period(p: &GomesParams) -> f64 {
     2.0 * PI / precession_rate(p)
+}
+
+/// [`precession_period`] as a typed [`Time`].
+pub fn precession_period_typed(p: &GomesParams) -> Time {
+    days(precession_period(p))
 }
 
 /// Solar obliquity induced at time `t` (days), given a fixed primordial solar
@@ -171,6 +202,11 @@ pub fn obliquity_at_time(p: &GomesParams, t: f64) -> f64 {
     2.0 * i_p * (PI * t / t_prec).sin().abs()
 }
 
+/// [`obliquity_at_time`] as a typed [`Angle`].
+pub fn obliquity_at_time_typed(p: &GomesParams, t: f64) -> Angle {
+    radians(obliquity_at_time(p, t))
+}
+
 /// Maximum solar obliquity achievable over a full precession cycle (radians).
 ///
 /// As the planetary plane precesses about L_tot on a cone of half-angle i_p
@@ -183,6 +219,11 @@ pub fn max_obliquity(p: &GomesParams) -> f64 {
     2.0 * forced_inclination(p)
 }
 
+/// [`max_obliquity`] as a typed [`Angle`].
+pub fn max_obliquity_typed(p: &GomesParams) -> Angle {
+    radians(max_obliquity(p))
+}
+
 /// Maximum achievable solar obliquity in degrees.
 pub fn max_obliquity_deg(p: &GomesParams) -> f64 {
     max_obliquity(p) * RAD2DEG
@@ -192,6 +233,11 @@ pub fn max_obliquity_deg(p: &GomesParams) -> f64 {
 pub fn obliquity_over_age(p: &GomesParams) -> f64 {
     let t_age = crate::reference::SOLAR_SYSTEM_AGE_GYR * GYR_DAYS;
     obliquity_at_time(p, t_age)
+}
+
+/// [`obliquity_over_age`] as a typed [`Angle`].
+pub fn obliquity_over_age_typed(p: &GomesParams) -> Angle {
+    radians(obliquity_over_age(p))
 }
 
 /// Convenience: solar obliquity over the age of the Solar System in degrees.
@@ -206,6 +252,17 @@ pub struct ObliquitySample {
     pub t: f64,
     /// Induced solar obliquity (radians).
     pub obliquity: f64,
+}
+
+impl ObliquitySample {
+    /// Time since formation as a [`Time`].
+    pub fn time(&self) -> Time {
+        days(self.t)
+    }
+    /// Induced solar obliquity as an [`Angle`].
+    pub fn obliquity_typed(&self) -> Angle {
+        radians(self.obliquity)
+    }
 }
 
 /// Sample the induced obliquity at `n` evenly spaced times over `[0, t_max]`.
@@ -225,6 +282,45 @@ pub fn obliquity_series(p: &GomesParams, t_max: f64, n: usize) -> Vec<ObliquityS
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
+    use uom::si::angle::radian;
+    use uom::si::angular_velocity::radian_per_second;
+    use uom::si::length::astronomical_unit;
+    use uom::si::time::day;
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        let p = GomesParams::nominal();
+        assert_relative_eq!(p.semi_major_axis().get::<astronomical_unit>(), p.a9);
+        assert_relative_eq!(p.inclination().get::<radian>(), p.i9);
+        assert_relative_eq!(
+            forced_inclination_typed(&p).get::<radian>(),
+            forced_inclination(&p)
+        );
+        assert_relative_eq!(
+            precession_rate_typed(&p).get::<radian_per_second>(),
+            precession_rate(&p) / 86_400.0,
+            epsilon = 1e-40
+        );
+        assert_relative_eq!(
+            precession_period_typed(&p).get::<day>(),
+            precession_period(&p)
+        );
+        assert_relative_eq!(max_obliquity_typed(&p).get::<radian>(), max_obliquity(&p));
+        assert_relative_eq!(
+            obliquity_over_age_typed(&p).get::<radian>(),
+            obliquity_over_age(&p)
+        );
+        let s = ObliquitySample {
+            t: 1.0e9,
+            obliquity: 0.1,
+        };
+        assert_relative_eq!(s.time().get::<day>(), s.t);
+        assert_relative_eq!(s.obliquity_typed().get::<radian>(), s.obliquity);
+        assert_relative_eq!(
+            crate::reference::observed_solar_obliquity().get::<radian>(),
+            crate::reference::observed_solar_obliquity_rad()
+        );
+    }
 
     /// The headline result: a nominal Planet Nine is capable of exciting a
     /// solar obliquity in the published 5-10° band, matching the observed

--- a/crates/p9-2016-obliquity-lai/Cargo.toml
+++ b/crates/p9-2016-obliquity-lai/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2016-obliquity-lai/src/planets.rs
+++ b/crates/p9-2016-obliquity-lai/src/planets.rs
@@ -10,6 +10,7 @@
 
 use p9_core::constants::*;
 use p9_core::initial_conditions::giant_planets::GIANT_PLANETS;
+use p9_core::units::{days, radians, AngularVelocity};
 
 /// Terrestrial planet (mass in M_sun, semi-major axis in AU). Masses from
 /// JPL DE440 GM ratios; semi-major axes are mean osculating values.
@@ -39,6 +40,11 @@ pub fn mean_motion(a_au: f64) -> f64 {
     (G_AU3_MSUN_DAY2 * (a_au * a_au * a_au).recip()).sqrt()
 }
 
+/// [`mean_motion`] as a typed [`AngularVelocity`].
+pub fn mean_motion_typed(a_au: f64) -> AngularVelocity {
+    (radians(mean_motion(a_au)) / days(1.0)).into()
+}
+
 /// Orbital angular momentum of a circular planet, `L = m √(GM_sun a)`,
 /// in M_sun·AU²/day.
 pub fn orbital_angular_momentum(mass_solar: f64, a_au: f64) -> f64 {
@@ -62,6 +68,17 @@ pub fn total_orbital_angular_momentum() -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+    use uom::si::angular_velocity::radian_per_second;
+
+    #[test]
+    fn typed_mean_motion_matches_f64() {
+        assert_relative_eq!(
+            mean_motion_typed(A_JUPITER_AU).get::<radian_per_second>(),
+            mean_motion(A_JUPITER_AU) / 86_400.0,
+            epsilon = 1e-30
+        );
+    }
 
     #[test]
     fn total_l_matches_lai_1p624_lj() {

--- a/crates/p9-2016-obliquity-lai/src/precession.rs
+++ b/crates/p9-2016-obliquity-lai/src/precession.rs
@@ -5,6 +5,7 @@
 use std::f64::consts::PI;
 
 use p9_core::constants::*;
+use p9_core::units::{au, days, earth_masses, radians, Angle, AngularVelocity, Length, Mass};
 
 use crate::planets;
 
@@ -71,6 +72,25 @@ impl PlanetNine {
     pub fn angular_momentum(&self) -> f64 {
         planets::orbital_angular_momentum(self.mass_solar(), self.a_tilde_au())
     }
+
+    // ---- typed (uom) boundary: dimension-checked views ----
+
+    /// Planet Nine mass as a [`Mass`].
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+    /// Planet Nine semi-major axis as a [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_au)
+    }
+    /// Planet Nine inclination as an [`Angle`].
+    pub fn inclination(&self) -> Angle {
+        radians(self.inclination_rad)
+    }
+    /// Effective semi-major axis ãₚ as a typed [`Length`].
+    pub fn a_tilde(&self) -> Length {
+        au(self.a_tilde_au())
+    }
 }
 
 /// Differential nodal precession rate Ω_jp that P9 induces on canonical planet
@@ -99,6 +119,11 @@ pub fn omega_l(p9: &PlanetNine) -> f64 {
     num / l_total
 }
 
+/// [`omega_l`] as a typed [`AngularVelocity`].
+pub fn omega_l_typed(p9: &PlanetNine) -> AngularVelocity {
+    (radians(omega_l(p9)) / days(1.0)).into()
+}
+
 /// Solar spin-axis precession frequency Ω★ps driven by the planetary torques
 /// on the solar rotational bulge (Lai Eq. 7), in rad/day:
 ///
@@ -112,6 +137,11 @@ pub fn omega_spin_precession(spin_period_days: f64) -> f64 {
         .iter()
         .map(|&(m, a)| coeff * (m / 1.0) * (RADIUS_SUN_AU / a).powi(3) * omega_star)
         .sum()
+}
+
+/// [`omega_spin_precession`] as a typed [`AngularVelocity`].
+pub fn omega_spin_precession_typed(spin_period_days: f64) -> AngularVelocity {
+    (radians(omega_spin_precession(spin_period_days)) / days(1.0)).into()
 }
 
 /// The two precession frequencies of the spin equation in the frame
@@ -135,6 +165,18 @@ pub fn corotating_frequencies(p9: &PlanetNine, spin_period_days: f64) -> (f64, f
     (omega_y, omega_z)
 }
 
+/// [`corotating_frequencies`] as typed [`AngularVelocity`] pair `(Ω_y, Ω_z)`.
+pub fn corotating_frequencies_typed(
+    p9: &PlanetNine,
+    spin_period_days: f64,
+) -> (AngularVelocity, AngularVelocity) {
+    let (omega_y, omega_z) = corotating_frequencies(p9, spin_period_days);
+    (
+        (radians(omega_y) / days(1.0)).into(),
+        (radians(omega_z) / days(1.0)).into(),
+    )
+}
+
 /// The analytic solar obliquity θsl at time `t` (Lai Eq. 15), in radians:
 ///
 ///   θsl ≃ |(2 Ω_y / Ω_z) sin(Ω_z t / 2)|
@@ -151,6 +193,11 @@ pub fn solar_obliquity_rad(p9: &PlanetNine, spin_period_days: f64, t_gyr: f64) -
     ((2.0 * omega_y / omega_z) * (omega_z * t / 2.0).sin()).abs()
 }
 
+/// [`solar_obliquity_rad`] as a typed [`Angle`].
+pub fn solar_obliquity_typed(p9: &PlanetNine, spin_period_days: f64, t_gyr: f64) -> Angle {
+    radians(solar_obliquity_rad(p9, spin_period_days, t_gyr))
+}
+
 /// Convenience: obliquity in degrees at 4.5 Gyr.
 pub fn solar_obliquity_deg(p9: &PlanetNine, spin_period_days: f64) -> f64 {
     solar_obliquity_rad(p9, spin_period_days, 4.5) * RAD2DEG
@@ -159,6 +206,36 @@ pub fn solar_obliquity_deg(p9: &PlanetNine, spin_period_days: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+    use uom::si::angle::radian;
+    use uom::si::angular_velocity::radian_per_second;
+    use uom::si::length::astronomical_unit;
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        let p9 = nominal_p9();
+        assert_relative_eq!(p9.semi_major_axis().get::<astronomical_unit>(), p9.a_au);
+        assert_relative_eq!(p9.inclination().get::<radian>(), p9.inclination_rad);
+        assert_relative_eq!(p9.a_tilde().get::<astronomical_unit>(), p9.a_tilde_au());
+        assert_relative_eq!(
+            omega_l_typed(&p9).get::<radian_per_second>(),
+            omega_l(&p9) / 86_400.0,
+            epsilon = 1e-40
+        );
+        assert_relative_eq!(
+            omega_spin_precession_typed(10.0).get::<radian_per_second>(),
+            omega_spin_precession(10.0) / 86_400.0,
+            epsilon = 1e-40
+        );
+        let (y, z) = corotating_frequencies(&p9, 20.0);
+        let (yt, zt) = corotating_frequencies_typed(&p9, 20.0);
+        assert_relative_eq!(yt.get::<radian_per_second>(), y / 86_400.0, epsilon = 1e-40);
+        assert_relative_eq!(zt.get::<radian_per_second>(), z / 86_400.0, epsilon = 1e-40);
+        assert_relative_eq!(
+            solar_obliquity_typed(&p9, 20.0, 4.5).get::<radian>(),
+            solar_obliquity_rad(&p9, 20.0, 4.5)
+        );
+    }
 
     /// A nominal P9: 10 m⊕, ãₚ = 400 AU (set via a, e), θₚ = 20°.
     fn nominal_p9() -> PlanetNine {

--- a/crates/p9-2016-obliquity-lai/src/survey.rs
+++ b/crates/p9-2016-obliquity-lai/src/survey.rs
@@ -6,6 +6,8 @@
 
 use std::f64::consts::PI;
 
+use p9_core::units::{au, Length};
+
 use crate::precession::{self, published, PlanetNine};
 
 /// Lai Eq. (19) auxiliary quantities for a target ΔΩ (the relative longitude
@@ -38,6 +40,11 @@ impl NodeGeometry {
 pub fn required_a_tilde(mass_earth: f64, theta_p_rad: f64, geom: &NodeGeometry) -> f64 {
     let inner = (mass_earth / 10.0) * (2.0 * theta_p_rad).sin() / (geom.theta_sl_hat * geom.f);
     published::A_TILDE_PREFACTOR_AU * inner.powf(1.0 / 3.0)
+}
+
+/// [`required_a_tilde`] as a typed [`Length`].
+pub fn required_a_tilde_typed(mass_earth: f64, theta_p_rad: f64, geom: &NodeGeometry) -> Length {
+    au(required_a_tilde(mass_earth, theta_p_rad, geom))
 }
 
 /// Brute-force inversion of the full analytic theory: find the effective
@@ -108,7 +115,18 @@ pub fn eq18_rhs_l_over_lp(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use p9_core::constants::DEG2RAD;
+    use uom::si::length::astronomical_unit;
+
+    #[test]
+    fn typed_required_a_tilde_matches_f64() {
+        let geom = NodeGeometry::new(6.0, 45.0 * DEG2RAD);
+        assert_relative_eq!(
+            required_a_tilde_typed(10.0, 20.0 * DEG2RAD, &geom).get::<astronomical_unit>(),
+            required_a_tilde(10.0, 20.0 * DEG2RAD, &geom)
+        );
+    }
 
     #[test]
     fn eq17_prefactor_lands_in_published_band() {

--- a/crates/p9-2016-obliquity/Cargo.toml
+++ b/crates/p9-2016-obliquity/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2016-obliquity/src/parameter_survey.rs
+++ b/crates/p9-2016-obliquity/src/parameter_survey.rs
@@ -5,6 +5,7 @@
 
 use p9_core::constants::*;
 use p9_core::initial_conditions::giant_planets;
+use p9_core::units::{au, degrees, earth_masses, radians, Angle, Length, Mass};
 
 use crate::secular_hamiltonian::{integrate_obliquity, SecularParams, SpinOrbitState};
 
@@ -18,6 +19,27 @@ pub struct SurveyResult {
     pub required_i9: Option<f64>,
     /// Final obliquity achieved (deg)
     pub final_obliquity_deg: f64,
+}
+
+impl SurveyResult {
+    // ---- typed (uom) boundary: dimension-checked views of the f64 fields ----
+
+    /// Planet Nine mass as a [`Mass`].
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+    /// Planet Nine semi-major axis as a [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a9)
+    }
+    /// Required Planet Nine inclination as an [`Angle`], if a solution exists.
+    pub fn required_inclination(&self) -> Option<Angle> {
+        self.required_i9.map(radians)
+    }
+    /// Final achieved solar obliquity as an [`Angle`].
+    pub fn final_obliquity(&self) -> Angle {
+        degrees(self.final_obliquity_deg)
+    }
 }
 
 /// Find the Planet Nine inclination that produces a target obliquity.
@@ -165,6 +187,32 @@ pub fn quick_survey() -> Vec<SurveyResult> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+    use uom::si::angle::{degree, radian};
+    use uom::si::length::astronomical_unit;
+    use uom::si::mass::kilogram;
+
+    #[test]
+    fn typed_survey_accessors_match_f64_fields() {
+        let r = SurveyResult {
+            mass_earth: 10.0,
+            a9: 700.0,
+            e9: 0.6,
+            required_i9: Some(20.0 * DEG2RAD),
+            final_obliquity_deg: 6.0,
+        };
+        assert_relative_eq!(
+            r.mass().get::<kilogram>(),
+            r.mass_earth * p9_core::units::EARTH_MASS_KG,
+            epsilon = 1.0
+        );
+        assert_relative_eq!(r.semi_major_axis().get::<astronomical_unit>(), r.a9);
+        assert_relative_eq!(
+            r.required_inclination().unwrap().get::<radian>(),
+            r.required_i9.unwrap()
+        );
+        assert_relative_eq!(r.final_obliquity().get::<degree>(), r.final_obliquity_deg);
+    }
 
     #[test]
     fn test_quick_survey_runs() {

--- a/crates/p9-2016-obliquity/src/secular_hamiltonian.rs
+++ b/crates/p9-2016-obliquity/src/secular_hamiltonian.rs
@@ -16,6 +16,7 @@
 use p9_core::analysis::circular::wrap_to_pi;
 use p9_core::constants::*;
 use p9_core::initial_conditions::giant_planets;
+use p9_core::units::{au, days, radians, solar_masses, Angle, Length, Mass, Time};
 
 use crate::solar_model;
 
@@ -79,6 +80,16 @@ impl SpinOrbitState {
             self.l_gp[0] * self.l_9[0] + self.l_gp[1] * self.l_9[1] + self.l_gp[2] * self.l_9[2];
         dot.clamp(-1.0, 1.0).acos()
     }
+
+    /// Solar obliquity [`obliquity`](Self::obliquity) as a typed [`Angle`].
+    pub fn obliquity_typed(&self) -> Angle {
+        radians(self.obliquity())
+    }
+    /// Mutual inclination [`mutual_inclination`](Self::mutual_inclination) as a
+    /// typed [`Angle`].
+    pub fn mutual_inclination_typed(&self) -> Angle {
+        radians(self.mutual_inclination())
+    }
 }
 
 /// Parameters for the secular integration.
@@ -99,6 +110,25 @@ pub struct SecularParams {
 impl SecularParams {
     pub fn epsilon_9(&self) -> f64 {
         (1.0 - self.e9 * self.e9).sqrt()
+    }
+
+    // ---- typed (uom) boundary: dimension-checked views of the f64 fields ----
+
+    /// Planet Nine mass as a [`Mass`].
+    pub fn mass(&self) -> Mass {
+        solar_masses(self.m9_solar)
+    }
+    /// Planet Nine semi-major axis as a [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a9)
+    }
+    /// Total integration time as a [`Time`].
+    pub fn total_time(&self) -> Time {
+        days(self.t_total)
+    }
+    /// Integration time step as a [`Time`].
+    pub fn timestep(&self) -> Time {
+        days(self.dt)
     }
 }
 
@@ -259,6 +289,39 @@ pub struct ObliquitySnapshot {
     pub delta_omega_big: f64,
 }
 
+impl ObliquitySnapshot {
+    // ---- typed (uom) boundary: dimension-checked views of the f64 fields ----
+
+    /// Snapshot time as a [`Time`].
+    pub fn time(&self) -> Time {
+        days(self.t)
+    }
+    /// Solar obliquity as an [`Angle`].
+    pub fn obliquity_typed(&self) -> Angle {
+        radians(self.obliquity)
+    }
+    /// Mutual inclination (giant planets vs P9) as an [`Angle`].
+    pub fn mutual_inclination_typed(&self) -> Angle {
+        radians(self.mutual_inclination)
+    }
+    /// Solar spin node longitude as an [`Angle`].
+    pub fn omega_big_sun_typed(&self) -> Angle {
+        radians(self.omega_big_sun)
+    }
+    /// Planet Nine inclination as an [`Angle`].
+    pub fn i9_typed(&self) -> Angle {
+        radians(self.i_9)
+    }
+    /// Planet Nine node longitude as an [`Angle`].
+    pub fn omega_big_9_typed(&self) -> Angle {
+        radians(self.omega_big_9)
+    }
+    /// ΔΩ = Ω_sun − Ω_9 as an [`Angle`].
+    pub fn delta_omega_typed(&self) -> Angle {
+        radians(self.delta_omega_big)
+    }
+}
+
 /// Integrate the secular spin-orbit equations over the solar system lifetime.
 ///
 /// Uses RK4 with time-dependent coupling (Skumanich spin-down).
@@ -372,7 +435,51 @@ fn make_snapshot(state: &SpinOrbitState, t: f64) -> ObliquitySnapshot {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use std::f64::consts::PI;
+    use uom::si::angle::radian;
+    use uom::si::length::astronomical_unit;
+    use uom::si::time::day;
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        let params = SecularParams {
+            m9_solar: 10.0 * EARTH_MASS_SOLAR,
+            a9: 700.0,
+            e9: 0.6,
+            t_total: 4.5 * GYR_DAYS,
+            dt: 1e5 * YEAR_DAYS,
+        };
+        assert_relative_eq!(
+            params.semi_major_axis().get::<astronomical_unit>(),
+            params.a9
+        );
+        assert_relative_eq!(params.total_time().get::<day>(), params.t_total);
+        assert_relative_eq!(params.timestep().get::<day>(), params.dt);
+
+        let state = SpinOrbitState::from_inclinations(0.5, 1.0, 1.0, 0.3);
+        assert_relative_eq!(state.obliquity_typed().get::<radian>(), state.obliquity());
+        assert_relative_eq!(
+            state.mutual_inclination_typed().get::<radian>(),
+            state.mutual_inclination()
+        );
+
+        let snap = ObliquitySnapshot {
+            t: 1.0e9,
+            obliquity: 0.1,
+            mutual_inclination: 0.2,
+            omega_big_sun: 0.3,
+            i_9: 0.4,
+            omega_big_9: 0.5,
+            delta_omega_big: -0.2,
+        };
+        assert_relative_eq!(snap.time().get::<day>(), snap.t);
+        assert_relative_eq!(snap.obliquity_typed().get::<radian>(), snap.obliquity);
+        assert_relative_eq!(
+            snap.delta_omega_typed().get::<radian>(),
+            snap.delta_omega_big
+        );
+    }
 
     #[test]
     fn test_coupling_constant_positive() {

--- a/crates/p9-2016-obliquity/src/solar_model.rs
+++ b/crates/p9-2016-obliquity/src/solar_model.rs
@@ -9,6 +9,7 @@
 use std::f64::consts::PI;
 
 use p9_core::constants::*;
+use p9_core::units::{au, days, radians, AngularVelocity, Length};
 
 /// Dimensionless moment of inertia for n=3 polytrope (Table 1 of Bailey+2016).
 pub const I_HAT: f64 = 0.08;
@@ -31,6 +32,11 @@ pub const P_SUN_INITIAL_DAYS: f64 = 10.0;
 /// Angular velocity of the Sun from rotation period (rad/day).
 pub fn omega_sun(period_days: f64) -> f64 {
     2.0 * PI / period_days
+}
+
+/// [`omega_sun`] as a typed [`AngularVelocity`].
+pub fn omega_sun_typed(period_days: f64) -> AngularVelocity {
+    (radians(omega_sun(period_days)) / days(1.0)).into()
 }
 
 /// Skumanich spin-down: ω(t) = ω₀ * (t₀/t)^{1/2}, capped at the initial
@@ -56,6 +62,11 @@ pub fn solar_omega_at_time(t: f64, t_age: f64) -> f64 {
     (omega_present * (t_age / t).sqrt()).min(omega_initial)
 }
 
+/// [`solar_omega_at_time`] as a typed [`AngularVelocity`].
+pub fn solar_omega_at_time_typed(t: f64, t_age: f64) -> AngularVelocity {
+    (radians(solar_omega_at_time(t, t_age)) / days(1.0)).into()
+}
+
 /// Spin angular momentum of the Sun: L = I_hat * M * R² * ω
 ///
 /// Returns value in units of M_sun * AU² / day.
@@ -76,9 +87,37 @@ pub fn solar_ring_semimajor_axis(omega: f64) -> f64 {
     (numerator / denominator).powf(1.0 / 3.0)
 }
 
+/// [`solar_ring_semimajor_axis`] as a typed [`Length`].
+pub fn solar_ring_semimajor_axis_typed(omega: f64) -> Length {
+    au(solar_ring_semimajor_axis(omega))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+    use uom::si::angular_velocity::radian_per_second;
+    use uom::si::length::astronomical_unit;
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        let t_age = 4.5 * GYR_DAYS;
+        let omega = omega_sun(P_SUN_PRESENT_DAYS);
+        assert_relative_eq!(
+            omega_sun_typed(P_SUN_PRESENT_DAYS).get::<radian_per_second>(),
+            omega / 86_400.0,
+            epsilon = 1e-30
+        );
+        assert_relative_eq!(
+            solar_omega_at_time_typed(t_age, t_age).get::<radian_per_second>(),
+            solar_omega_at_time(t_age, t_age) / 86_400.0,
+            epsilon = 1e-30
+        );
+        assert_relative_eq!(
+            solar_ring_semimajor_axis_typed(omega).get::<astronomical_unit>(),
+            solar_ring_semimajor_axis(omega)
+        );
+    }
 
     #[test]
     fn test_skumanich_spindown() {


### PR DESCRIPTION
Adopts the `p9_core::units` typed (uom) boundary ADDITIVELY across seven 2016-era crates. Every change is a new accessor/sibling returning a dimension-checked `uom` quantity that wraps the existing `f64` source; no existing `f64` fields, signatures, reference values, or inner physics were touched. Each new accessor is pinned against its `f64` source with `assert_relative_eq!`.

## Per-crate changes

- **p9-2016-inclination-instability** — `growth.rs`: typed `Time`/`AngularVelocity` siblings for `mean_motion`, `orbital_period`, `secular_frequency`, `secular_time_days`, `growth_rate`, `efolding_time`. `suppression.rs`: `giant_planet_precession_rate_typed` (`AngularVelocity`) and `critical_mass` (`Mass`).
- **p9-2016-inclined-tnos** — `simulation.rs`: typed accessors on `InclinedTnoConfig` (a-min/max, q-min/max as `Length`; `sigma_i` as `Angle`; t_total/dt/snapshot_interval as `Time`) and `TnoSnapshot::time()`.
- **p9-2016-iorio-precession** — `PlanetBound`: `semi_major_axis()` (`Length`), `bound()` and `mean_motion()` (`AngularVelocity`, arcsec/cy and rad/day); typed siblings `planet_perihelion_precession` (`AngularVelocity`) and `critical_distance` (`Length`).
- **p9-2016-linder-evolution** — `MagnitudeRow::{mass,distance}`, `thermal::P9::{mass,distance,radius}`, `Band::wavelength()` (`Length`). Skipped temperature (`t_eff_k`), frequency, and magnitudes — no matching quantity type.
- **p9-2016-obliquity** — `solar_model`: typed siblings for `omega_sun`, `solar_omega_at_time` (`AngularVelocity`) and `solar_ring_semimajor_axis` (`Length`). `SurveyResult::{mass,semi_major_axis,required_inclination,final_obliquity}`. `SpinOrbitState::{obliquity_typed,mutual_inclination_typed}`. `SecularParams::{mass,semi_major_axis,total_time,timestep}`. `ObliquitySnapshot` time + all angle fields.
- **p9-2016-obliquity-gomes** — `reference::observed_solar_obliquity()` (`Angle`); `GomesParams::{mass,semi_major_axis,inclination}`; typed siblings for `forced_inclination`, `precession_rate`, `precession_period`, `max_obliquity`, `obliquity_over_age`; `ObliquitySample::{time,obliquity_typed}`.
- **p9-2016-obliquity-lai** — `PlanetNine::{mass,semi_major_axis,inclination,a_tilde}`; typed siblings for `omega_l`, `omega_spin_precession`, `corotating_frequencies`, `solar_obliquity_rad`; `planets::mean_motion_typed`; `survey::required_a_tilde_typed`.

## Skips

No crate was skipped wholesale. Within crates, purely dimensionless or unmatched scalars were intentionally left alone: eccentricities, dimensionless ring/coupling factors (`epsilon_9`, J2_eff area, `NodeGeometry` ratios), angular-momentum magnitudes (no named quantity), effective temperatures (no Temperature constructor in the units API), band frequencies (no Frequency type), and photometric magnitudes/counts.

## Validation

`cargo build` and `cargo test` pass for all seven crates; `cargo fmt` clean; no new warnings. `uom` added as a dev-dependency to each crate for the round-trip assertions.