### PR TITLE
Add typed uom boundary accessors to ten crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,6 +1926,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1937,6 +1938,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1949,6 +1951,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1959,6 +1962,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1971,6 +1975,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1983,6 +1988,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1993,6 +1999,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -2025,6 +2032,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]

--- a/crates/p9-2025-perturbation/Cargo.toml
+++ b/crates/p9-2025-perturbation/Cargo.toml
@@ -13,3 +13,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2025-perturbation/src/resonance.rs
+++ b/crates/p9-2025-perturbation/src/resonance.rs
@@ -19,6 +19,7 @@
 use p9_core::analysis::hansen::{hansen_coefficient, hansen_x_neg3_2_neptune_chain};
 use p9_core::analysis::resonance::resonance_semi_major_axis;
 use p9_core::constants::{A_NEPTUNE_AU, MASS_NEPTUNE_SOLAR};
+use p9_core::units::{au, Length};
 use serde::{Deserialize, Serialize};
 
 /// A resonance in the m:j chain with Neptune.
@@ -34,6 +35,18 @@ pub struct Resonance {
     pub a_nominal: f64,
     /// Resonance half-width (AU)
     pub delta_a: f64,
+}
+
+impl Resonance {
+    /// Nominal semi-major axis as a dimension-checked [`Length`] (AU storage).
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_nominal)
+    }
+
+    /// Resonance half-width as a dimension-checked [`Length`] (AU storage).
+    pub fn half_width(&self) -> Length {
+        au(self.delta_a)
+    }
 }
 
 /// Nominal semi-major axis for an m:j resonance (n/n_N = m/j):
@@ -239,5 +252,23 @@ mod tests {
     fn test_resonance_width_positive() {
         let w = resonance_width(200.0, 2, 0.75, 0.1);
         assert!(w > 0.0);
+    }
+
+    #[test]
+    fn typed_accessors_match_f64_fields() {
+        use approx::assert_relative_eq;
+        use uom::si::length::astronomical_unit;
+
+        let r = &build_2j_chain(10, 10, 35.0)[0];
+        assert_relative_eq!(
+            r.semi_major_axis().get::<astronomical_unit>(),
+            r.a_nominal,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            r.half_width().get::<astronomical_unit>(),
+            r.delta_a,
+            epsilon = 1e-12
+        );
     }
 }

--- a/crates/p9-2025-planet-y/Cargo.toml
+++ b/crates/p9-2025-planet-y/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2025-planet-y/src/laplace_plane.rs
+++ b/crates/p9-2025-planet-y/src/laplace_plane.rs
@@ -56,6 +56,7 @@ use p9_core::constants::{
     MASS_URANUS_SOLAR,
 };
 use p9_core::forces::j2_secular::effective_j2;
+use p9_core::units::{au, degrees, radians, solar_masses, Angle, Length, Mass};
 
 /// Published Planet Y reference numbers (Siraj et al. 2025), kept as labelled
 /// constants so the tests pin against them rather than against magic numbers.
@@ -108,6 +109,20 @@ impl PlanetY {
             a_au,
             inclination: inclination_deg * DEG2RAD,
         }
+    }
+
+    /// Mass as a dimension-checked [`Mass`] (solar-mass storage).
+    pub fn mass(&self) -> Mass {
+        solar_masses(self.mass_solar)
+    }
+    /// Semi-major axis as a dimension-checked [`Length`] (AU storage).
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_au)
+    }
+    /// Orbital-plane inclination as a dimension-checked [`Angle`] (radian
+    /// storage).
+    pub fn inclination_angle(&self) -> Angle {
+        radians(self.inclination)
     }
 }
 
@@ -200,6 +215,17 @@ pub struct ForcedProfilePoint {
     pub i_forced_deg: f64,
 }
 
+impl ForcedProfilePoint {
+    /// Semi-major axis as a dimension-checked [`Length`] (AU storage).
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_au)
+    }
+    /// Forced inclination as a dimension-checked [`Angle`] (degree storage).
+    pub fn forced_inclination_angle(&self) -> Angle {
+        degrees(self.i_forced_deg)
+    }
+}
+
 /// Sample the forced-inclination profile i_forced(a) over a grid of
 /// semi-major axes (AU), inclusive of both endpoints.
 pub fn forced_profile(
@@ -233,6 +259,29 @@ pub struct WarpFeature {
     pub i_outer_deg: f64,
     /// Warp amplitude (deg): rise across the band, i_outer − i_inner.
     pub amplitude_deg: f64,
+}
+
+impl WarpFeature {
+    /// Semi-major axis of the in-band peak as a [`Length`] (AU storage).
+    pub fn a_peak(&self) -> Length {
+        au(self.a_peak_au)
+    }
+    /// Forced tilt at the peak as an [`Angle`] (degree storage).
+    pub fn peak_tilt(&self) -> Angle {
+        degrees(self.i_peak_deg)
+    }
+    /// Forced tilt at the inner band edge as an [`Angle`] (degree storage).
+    pub fn inner_tilt(&self) -> Angle {
+        degrees(self.i_inner_deg)
+    }
+    /// Forced tilt at the outer band edge as an [`Angle`] (degree storage).
+    pub fn outer_tilt(&self) -> Angle {
+        degrees(self.i_outer_deg)
+    }
+    /// Warp amplitude (i_outer − i_inner) as an [`Angle`] (degree storage).
+    pub fn amplitude(&self) -> Angle {
+        degrees(self.amplitude_deg)
+    }
 }
 
 /// Measure the warp feature in the 50–80 AU band: the rise of the forced tilt
@@ -447,5 +496,54 @@ mod tests {
         assert!(neptune_mass_solar() > 0.0);
         let with_n = inner_torque_coeff(60.0);
         assert!(with_n > 0.0);
+    }
+
+    #[test]
+    fn typed_accessors_match_f64_fields() {
+        use uom::si::angle::{degree, radian};
+        use uom::si::length::astronomical_unit;
+        use uom::si::mass::kilogram;
+
+        let py = nominal_planet_y();
+        assert_relative_eq!(
+            py.mass().get::<kilogram>(),
+            solar_masses(py.mass_solar).get::<kilogram>(),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            py.semi_major_axis().get::<astronomical_unit>(),
+            py.a_au,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            py.inclination_angle().get::<radian>(),
+            py.inclination,
+            epsilon = 1e-12
+        );
+
+        let pt = &forced_profile(50.0, 80.0, 11, &py)[5];
+        assert_relative_eq!(
+            pt.semi_major_axis().get::<astronomical_unit>(),
+            pt.a_au,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            pt.forced_inclination_angle().get::<degree>(),
+            pt.i_forced_deg,
+            epsilon = 1e-12
+        );
+
+        let w = warp_feature(&py);
+        assert_relative_eq!(
+            w.a_peak().get::<astronomical_unit>(),
+            w.a_peak_au,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(w.peak_tilt().get::<degree>(), w.i_peak_deg, epsilon = 1e-12);
+        assert_relative_eq!(
+            w.amplitude().get::<degree>(),
+            w.amplitude_deg,
+            epsilon = 1e-12
+        );
     }
 }

--- a/crates/p9-2025-ps1-holman/Cargo.toml
+++ b/crates/p9-2025-ps1-holman/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2025-ps1-holman/src/exclusion.rs
+++ b/crates/p9-2025-ps1-holman/src/exclusion.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use p9_core::coords::sky::apparent_position_deg;
 use p9_core::data::reference_population::generate_reference_population;
 use p9_core::types::OrbitalElements;
+use p9_core::units::{degrees, Angle};
 
 use crate::survey_model::Ps1StackSurvey;
 
@@ -26,6 +27,13 @@ use crate::survey_model::Ps1StackSurvey;
 pub struct DetectionTarget {
     pub dec_deg: f64,
     pub r_magnitude: f64,
+}
+
+impl DetectionTarget {
+    /// Equatorial declination as a dimension-checked [`Angle`] (degree storage).
+    pub fn declination(&self) -> Angle {
+        degrees(self.dec_deg)
+    }
 }
 
 /// Result of the exclusion analysis.
@@ -109,6 +117,18 @@ pub fn monte_carlo_detected(
 mod tests {
     use super::*;
     use crate::published;
+
+    #[test]
+    fn declination_accessor_matches_f64_field() {
+        use approx::assert_relative_eq;
+        use uom::si::angle::degree;
+
+        let t = DetectionTarget {
+            dec_deg: -12.5,
+            r_magnitude: 22.0,
+        };
+        assert_relative_eq!(t.declination().get::<degree>(), t.dec_deg, epsilon = 1e-12);
+    }
 
     #[test]
     fn exclusion_fraction_in_open_unit_interval() {

--- a/crates/p9-2025-ps1-holman/src/photometry.rs
+++ b/crates/p9-2025-ps1-holman/src/photometry.rs
@@ -8,6 +8,7 @@
 //! sensitivity, which grows with assumed mass.
 
 use p9_core::analysis::photometry::{planet_apparent_magnitude, ALBEDO_NEPTUNE};
+use p9_core::units::{au, Length};
 
 use crate::survey_model::Ps1StackSurvey;
 
@@ -49,6 +50,11 @@ pub fn max_detectable_distance(survey: &Ps1StackSurvey, mass_earth: f64) -> f64 
     0.5 * (lo + hi)
 }
 
+/// [`max_detectable_distance`] as a dimension-checked [`Length`].
+pub fn max_detectable_distance_typed(survey: &Ps1StackSurvey, mass_earth: f64) -> Length {
+    au(max_detectable_distance(survey, mass_earth))
+}
+
 /// Inner bound of the bisection bracket (AU). Objects closer than the giant
 /// planets are outside the P9 search regime.
 pub const R_MIN_AU: f64 = 30.0;
@@ -85,6 +91,17 @@ mod tests {
             "m(r_max) = {:.3} vs depth {:.3}",
             apparent_r_magnitude(6.0, r),
             s.effective_depth()
+        );
+    }
+
+    #[test]
+    fn typed_distance_matches_f64() {
+        use uom::si::length::astronomical_unit;
+        let s = Ps1StackSurvey::default();
+        assert_relative_eq!(
+            max_detectable_distance_typed(&s, 6.0).get::<astronomical_unit>(),
+            max_detectable_distance(&s, 6.0),
+            epsilon = 1e-12
         );
     }
 

--- a/crates/p9-2025-simons-forecast/Cargo.toml
+++ b/crates/p9-2025-simons-forecast/Cargo.toml
@@ -10,3 +10,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2025-simons-forecast/src/forecast.rs
+++ b/crates/p9-2025-simons-forecast/src/forecast.rs
@@ -13,6 +13,8 @@
 //! 3. The detectable fraction of a reference mass–distance box lies in (0, 1)
 //!    and is larger for SO than for ACT.
 
+use p9_core::units::{au, earth_masses, Length, Mass};
+
 use crate::bands::MmSensitivity;
 use crate::thermal::P9Thermal;
 
@@ -44,6 +46,11 @@ pub fn max_detectable_distance(mass_earth: f64, sens: &MmSensitivity) -> f64 {
         }
     }
     0.5 * (lo + hi)
+}
+
+/// [`max_detectable_distance`] as a dimension-checked [`Length`].
+pub fn max_detectable_distance_typed(mass_earth: f64, sens: &MmSensitivity) -> Length {
+    au(max_detectable_distance(mass_earth, sens))
 }
 
 /// Expected detection significance (signal-to-noise ratio) of a Planet Nine of
@@ -89,6 +96,23 @@ impl ReferenceBox {
     /// points whose flux exceeds the sensitivity threshold, by a uniform grid
     /// quadrature. In (0, 1) for a sensitivity that detects part but not all
     /// of the box.
+    /// Lower mass bound as a dimension-checked [`Mass`] (Earth-mass storage).
+    pub fn mass_min(&self) -> Mass {
+        earth_masses(self.mass_min_earth)
+    }
+    /// Upper mass bound as a dimension-checked [`Mass`] (Earth-mass storage).
+    pub fn mass_max(&self) -> Mass {
+        earth_masses(self.mass_max_earth)
+    }
+    /// Lower distance bound as a dimension-checked [`Length`] (AU storage).
+    pub fn dist_min(&self) -> Length {
+        au(self.dist_min_au)
+    }
+    /// Upper distance bound as a dimension-checked [`Length`] (AU storage).
+    pub fn dist_max(&self) -> Length {
+        au(self.dist_max_au)
+    }
+
     pub fn detectable_fraction(&self, sens: &MmSensitivity) -> f64 {
         let n = 200usize;
         let mut detected = 0usize;
@@ -111,6 +135,30 @@ impl ReferenceBox {
 mod tests {
     use super::*;
     use crate::bands::{ACT_SENSITIVITY, SO_SENSITIVITY, SO_SENSITIVITY_SHALLOW};
+
+    #[test]
+    fn typed_boundary_matches_f64() {
+        use approx::assert_relative_eq;
+        use uom::si::length::astronomical_unit;
+        use uom::si::mass::kilogram;
+
+        assert_relative_eq!(
+            max_detectable_distance_typed(5.0, &SO_SENSITIVITY).get::<astronomical_unit>(),
+            max_detectable_distance(5.0, &SO_SENSITIVITY),
+            epsilon = 1e-9
+        );
+        let bx = ReferenceBox::nominal();
+        assert_relative_eq!(
+            bx.dist_min().get::<astronomical_unit>(),
+            bx.dist_min_au,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            bx.mass_max().get::<kilogram>(),
+            earth_masses(bx.mass_max_earth).get::<kilogram>(),
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn reach_increases_with_mass() {

--- a/crates/p9-2025-simons-forecast/src/thermal.rs
+++ b/crates/p9-2025-simons-forecast/src/thermal.rs
@@ -37,6 +37,7 @@ use p9_core::analysis::photometry::mass_radius_neptunian;
 use p9_core::analysis::thermal::{
     effective_temp, planck_bnu, rayleigh_jeans_bnu, solar_equilibrium_temp, thermal_flux_jy,
 };
+use p9_core::units::{au, earth_masses, meters, Length, Mass};
 
 /// Earth radius (m).
 const R_EARTH_M: f64 = 6.371e6;
@@ -81,6 +82,19 @@ impl P9Thermal {
     /// Physical radius in meters (Neptune-anchored mass–radius relation).
     pub fn radius_m(&self) -> f64 {
         mass_radius_neptunian(self.mass_earth) * R_EARTH_M
+    }
+
+    /// Mass as a dimension-checked [`Mass`] (Earth-mass storage).
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+    /// Heliocentric distance as a dimension-checked [`Length`] (AU storage).
+    pub fn distance(&self) -> Length {
+        au(self.distance_au)
+    }
+    /// Physical radius as a dimension-checked [`Length`] (meter storage).
+    pub fn radius(&self) -> Length {
+        meters(self.radius_m())
     }
 
     /// Solar equilibrium temperature (K) for a fast rotator radiating from its
@@ -139,7 +153,31 @@ pub fn flux_mjy(mass_earth: f64, distance_au: f64, nu_ghz: f64) -> f64 {
 mod tests {
     use super::*;
     use crate::bands::SO_280;
+    use approx::assert_relative_eq;
     use p9_core::analysis::thermal::{H_PLANCK, K_BOLTZ};
+
+    #[test]
+    fn typed_accessors_match_f64_fields() {
+        use uom::si::length::{astronomical_unit, meter};
+        use uom::si::mass::kilogram;
+
+        let p = P9Thermal::new(5.0, 500.0);
+        assert_relative_eq!(
+            p.mass().get::<kilogram>(),
+            earth_masses(p.mass_earth).get::<kilogram>(),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            p.distance().get::<astronomical_unit>(),
+            p.distance_au,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            p.radius().get::<meter>(),
+            p.radius_m(),
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn cold_body_is_in_rayleigh_jeans_regime_at_280ghz() {

--- a/crates/p9-2025-stacking/Cargo.toml
+++ b/crates/p9-2025-stacking/Cargo.toml
@@ -13,3 +13,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2025-stacking/src/lib.rs
+++ b/crates/p9-2025-stacking/src/lib.rs
@@ -31,6 +31,9 @@ pub mod significance;
 /// Labelled reference numbers from the paper (for regression comparison only;
 /// every quantity used in tests is computed, not taken from here).
 pub mod published {
+    use p9_core::constants::YEAR_DAYS;
+    use p9_core::units::{days, Time};
+
     /// ZTF single-exposure r-band limiting magnitude (Bellm et al. 2019).
     pub const ZTF_SINGLE_DEPTH: f64 = 20.5;
     /// Headline stacked depth reached for TNOs (~27th magnitude).
@@ -39,4 +42,26 @@ pub mod published {
     pub const TRIAL_ORBITS_ORDER: f64 = 1.0e9;
     /// Survey baseline of the ZTF validation (six years).
     pub const ZTF_BASELINE_YEARS: f64 = 6.0;
+
+    /// [`ZTF_BASELINE_YEARS`] as a dimension-checked [`Time`].
+    pub fn ztf_baseline() -> Time {
+        days(ZTF_BASELINE_YEARS * YEAR_DAYS)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::published::{ztf_baseline, ZTF_BASELINE_YEARS};
+    use approx::assert_relative_eq;
+    use p9_core::constants::YEAR_DAYS;
+    use uom::si::time::day;
+
+    #[test]
+    fn ztf_baseline_matches_f64() {
+        assert_relative_eq!(
+            ztf_baseline().get::<day>(),
+            ZTF_BASELINE_YEARS * YEAR_DAYS,
+            epsilon = 1e-9
+        );
+    }
 }

--- a/crates/p9-2026-apsidal-clustering/Cargo.toml
+++ b/crates/p9-2026-apsidal-clustering/Cargo.toml
@@ -13,3 +13,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2026-apsidal-clustering/src/estimator.rs
+++ b/crates/p9-2026-apsidal-clustering/src/estimator.rs
@@ -19,6 +19,7 @@
 use p9_core::analysis::circular::{
     bessel_i0, circular_mean, kappa_from_r_bar, mean_resultant_length,
 };
+use p9_core::units::{radians, Angle};
 use serde::{Deserialize, Serialize};
 
 /// Maximum-likelihood von Mises fit of a ϖ sample plus the resulting
@@ -35,6 +36,14 @@ pub struct ApsidalFit {
     pub r_bar: f64,
     /// Log-likelihood ratio Λ = ln L(H1) − ln L(H0).
     pub lambda: f64,
+}
+
+impl ApsidalFit {
+    /// Maximum-likelihood mean direction µ as a dimension-checked [`Angle`]
+    /// (radian storage).
+    pub fn mean_direction(&self) -> Angle {
+        radians(self.mu)
+    }
 }
 
 /// Maximum-likelihood von Mises fit (µ = circular mean, κ = A⁻¹(R̄)).
@@ -99,5 +108,19 @@ mod tests {
         let fit = fit(&varpi);
         assert!((fit.mu - 2.0).abs() < 0.05, "µ = {}", fit.mu);
         assert!(fit.kappa > 1.0, "κ = {}", fit.kappa);
+    }
+
+    #[test]
+    fn mean_direction_matches_f64_field() {
+        use approx::assert_relative_eq;
+        use uom::si::angle::radian;
+
+        let varpi: Vec<f64> = (0..20).map(|k| 2.0 + 0.02 * (k as f64 - 10.0)).collect();
+        let fit = fit(&varpi);
+        assert_relative_eq!(
+            fit.mean_direction().get::<radian>(),
+            fit.mu,
+            epsilon = 1e-12
+        );
     }
 }

--- a/crates/p9-2026-iorio-precession/Cargo.toml
+++ b/crates/p9-2026-iorio-precession/Cargo.toml
@@ -11,3 +11,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2026-iorio-precession/src/lib.rs
+++ b/crates/p9-2026-iorio-precession/src/lib.rs
@@ -83,6 +83,10 @@ use serde::{Deserialize, Serialize};
 
 use p9_core::analysis::secular::{coplanar_quadrupole, perturber_perihelion_precession};
 use p9_core::constants::{EARTH_MASS_SOLAR, GM_SUN};
+use p9_core::units::{
+    arcseconds, au, days, earth_masses, gm_from_au3_day2, julian_centuries, radians,
+    AngularVelocity, GravitationalParameter, Length, Mass,
+};
 
 /// Saturn's semi-major axis in AU (JPL mean element, J2000). Labelled here
 /// because `p9-core` does not currently carry an inner/giant-planet semi-major
@@ -128,6 +132,20 @@ impl Perturber {
     /// GM in AU^3/day^2.
     pub fn gm(&self) -> f64 {
         self.mass_solar() * GM_SUN
+    }
+
+    /// Mass as a dimension-checked [`Mass`] (Earth-mass storage).
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+    /// Semi-major axis as a dimension-checked [`Length`] (AU storage).
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_au)
+    }
+    /// Gravitational parameter as a dimension-checked
+    /// [`GravitationalParameter`] (AU³/day² storage).
+    pub fn gm_typed(&self) -> GravitationalParameter {
+        gm_from_au3_day2(self.gm())
     }
 
     /// Planet Nine, Batygin/Brown-class nominal: ~6 Earth masses at ~460 AU,
@@ -177,9 +195,26 @@ pub fn saturn_perihelion_precession_arcsec_per_cy(p: &Perturber) -> f64 {
     perturber_perihelion_precession(A_SATURN_AU, E_SATURN, p.mass_solar(), p.a_au, p.e)
 }
 
+/// [`saturn_perihelion_precession_arcsec_per_cy`] as a dimension-checked
+/// [`AngularVelocity`] (arcsecond-per-century storage).
+pub fn saturn_perihelion_precession(p: &Perturber) -> AngularVelocity {
+    (arcseconds(saturn_perihelion_precession_arcsec_per_cy(p)) / julian_centuries(1.0)).into()
+}
+
+/// The adopted ephemeris bound as a dimension-checked [`AngularVelocity`].
+pub fn saturn_precession_bound() -> AngularVelocity {
+    (arcseconds(SATURN_PRECESSION_BOUND_ARCSEC_PER_CY) / julian_centuries(1.0)).into()
+}
+
 /// Saturn's Keplerian mean motion n = sqrt(GM_sun / a^3) in radians/day.
 pub fn saturn_mean_motion_rad_per_day() -> f64 {
     (GM_SUN / A_SATURN_AU.powi(3)).sqrt()
+}
+
+/// [`saturn_mean_motion_rad_per_day`] as a dimension-checked
+/// [`AngularVelocity`] (radian-per-day storage).
+pub fn saturn_mean_motion() -> AngularVelocity {
+    (radians(saturn_mean_motion_rad_per_day()) / days(1.0)).into()
 }
 
 /// True if this perturber's predicted Saturn precession exceeds the adopted
@@ -234,6 +269,11 @@ pub fn hypotheses() -> [Perturber; 3] {
 pub fn critical_distance_au(p: &Perturber) -> f64 {
     let rate = saturn_perihelion_precession_arcsec_per_cy(p).abs();
     p.a_au * (rate / SATURN_PRECESSION_BOUND_ARCSEC_PER_CY).cbrt()
+}
+
+/// [`critical_distance_au`] as a dimension-checked [`Length`] (AU storage).
+pub fn critical_distance(p: &Perturber) -> Length {
+    au(critical_distance_au(p))
 }
 
 #[cfg(test)]
@@ -374,6 +414,57 @@ mod tests {
             let ratio = quadrupole_prefactor_consistency(&p);
             assert_relative_eq!(ratio, 1.0, max_relative = 1e-12);
         }
+    }
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        use uom::si::angle::radian;
+        use uom::si::angular_velocity::radian_per_second;
+        use uom::si::length::astronomical_unit;
+        use uom::si::mass::kilogram;
+        use uom::si::time::second;
+
+        let p = Perturber::planet_x();
+
+        assert_relative_eq!(
+            p.mass().get::<kilogram>(),
+            earth_masses(p.mass_earth).get::<kilogram>(),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            p.semi_major_axis().get::<astronomical_unit>(),
+            p.a_au,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            p.gm_typed().value,
+            gm_from_au3_day2(p.gm()).value,
+            max_relative = 1e-12
+        );
+
+        // Mean motion rad/day -> rad/s.
+        let n_rad_s = saturn_mean_motion().get::<radian_per_second>();
+        assert_relative_eq!(
+            n_rad_s * 86_400.0,
+            saturn_mean_motion_rad_per_day(),
+            max_relative = 1e-12
+        );
+
+        // Perihelion precession arcsec/century -> rad/s.
+        let arcsec_rad = arcseconds(1.0).get::<radian>();
+        let century_s = julian_centuries(1.0).get::<second>();
+        let rate_rad_s = saturn_perihelion_precession(&p).get::<radian_per_second>();
+        assert_relative_eq!(
+            rate_rad_s * century_s / arcsec_rad,
+            saturn_perihelion_precession_arcsec_per_cy(&p),
+            max_relative = 1e-9
+        );
+
+        assert_relative_eq!(
+            critical_distance(&p).get::<astronomical_unit>(),
+            critical_distance_au(&p),
+            epsilon = 1e-9
+        );
     }
 
     #[test]

--- a/crates/p9-survey/Cargo.toml
+++ b/crates/p9-survey/Cargo.toml
@@ -14,3 +14,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-survey/src/schema.rs
+++ b/crates/p9-survey/src/schema.rs
@@ -13,6 +13,7 @@
 //! the telescope's stated band, treated as a reflected-light proxy).
 
 use p9_core::analysis::surveys::Footprint;
+use p9_core::units::{au, degrees, earth_masses, Angle, Length, Mass};
 use serde::{Deserialize, Serialize};
 
 /// Schema version. The Python loader asserts the file matches this exactly.
@@ -49,6 +50,33 @@ pub struct OrbitSolution {
     pub omega_big_sigma_deg: f64,
     /// Provenance note: where each number comes from, what is assumed.
     pub note: String,
+}
+
+impl OrbitSolution {
+    // ---- typed boundary accessors (dimension-checked views of the wire
+    // fields; the serialized schema is unchanged) ----
+
+    /// Perturber mass as a dimension-checked [`Mass`] (Earth-mass storage).
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+    /// Semi-major axis as a dimension-checked [`Length`] (AU storage).
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_au)
+    }
+    /// Inclination as a dimension-checked [`Angle`] (degree storage).
+    pub fn inclination(&self) -> Angle {
+        degrees(self.i_deg)
+    }
+    /// Argument of perihelion as a dimension-checked [`Angle`] (degree storage).
+    pub fn argument_of_perihelion(&self) -> Angle {
+        degrees(self.omega_deg)
+    }
+    /// Longitude of ascending node as a dimension-checked [`Angle`] (degree
+    /// storage).
+    pub fn longitude_of_node(&self) -> Angle {
+        degrees(self.omega_big_deg)
+    }
 }
 
 /// The fixed RA/Dec grid the probability maps live on. Cell `(i_ra, i_dec)`
@@ -113,6 +141,29 @@ pub struct StudyResult {
     pub v_p84: f64,
 }
 
+impl StudyResult {
+    /// Most-probable-cell RA as a dimension-checked [`Angle`] (degree storage).
+    pub fn peak_ra(&self) -> Angle {
+        degrees(self.peak_ra_deg)
+    }
+    /// Most-probable-cell Dec as a dimension-checked [`Angle`] (degree storage).
+    pub fn peak_dec(&self) -> Angle {
+        degrees(self.peak_dec_deg)
+    }
+    /// 16th-percentile heliocentric distance as a [`Length`] (AU storage).
+    pub fn dist_p16(&self) -> Length {
+        au(self.dist_p16_au)
+    }
+    /// Median heliocentric distance as a [`Length`] (AU storage).
+    pub fn dist_median(&self) -> Length {
+        au(self.dist_median_au)
+    }
+    /// 84th-percentile heliocentric distance as a [`Length`] (AU storage).
+    pub fn dist_p84(&self) -> Length {
+        au(self.dist_p84_au)
+    }
+}
+
 /// A telescope/survey: a limiting magnitude in some band plus a footprint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Telescope {
@@ -164,6 +215,22 @@ pub struct Constraints {
     pub favored_arc: Vec<[f64; 2]>,
 }
 
+impl Constraints {
+    /// Rubin/LSST northern declination limit as a dimension-checked [`Angle`]
+    /// (degree storage).
+    pub fn rubin_dec_max(&self) -> Angle {
+        degrees(self.rubin_dec_max_deg)
+    }
+    /// Lower edge of the favored true-anomaly interval as an [`Angle`].
+    pub fn favored_nu_lo(&self) -> Angle {
+        degrees(self.favored_nu_lo_deg)
+    }
+    /// Upper edge of the favored true-anomaly interval as an [`Angle`].
+    pub fn favored_nu_hi(&self) -> Angle {
+        degrees(self.favored_nu_hi_deg)
+    }
+}
+
 /// The complete dataset written to JSON and read by the plotter.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SurveyDataset {
@@ -177,4 +244,114 @@ pub struct SurveyDataset {
     pub telescopes: Vec<TelescopeResult>,
     pub overlays: Overlays,
     pub constraints: Constraints,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use uom::si::angle::degree;
+    use uom::si::length::astronomical_unit;
+    use uom::si::mass::kilogram;
+
+    fn sample_solution() -> OrbitSolution {
+        OrbitSolution {
+            name: "test".into(),
+            citation: String::new(),
+            arxiv: String::new(),
+            mass_earth: 6.0,
+            albedo: 0.3,
+            a_au: 460.0,
+            a_sigma_au: 50.0,
+            e: 0.2,
+            e_sigma: 0.05,
+            i_deg: 16.0,
+            i_sigma_deg: 5.0,
+            omega_deg: 150.0,
+            omega_sigma_deg: 10.0,
+            omega_big_deg: 100.0,
+            omega_big_sigma_deg: 10.0,
+            note: String::new(),
+        }
+    }
+
+    #[test]
+    fn orbit_solution_typed_accessors_match_fields() {
+        let s = sample_solution();
+        assert_relative_eq!(
+            s.mass().get::<kilogram>(),
+            earth_masses(s.mass_earth).get::<kilogram>(),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            s.semi_major_axis().get::<astronomical_unit>(),
+            s.a_au,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(s.inclination().get::<degree>(), s.i_deg, epsilon = 1e-12);
+        assert_relative_eq!(
+            s.argument_of_perihelion().get::<degree>(),
+            s.omega_deg,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            s.longitude_of_node().get::<degree>(),
+            s.omega_big_deg,
+            epsilon = 1e-12
+        );
+    }
+
+    #[test]
+    fn study_result_typed_accessors_match_fields() {
+        let r = StudyResult {
+            solution: sample_solution(),
+            prob: vec![1.0],
+            peak_ra_deg: 85.0,
+            peak_dec_deg: 20.0,
+            area68_deg2: 100.0,
+            area95_deg2: 300.0,
+            dist_p16_au: 400.0,
+            dist_median_au: 500.0,
+            dist_p84_au: 650.0,
+            v_p16: 19.0,
+            v_median: 21.0,
+            v_p84: 23.0,
+        };
+        assert_relative_eq!(r.peak_ra().get::<degree>(), r.peak_ra_deg, epsilon = 1e-12);
+        assert_relative_eq!(
+            r.peak_dec().get::<degree>(),
+            r.peak_dec_deg,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            r.dist_median().get::<astronomical_unit>(),
+            r.dist_median_au,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            r.dist_p16().get::<astronomical_unit>(),
+            r.dist_p16_au,
+            epsilon = 1e-12
+        );
+    }
+
+    #[test]
+    fn constraints_typed_accessors_match_fields() {
+        let c = Constraints {
+            rubin_dec_max_deg: 12.0,
+            favored_nu_lo_deg: 30.0,
+            favored_nu_hi_deg: 60.0,
+            favored_arc: vec![],
+        };
+        assert_relative_eq!(
+            c.rubin_dec_max().get::<degree>(),
+            c.rubin_dec_max_deg,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            c.favored_nu_lo().get::<degree>(),
+            c.favored_nu_lo_deg,
+            epsilon = 1e-12
+        );
+    }
 }

--- a/crates/p9-survey/src/telescope.rs
+++ b/crates/p9-survey/src/telescope.rs
@@ -22,9 +22,15 @@
 
 use crate::schema::Telescope;
 use p9_core::analysis::surveys::Footprint;
+use p9_core::units::{meters, Length};
 
 /// JBT 0.5 m + SPENCER derived optics (see module docs / `focalplane`).
 pub const JBT_APERTURE_M: f64 = 0.485;
+
+/// [`JBT_APERTURE_M`] as a dimension-checked [`Length`].
+pub fn jbt_aperture() -> Length {
+    meters(JBT_APERTURE_M)
+}
 pub const JBT_F_NUMBER: f64 = 12.3;
 pub const JBT_PLATE_SCALE_ARCSEC_PER_PX: f64 = 0.130;
 /// Instantaneous field of the 4-chip SPENCER array (deg²).


### PR DESCRIPTION
Adopts the `p9_core::units` typed (uom) boundary additively across this batch of
crates. Existing `f64` fields, signatures, test reference values, and the
p9-survey serialized schema are unchanged — only new dimension-checked accessor
methods / typed sibling functions were added, each pinned against its `f64`
source with `assert_relative_eq!`. `uom` added as a dev-dependency where
round-trip tests name units.

Per-crate:

- **p9-2025-perturbation** — `Resonance::{semi_major_axis, half_width}` -> `Length` (AU fields).
- **p9-2025-planet-y** — `PlanetY::{mass, semi_major_axis, inclination_angle}`; `ForcedProfilePoint::{semi_major_axis, forced_inclination_angle}`; `WarpFeature::{a_peak, peak_tilt, inner_tilt, outer_tilt, amplitude}`.
- **p9-2025-ps1-holman** — `DetectionTarget::declination` -> `Angle`; `max_detectable_distance_typed` -> `Length`.
- **p9-2025-simons-forecast** — `P9Thermal::{mass, distance, radius}`; `ReferenceBox::{mass_min, mass_max, dist_min, dist_max}`; `max_detectable_distance_typed` -> `Length`.
- **p9-2025-stacking** — mostly statistics/magnitudes/counts; the one dimensional scalar (ZTF baseline) gets `published::ztf_baseline` -> `Time`.
- **p9-2026-apsidal-clustering** — mostly statistics; the mean direction µ gets `ApsidalFit::mean_direction` -> `Angle`.
- **p9-2026-iorio-precession** — `Perturber::{mass, semi_major_axis, gm_typed}`; `saturn_perihelion_precession` and `saturn_mean_motion` -> `AngularVelocity` (built via `.into()` to drop AngleKind); `saturn_precession_bound` -> `AngularVelocity`; `critical_distance` -> `Length`.
- **p9-survey** — typed accessor METHODS only (wire format / SCHEMA_VERSION untouched): `OrbitSolution::{mass, semi_major_axis, inclination, argument_of_perihelion, longitude_of_node}`; `StudyResult::{peak_ra, peak_dec, dist_p16, dist_median, dist_p84}`; `Constraints::{rubin_dec_max, favored_nu_lo, favored_nu_hi}`; `telescope::jbt_aperture` -> `Length`.

Skipped:

- **p9-review-article** — binary that only emits an HTML review; no public API and no dimensional public scalar to type.

`cargo build` and `cargo test` pass for every touched crate; `cargo fmt` applied.