### PR TITLE
Add typed units accessors to 2020/2021 survey crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1591,6 +1591,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1603,6 +1604,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1614,6 +1616,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1624,6 +1627,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1635,6 +1639,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1647,6 +1652,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1660,6 +1666,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]

--- a/crates/p9-2020-des-isotropy/Cargo.toml
+++ b/crates/p9-2020-des-isotropy/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2020-des-isotropy/src/des_sample.rs
+++ b/crates/p9-2020-des-isotropy/src/des_sample.rs
@@ -20,6 +20,7 @@
 //! separate entry and excluded from the Case membership predicates.
 
 use p9_core::constants::{DEG2RAD, TWO_PI};
+use p9_core::units::{self, au, degrees, radians, Length};
 
 /// A DES eTNO with the orbital angles relevant to the isotropy tests.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -59,6 +60,38 @@ impl DesEtno {
     /// Longitude of perihelion ϖ = ω + Ω in radians, wrapped to [0, 2π).
     pub fn varpi(&self) -> f64 {
         ((self.argp_deg + self.node_deg) * DEG2RAD).rem_euclid(TWO_PI)
+    }
+
+    // ---- typed boundary accessors (dimension-checked views of the f64 fields) ----
+
+    /// Semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
+    }
+
+    /// Perihelion distance q = a(1 − e) as a typed [`Length`].
+    pub fn perihelion_typed(&self) -> Length {
+        au(self.perihelion())
+    }
+
+    /// Inclination as a typed [`units::Angle`].
+    pub fn inclination(&self) -> units::Angle {
+        degrees(self.i_deg)
+    }
+
+    /// Longitude of ascending node Ω as a typed [`units::Angle`].
+    pub fn node_typed(&self) -> units::Angle {
+        radians(self.node())
+    }
+
+    /// Argument of perihelion ω as a typed [`units::Angle`].
+    pub fn argp_typed(&self) -> units::Angle {
+        radians(self.argp())
+    }
+
+    /// Longitude of perihelion ϖ as a typed [`units::Angle`].
+    pub fn varpi_typed(&self) -> units::Angle {
+        radians(self.varpi())
     }
 }
 
@@ -240,6 +273,29 @@ mod tests {
         let ra109 = DES_ETNOS.iter().find(|o| o.name == "2013 RA109").unwrap();
         let varpi_deg = ra109.varpi() * p9_core::constants::RAD2DEG;
         assert!((varpi_deg - 7.70).abs() < 0.05, "varpi = {varpi_deg:.2}");
+    }
+
+    #[test]
+    fn typed_accessors_match_f64() {
+        use approx::assert_relative_eq;
+        use uom::si::angle::{degree, radian};
+        use uom::si::length::astronomical_unit;
+
+        let o = DES_ETNOS[0];
+        assert_relative_eq!(
+            o.semi_major_axis().get::<astronomical_unit>(),
+            o.a,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            o.perihelion_typed().get::<astronomical_unit>(),
+            o.perihelion(),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(o.inclination().get::<degree>(), o.i_deg, epsilon = 1e-12);
+        assert_relative_eq!(o.node_typed().get::<radian>(), o.node(), epsilon = 1e-12);
+        assert_relative_eq!(o.argp_typed().get::<radian>(), o.argp(), epsilon = 1e-12);
+        assert_relative_eq!(o.varpi_typed().get::<radian>(), o.varpi(), epsilon = 1e-12);
     }
 
     #[test]

--- a/crates/p9-2020-resonance-hopping/Cargo.toml
+++ b/crates/p9-2020-resonance-hopping/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2020-resonance-hopping/src/classification.rs
+++ b/crates/p9-2020-resonance-hopping/src/classification.rs
@@ -31,6 +31,7 @@
 //! exist, so an object there sits in an isolated island and can STICK.
 
 use p9_core::analysis::resonance::resonance_semi_major_axis;
+use p9_core::units::{au, Length};
 
 /// Greatest common divisor (for reducing p:q to lowest terms).
 fn gcd(a: u32, b: u32) -> u32 {
@@ -61,6 +62,12 @@ impl Mmr {
     /// the single workspace resonance-location convention.
     pub fn semimajor_axis(&self, a_p9: f64) -> f64 {
         resonance_semi_major_axis(self.q, self.p, a_p9)
+    }
+
+    /// Semimajor axis of this interior resonance as a typed [`Length`], for a
+    /// Planet Nine at `a_p9` (AU).
+    pub fn semi_major_axis_typed(&self, a_p9: f64) -> Length {
+        au(self.semimajor_axis(a_p9))
     }
 
     /// Order of the resonance, |p − q|.
@@ -132,6 +139,11 @@ impl ResonanceLandscape {
             spectrum,
             simple,
         }
+    }
+
+    /// Planet Nine semimajor axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_p9)
     }
 
     /// Nearest SIMPLE (n:1 / n:2) resonance to `a` (AU): (resonance, centre,
@@ -299,6 +311,24 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use p9_core::analysis::resonance::resonance_semi_major_axis;
+    use uom::si::length::astronomical_unit;
+
+    #[test]
+    fn typed_semi_major_axis_matches_f64() {
+        let a_p9 = 500.0;
+        let mmr = Mmr { p: 3, q: 1 };
+        assert_relative_eq!(
+            mmr.semi_major_axis_typed(a_p9).get::<astronomical_unit>(),
+            mmr.semimajor_axis(a_p9),
+            epsilon = 1e-12
+        );
+        let land = ResonanceLandscape::new(a_p9, 100.0, 600.0, 5);
+        assert_relative_eq!(
+            land.semi_major_axis().get::<astronomical_unit>(),
+            land.a_p9,
+            epsilon = 1e-12
+        );
+    }
 
     #[test]
     fn resonance_location_matches_analytic_relation() {

--- a/crates/p9-2020-resonance-hopping/src/population.rs
+++ b/crates/p9-2020-resonance-hopping/src/population.rs
@@ -9,6 +9,7 @@
 use crate::classification::{classify, Class, ResonanceLandscape};
 use crate::published;
 use p9_core::constants::EARTH_MASS_SOLAR;
+use p9_core::units::{au, Length};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use rand_distr::{Distribution, Uniform};
@@ -28,6 +29,16 @@ impl Tno {
     /// Perihelion distance q = a(1 − e) (AU).
     pub fn perihelion(&self) -> f64 {
         self.a * (1.0 - self.e)
+    }
+
+    /// Semimajor axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
+    }
+
+    /// Perihelion distance as a typed [`Length`].
+    pub fn perihelion_typed(&self) -> Length {
+        au(self.perihelion())
     }
 }
 
@@ -176,6 +187,23 @@ pub fn default_landscape(a_min: f64, a_max: f64) -> ResonanceLandscape {
 mod tests {
     use super::*;
     use crate::classification::resonance_overlap_k;
+    use approx::assert_relative_eq;
+    use uom::si::length::astronomical_unit;
+
+    #[test]
+    fn typed_tno_accessors_match_f64() {
+        let t = Tno { a: 300.0, e: 0.7 };
+        assert_relative_eq!(
+            t.semi_major_axis().get::<astronomical_unit>(),
+            t.a,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            t.perihelion_typed().get::<astronomical_unit>(),
+            t.perihelion(),
+            epsilon = 1e-12
+        );
+    }
 
     const A_MIN: f64 = 150.0;
     const A_MAX: f64 = 499.0;

--- a/crates/p9-2020-secular-octupole/Cargo.toml
+++ b/crates/p9-2020-secular-octupole/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2020-secular-octupole/src/precession.rs
+++ b/crates/p9-2020-secular-octupole/src/precession.rs
@@ -22,6 +22,7 @@
 
 use crate::octupole::{hamiltonian_octupole, hamiltonian_quadrupole, octupole_coupling};
 use p9_core::constants::GM_SUN;
+use p9_core::units::{days, radians, AngularVelocity};
 
 /// Canonical apsidal momentum Gamma = sqrt(GM_sun a)(1 - sqrt(1-e^2)).
 pub fn gamma_of_e(a: f64, e: f64) -> f64 {
@@ -45,6 +46,18 @@ pub fn precession_rate_quadrupole(a: f64, e: f64, a_p: f64, e_p: f64, gm_p: f64)
     dh_de * de_dgamma(a, e)
 }
 
+/// QUADRUPOLE apsidal precession rate as a typed [`AngularVelocity`] (the
+/// dimension-checked view of [`precession_rate_quadrupole`], rad/day).
+pub fn precession_rate_quadrupole_typed(
+    a: f64,
+    e: f64,
+    a_p: f64,
+    e_p: f64,
+    gm_p: f64,
+) -> AngularVelocity {
+    (radians(precession_rate_quadrupole(a, e, a_p, e_p, gm_p)) / days(1.0)).into()
+}
+
 /// OCTUPOLE apsidal precession rate d(dvarpi)/dt (radians/day) at apsidal angle
 /// `dvarpi`. Carries the dvarpi-dependence from the octupole term; equals the
 /// quadrupole rate plus an octupole modulation proportional to cos(dvarpi).
@@ -54,6 +67,19 @@ pub fn precession_rate_octupole(a: f64, e: f64, dvarpi: f64, a_p: f64, e_p: f64,
         - hamiltonian_octupole(a, e - de, dvarpi, a_p, e_p, gm_p))
         / (2.0 * de);
     dh_de * de_dgamma(a, e)
+}
+
+/// OCTUPOLE apsidal precession rate as a typed [`AngularVelocity`] (the
+/// dimension-checked view of [`precession_rate_octupole`], rad/day).
+pub fn precession_rate_octupole_typed(
+    a: f64,
+    e: f64,
+    dvarpi: f64,
+    a_p: f64,
+    e_p: f64,
+    gm_p: f64,
+) -> AngularVelocity {
+    (radians(precession_rate_octupole(a, e, dvarpi, a_p, e_p, gm_p)) / days(1.0)).into()
 }
 
 /// Peak octupole modulation of the precession rate (radians/day): the
@@ -67,14 +93,54 @@ pub fn octupole_modulation_amplitude(a: f64, e: f64, a_p: f64, e_p: f64, gm_p: f
     c_oct * e_p * de_dgamma(a, e)
 }
 
+/// Peak octupole modulation of the precession rate as a typed
+/// [`AngularVelocity`] (the dimension-checked view of
+/// [`octupole_modulation_amplitude`], rad/day).
+pub fn octupole_modulation_amplitude_typed(
+    a: f64,
+    e: f64,
+    a_p: f64,
+    e_p: f64,
+    gm_p: f64,
+) -> AngularVelocity {
+    (radians(octupole_modulation_amplitude(a, e, a_p, e_p, gm_p)) / days(1.0)).into()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use p9_core::constants::{EARTH_MASS_SOLAR, GM_SUN};
     use std::f64::consts::PI;
+    use uom::si::angular_velocity::radian_per_second;
 
     fn gm_p9(mass_earth: f64) -> f64 {
         mass_earth * EARTH_MASS_SOLAR * GM_SUN
+    }
+
+    #[test]
+    fn typed_precession_rates_match_f64() {
+        use approx::assert_relative_eq;
+        // 1 day = 86400 s, so a rate in rad/day reads back as rate/86400 in
+        // rad/s through the typed AngularVelocity.
+        const SEC_PER_DAY: f64 = 86_400.0;
+        let gm = gm_p9(10.0);
+        let (a, e, a_p, e_p, dv) = (250.0, 0.3, 700.0, 0.6, 0.4);
+
+        assert_relative_eq!(
+            precession_rate_quadrupole_typed(a, e, a_p, e_p, gm).get::<radian_per_second>(),
+            precession_rate_quadrupole(a, e, a_p, e_p, gm) / SEC_PER_DAY,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            precession_rate_octupole_typed(a, e, dv, a_p, e_p, gm).get::<radian_per_second>(),
+            precession_rate_octupole(a, e, dv, a_p, e_p, gm) / SEC_PER_DAY,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            octupole_modulation_amplitude_typed(a, e, a_p, e_p, gm).get::<radian_per_second>(),
+            octupole_modulation_amplitude(a, e, a_p, e_p, gm) / SEC_PER_DAY,
+            max_relative = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2020-tess-shiftstack/Cargo.toml
+++ b/crates/p9-2020-tess-shiftstack/Cargo.toml
@@ -11,3 +11,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2020-tess-shiftstack/src/tess.rs
+++ b/crates/p9-2020-tess-shiftstack/src/tess.rs
@@ -14,6 +14,8 @@
 //! single frame (T ≈ 15) but extremely well sampled in time — the regime where
 //! shift-and-stacking pays off.
 
+use p9_core::units::{arcseconds, Angle};
+
 /// TESS full-frame-image cadence during the prime mission, in minutes
 /// (Sectors 1–26 read the FFIs out every 30 minutes).
 pub const FFI_CADENCE_MIN: f64 = 30.0;
@@ -58,6 +60,12 @@ pub fn psf_sigma_arcsec(sigma_pixels: f64) -> f64 {
     sigma_pixels * PIXEL_SCALE_ARCSEC
 }
 
+/// Effective Gaussian PSF 1σ width as a typed [`Angle`] (the dimension-checked
+/// view of [`psf_sigma_arcsec`]).
+pub fn psf_sigma(sigma_pixels: f64) -> Angle {
+    arcseconds(psf_sigma_arcsec(sigma_pixels))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -91,5 +99,15 @@ mod tests {
     fn psf_sigma_scales_with_pixel_scale() {
         assert_relative_eq!(psf_sigma_arcsec(1.0), PIXEL_SCALE_ARCSEC, epsilon = 1e-12);
         assert_relative_eq!(psf_sigma_arcsec(0.5), 10.5, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn typed_psf_sigma_matches_f64() {
+        use uom::si::angle::second as arcsecond;
+        assert_relative_eq!(
+            psf_sigma(0.5).get::<arcsecond>(),
+            psf_sigma_arcsec(0.5),
+            epsilon = 1e-12
+        );
     }
 }

--- a/crates/p9-2020-tess-shiftstack/src/tracks.rs
+++ b/crates/p9-2020-tess-shiftstack/src/tracks.rs
@@ -17,6 +17,7 @@ use p9_core::analysis::stacking::orbit_metric::{
     n_trial_orbits, p9_orbital_sky_rate, rate_resolution, snr_retained_exact,
 };
 use p9_core::types::P9Params;
+use p9_core::units::{arcseconds, days, Angle, AngularVelocity};
 
 use crate::tess;
 
@@ -32,6 +33,12 @@ pub const SNR_TOLERANCE: f64 = 0.9;
 /// Effective TESS PSF 1σ for track-grid purposes (≈0.5 px ≈ 10.5 arcsec).
 pub fn track_psf_arcsec() -> f64 {
     tess::psf_sigma_arcsec(0.5)
+}
+
+/// Effective TESS track-grid PSF 1σ as a typed [`Angle`] (dimension-checked
+/// view of [`track_psf_arcsec`]).
+pub fn track_psf() -> Angle {
+    arcseconds(track_psf_arcsec())
 }
 
 /// Number of trial tracks for a TESS shift-stack over `n_sectors` sectors,
@@ -55,10 +62,22 @@ pub fn rate_cell_arcsec_per_day(n_sectors: f64) -> f64 {
     )
 }
 
+/// Rate-cell half-width as a typed [`AngularVelocity`] (dimension-checked view
+/// of [`rate_cell_arcsec_per_day`], arcsec/day).
+pub fn rate_cell(n_sectors: f64) -> AngularVelocity {
+    (arcseconds(rate_cell_arcsec_per_day(n_sectors)) / days(1.0)).into()
+}
+
 /// Planet Nine's heliocentric on-sky angular rate (arcsec/day) for a model —
 /// reused from the shared metric to confirm P9 sits inside the search box.
 pub fn p9_sky_rate(p9: &P9Params) -> f64 {
     p9_orbital_sky_rate(p9)
+}
+
+/// Planet Nine's heliocentric on-sky angular rate as a typed
+/// [`AngularVelocity`] (dimension-checked view of [`p9_sky_rate`], arcsec/day).
+pub fn p9_sky_rate_typed(p9: &P9Params) -> AngularVelocity {
+    (arcseconds(p9_sky_rate(p9)) / days(1.0)).into()
 }
 
 /// Retained matched-filter SNR for a track whose rate is offset by `rate_error`
@@ -104,6 +123,39 @@ mod tests {
         let c1 = rate_cell_arcsec_per_day(1.0);
         let c2 = rate_cell_arcsec_per_day(2.0);
         assert_relative_eq!(c1 / c2, 2.0, epsilon = 1e-9);
+    }
+
+    #[test]
+    fn typed_track_quantities_match_f64() {
+        use uom::si::angle::{radian, second as arcsecond};
+        use uom::si::angular_velocity::radian_per_second;
+        use uom::si::time::second;
+
+        // PSF angle round-trips to its arcsec source.
+        assert_relative_eq!(
+            track_psf().get::<arcsecond>(),
+            track_psf_arcsec(),
+            epsilon = 1e-12
+        );
+
+        // A rate in arcsec/day expressed through the typed AngularVelocity
+        // (read in rad/s) equals the source value converted by hand.
+        let sec_per_day = days(1.0).get::<second>();
+        let to_rad_per_s =
+            |arcsec_per_day: f64| arcseconds(arcsec_per_day).get::<radian>() / sec_per_day;
+
+        assert_relative_eq!(
+            rate_cell(1.0).get::<radian_per_second>(),
+            to_rad_per_s(rate_cell_arcsec_per_day(1.0)),
+            max_relative = 1e-12
+        );
+
+        let p9 = P9Params::mcmc_2021();
+        assert_relative_eq!(
+            p9_sky_rate_typed(&p9).get::<radian_per_second>(),
+            to_rad_per_s(p9_sky_rate(&p9)),
+            max_relative = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2021-act-mm/Cargo.toml
+++ b/crates/p9-2021-act-mm/Cargo.toml
@@ -11,3 +11,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2021-act-mm/src/detectability.rs
+++ b/crates/p9-2021-act-mm/src/detectability.rs
@@ -18,6 +18,7 @@ use p9_2018_wise_search::detectability::max_detectable_distance as wise_max_dist
 use p9_2018_wise_search::survey_model::WiseSurvey;
 use p9_core::analysis::thermal::planck_bnu;
 use p9_core::constants::AU_M;
+use p9_core::units::{au, Length};
 
 use crate::survey_model::ActSurvey;
 use crate::thermal_model::{P9Millimeter, MJY};
@@ -50,6 +51,19 @@ pub struct ReachComparison {
     pub act_mm_au: f64,
     /// WISE W1 maximum detectable distance (AU), or None if undetectable.
     pub wise_w1_au: Option<f64>,
+}
+
+impl ReachComparison {
+    /// ACT mm maximum detectable distance as a typed [`Length`].
+    pub fn act_mm_distance(&self) -> Length {
+        au(self.act_mm_au)
+    }
+
+    /// WISE W1 maximum detectable distance as a typed [`Length`], or `None` if
+    /// the body is undetectable in W1.
+    pub fn wise_w1_distance(&self) -> Option<Length> {
+        self.wise_w1_au.map(au)
+    }
 }
 
 /// Compare ACT mm vs WISE W1 reach for a given mass.
@@ -107,6 +121,25 @@ fn erfc(x: f64) -> f64 {
 mod tests {
     use super::*;
     use crate::survey_model::{CANDIDATE_COUNT, NU_150_GHZ};
+
+    #[test]
+    fn typed_reach_accessors_match_f64() {
+        use approx::assert_relative_eq;
+        use uom::si::length::astronomical_unit;
+        let cmp = compare_reach(&ActSurvey::default(), 10.0);
+        assert_relative_eq!(
+            cmp.act_mm_distance().get::<astronomical_unit>(),
+            cmp.act_mm_au,
+            epsilon = 1e-9
+        );
+        match (cmp.wise_w1_distance(), cmp.wise_w1_au) {
+            (Some(d), Some(au_val)) => {
+                assert_relative_eq!(d.get::<astronomical_unit>(), au_val, epsilon = 1e-9)
+            }
+            (None, None) => {}
+            _ => panic!("typed/optional reach mismatch"),
+        }
+    }
 
     #[test]
     fn closed_form_matches_bisection() {

--- a/crates/p9-2021-act-mm/src/thermal_model.rs
+++ b/crates/p9-2021-act-mm/src/thermal_model.rs
@@ -25,6 +25,7 @@ use std::f64::consts::PI;
 use p9_2018_wise_search::thermal_model::P9Thermal;
 use p9_core::analysis::thermal::{planck_bnu, rayleigh_jeans_bnu, JY as CORE_JY};
 use p9_core::constants::AU_M;
+use p9_core::units::{au, meters, Length};
 
 /// 1 Jansky in W/m²/Hz.
 pub const JY: f64 = CORE_JY;
@@ -66,6 +67,17 @@ impl P9Millimeter {
         self.body.radius_m()
     }
 
+    /// Physical radius as a typed [`Length`] (dimension-checked view of
+    /// [`radius_m`](Self::radius_m)).
+    pub fn radius(&self) -> Length {
+        meters(self.radius_m())
+    }
+
+    /// Heliocentric distance as a typed [`Length`].
+    pub fn distance(&self) -> Length {
+        au(self.body.distance_au)
+    }
+
     /// Thermal mm flux density (W/m²/Hz) at frequency `nu_hz`, unit-emissivity
     /// grey body: F_ν = π B_ν(T) (R/d)².
     pub fn flux_density_si(&self, nu_hz: f64) -> f64 {
@@ -105,6 +117,19 @@ mod tests {
 
     /// ACT 150 GHz in Hz.
     const NU_150: f64 = 150.0e9;
+
+    #[test]
+    fn typed_radius_and_distance_match_f64() {
+        use approx::assert_relative_eq;
+        use uom::si::length::{astronomical_unit, meter};
+        let p = P9Millimeter::new(10.0, 500.0);
+        assert_relative_eq!(p.radius().get::<meter>(), p.radius_m(), epsilon = 1e-3);
+        assert_relative_eq!(
+            p.distance().get::<astronomical_unit>(),
+            p.body.distance_au,
+            epsilon = 1e-12
+        );
+    }
 
     #[test]
     fn cold_body_is_on_the_rayleigh_jeans_tail_at_mm() {

--- a/crates/p9-2021-des-catalog/Cargo.toml
+++ b/crates/p9-2021-des-catalog/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2021-des-catalog/src/catalog.rs
+++ b/crates/p9-2021-des-catalog/src/catalog.rs
@@ -20,6 +20,7 @@
 //! vetted subset; see `super::reference::N_EXTREME_TNOS` for the labelled 16.
 
 use p9_core::constants::{DEG2RAD, TWO_PI};
+use p9_core::units::{self, au, degrees, radians, Length};
 
 /// A DES extreme TNO with the elements needed for clustering and completeness.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -63,6 +64,43 @@ impl DesTno {
     /// Longitude of perihelion ϖ = ω + Ω (radians, wrapped to [0, 2π)).
     pub fn varpi(&self) -> f64 {
         ((self.argp_deg + self.node_deg) * DEG2RAD).rem_euclid(TWO_PI)
+    }
+
+    // ---- typed boundary accessors (dimension-checked views of the f64 fields) ----
+
+    /// Semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
+    }
+
+    /// Perihelion distance q = a(1 − e) as a typed [`Length`].
+    pub fn perihelion_typed(&self) -> Length {
+        au(self.perihelion())
+    }
+
+    /// Aphelion distance Q = a(1 + e) as a typed [`Length`].
+    pub fn aphelion_typed(&self) -> Length {
+        au(self.aphelion())
+    }
+
+    /// Inclination as a typed [`units::Angle`].
+    pub fn inclination(&self) -> units::Angle {
+        degrees(self.i_deg)
+    }
+
+    /// Longitude of ascending node Ω as a typed [`units::Angle`].
+    pub fn node_typed(&self) -> units::Angle {
+        radians(self.node())
+    }
+
+    /// Argument of perihelion ω as a typed [`units::Angle`].
+    pub fn argp_typed(&self) -> units::Angle {
+        radians(self.argp())
+    }
+
+    /// Longitude of perihelion ϖ as a typed [`units::Angle`].
+    pub fn varpi_typed(&self) -> units::Angle {
+        radians(self.varpi())
     }
 }
 
@@ -204,6 +242,34 @@ mod tests {
         // 8 vetted objects, a documented subset of the paper's 16 extreme TNOs.
         assert_eq!(DES_EXTREME_TNOS.len(), 8);
         assert!(DES_EXTREME_TNOS.len() <= crate::reference::N_EXTREME_TNOS);
+    }
+
+    #[test]
+    fn typed_accessors_match_f64() {
+        use approx::assert_relative_eq;
+        use uom::si::angle::{degree, radian};
+        use uom::si::length::astronomical_unit;
+
+        let o = DES_EXTREME_TNOS[0];
+        assert_relative_eq!(
+            o.semi_major_axis().get::<astronomical_unit>(),
+            o.a,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            o.perihelion_typed().get::<astronomical_unit>(),
+            o.perihelion(),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            o.aphelion_typed().get::<astronomical_unit>(),
+            o.aphelion(),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(o.inclination().get::<degree>(), o.i_deg, epsilon = 1e-12);
+        assert_relative_eq!(o.node_typed().get::<radian>(), o.node(), epsilon = 1e-12);
+        assert_relative_eq!(o.argp_typed().get::<radian>(), o.argp(), epsilon = 1e-12);
+        assert_relative_eq!(o.varpi_typed().get::<radian>(), o.varpi(), epsilon = 1e-12);
     }
 
     #[test]

--- a/crates/p9-2021-detached-inclinations/Cargo.toml
+++ b/crates/p9-2021-detached-inclinations/Cargo.toml
@@ -14,3 +14,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2021-detached-inclinations/src/forcing.rs
+++ b/crates/p9-2021-detached-inclinations/src/forcing.rs
@@ -35,6 +35,7 @@ use p9_core::analysis::secular::quadrupole_hamiltonian;
 use p9_core::constants::GM_SUN;
 use p9_core::initial_conditions::planets::giant_planets_j2000;
 use p9_core::types::{cartesian_to_elements, P9Params};
+use p9_core::units::{julian_year, radians, Angle, AngularVelocity};
 
 /// Giant-planet nodal precession frequency `B_gp` for a particle at (a, e, i),
 /// in rad/yr. This is the secular self-frequency that anchors the particle to
@@ -61,6 +62,12 @@ pub fn giant_planet_frequency(a: f64, e: f64, i: f64) -> f64 {
         .sum();
     let rate_day = 0.75 * n * i.cos() / eta_sq * sum;
     (rate_day * 365.25).abs() // rad/yr
+}
+
+/// Giant-planet nodal precession frequency as a typed [`AngularVelocity`]
+/// (dimension-checked view of [`giant_planet_frequency`], rad/yr).
+pub fn giant_planet_frequency_typed(a: f64, e: f64, i: f64) -> AngularVelocity {
+    (radians(giant_planet_frequency(a, e, i)) / julian_year()).into()
 }
 
 /// Planet Nine secular inclination-coupling frequency `B_p9` for a test
@@ -92,6 +99,13 @@ pub fn planet_nine_frequency(a: f64, p9: &P9Params) -> f64 {
     let ecc_factor = (1.0 - p9.e * p9.e).powf(-1.5);
     let rate_day = 0.75 * n * m9 * alpha * alpha * ecc_factor;
     rate_day * 365.25 // rad/yr
+}
+
+/// Planet Nine secular inclination-coupling frequency as a typed
+/// [`AngularVelocity`] (dimension-checked view of [`planet_nine_frequency`],
+/// rad/yr).
+pub fn planet_nine_frequency_typed(a: f64, p9: &P9Params) -> AngularVelocity {
+    (radians(planet_nine_frequency(a, p9)) / julian_year()).into()
 }
 
 /// Curvature of the p9-core quadrupole Hamiltonian in inclination at I = 0,
@@ -126,6 +140,12 @@ pub fn forced_inclination(a: f64, e: f64, i: f64, p9: &P9Params) -> f64 {
     b_p9 / (b_gp + b_p9) * p9.i
 }
 
+/// Forced inclination as a typed [`Angle`] (dimension-checked view of
+/// [`forced_inclination`]).
+pub fn forced_inclination_typed(a: f64, e: f64, i: f64, p9: &P9Params) -> Angle {
+    radians(forced_inclination(a, e, i, p9))
+}
+
 /// Forced inclination in the Planet-Nine-free Solar System: identically zero
 /// (the particle's plane relaxes to the giant-planet invariable plane).
 pub fn forced_inclination_no_p9(_a: f64, _e: f64, _i: f64) -> f64 {
@@ -139,6 +159,34 @@ mod tests {
 
     fn nominal() -> P9Params {
         P9Params::nominal_2016() // 10 M⊕, a = 700, e = 0.6, i = 30°
+    }
+
+    #[test]
+    fn typed_forcing_accessors_match_f64() {
+        use approx::assert_relative_eq;
+        use uom::si::angle::radian;
+        use uom::si::angular_velocity::radian_per_second;
+        use uom::si::time::second;
+        // rad/yr → rad/s divisor (Julian year in seconds).
+        let yr_s = julian_year().get::<second>();
+        let p9 = nominal();
+        let (a, e, i) = (300.0, 0.5, 10.0 * DEG2RAD);
+
+        assert_relative_eq!(
+            forced_inclination_typed(a, e, i, &p9).get::<radian>(),
+            forced_inclination(a, e, i, &p9),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            giant_planet_frequency_typed(a, e, i).get::<radian_per_second>(),
+            giant_planet_frequency(a, e, i) / yr_s,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            planet_nine_frequency_typed(a, &p9).get::<radian_per_second>(),
+            planet_nine_frequency(a, &p9) / yr_s,
+            max_relative = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2021-detached-inclinations/src/lib.rs
+++ b/crates/p9-2021-detached-inclinations/src/lib.rs
@@ -31,6 +31,7 @@ pub mod population;
 /// computes its own inclination statistics and the tests compare against these.
 pub mod reference {
     use p9_core::constants::DEG2RAD;
+    use p9_core::units::{degrees, Angle};
 
     /// Planet Nine inclination used by Anderson & Kaib (2021), ≈ 20° to the
     /// invariable plane (their adopted Batygin-Brown-class orbit).
@@ -53,6 +54,12 @@ pub mod reference {
     /// Helper: Planet Nine inclination in radians.
     pub fn p9_inclination_rad() -> f64 {
         P9_INCLINATION_DEG * DEG2RAD
+    }
+
+    /// Planet Nine inclination as a typed [`Angle`] (dimension-checked view of
+    /// [`P9_INCLINATION_DEG`]).
+    pub fn p9_inclination() -> Angle {
+        degrees(P9_INCLINATION_DEG)
     }
 }
 
@@ -142,5 +149,14 @@ mod tests {
         assert!((reference::p9_inclination_rad() - 20.0 * DEG2RAD).abs() < 1e-12);
         assert_eq!(nominal_inclined_p9().mass_earth, reference::P9_MASS_EARTH);
         assert!((nominal_inclined_p9().i * RAD2DEG - reference::P9_INCLINATION_DEG).abs() < 1e-9);
+    }
+
+    #[test]
+    fn typed_reference_inclination_matches_rad() {
+        use uom::si::angle::radian;
+        assert!(
+            (reference::p9_inclination().get::<radian>() - reference::p9_inclination_rad()).abs()
+                < 1e-12
+        );
     }
 }

--- a/crates/p9-2021-detached-inclinations/src/population.rs
+++ b/crates/p9-2021-detached-inclinations/src/population.rs
@@ -29,6 +29,7 @@
 
 use p9_core::constants::DEG2RAD;
 use p9_core::types::P9Params;
+use p9_core::units::{au, radians, Angle, Length};
 use rand::rngs::StdRng;
 use rand::Rng;
 use rand::SeedableRng;
@@ -62,6 +63,22 @@ impl DetachedParticle {
         let cos_i = i_forced.cos() * self.i_free.cos()
             + i_forced.sin() * self.i_free.sin() * self.phase.cos();
         cos_i.clamp(-1.0, 1.0).acos()
+    }
+
+    /// Semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
+    }
+
+    /// Perihelion distance as a typed [`Length`].
+    pub fn perihelion_typed(&self) -> Length {
+        au(self.perihelion())
+    }
+
+    /// Observed inclination as a typed [`Angle`] (dimension-checked view of
+    /// [`observed_inclination`](Self::observed_inclination)).
+    pub fn observed_inclination_typed(&self, i_forced: f64) -> Angle {
+        radians(self.observed_inclination(i_forced))
     }
 }
 
@@ -193,6 +210,34 @@ mod tests {
 
     fn nominal() -> P9Params {
         P9Params::nominal_2016()
+    }
+
+    #[test]
+    fn typed_particle_accessors_match_f64() {
+        use approx::assert_relative_eq;
+        use uom::si::angle::radian;
+        use uom::si::length::astronomical_unit;
+        let p = DetachedParticle {
+            a: 400.0,
+            e: 0.7,
+            i_free: 0.2,
+            phase: 0.5,
+        };
+        assert_relative_eq!(
+            p.semi_major_axis().get::<astronomical_unit>(),
+            p.a,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            p.perihelion_typed().get::<astronomical_unit>(),
+            p.perihelion(),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            p.observed_inclination_typed(0.3).get::<radian>(),
+            p.observed_inclination(0.3),
+            epsilon = 1e-12
+        );
     }
 
     #[test]


### PR DESCRIPTION
Adopt the `p9_core::units` typed (uom) boundary additively across seven 2020/2021 crates. No existing `f64` fields, signatures, or test reference values were changed; every addition is a new typed accessor or typed sibling pinned against its f64 source with `assert_relative_eq!`. Added `uom` as a dev-dependency to each crate.

Per-crate changes:
- **p9-2020-des-isotropy**: `DesEtno` gains `semi_major_axis`/`perihelion_typed` (Length) and `inclination`/`node_typed`/`argp_typed`/`varpi_typed` (Angle).
- **p9-2020-resonance-hopping**: `Mmr::semi_major_axis_typed`, `ResonanceLandscape::semi_major_axis`, and `Tno::{semi_major_axis,perihelion_typed}` (Length).
- **p9-2020-secular-octupole**: typed AngularVelocity siblings for the apsidal precession rates (`precession_rate_quadrupole_typed`, `precession_rate_octupole_typed`, `octupole_modulation_amplitude_typed`).
- **p9-2020-tess-shiftstack**: `psf_sigma`/`track_psf` (Angle) and `rate_cell`/`p9_sky_rate_typed` (AngularVelocity, arcsec/day).
- **p9-2021-act-mm**: `P9Millimeter::{radius,distance}` (Length) and `ReachComparison::{act_mm_distance,wise_w1_distance}` (Length / Option<Length>).
- **p9-2021-des-catalog**: `DesTno` gains `semi_major_axis`/`perihelion_typed`/`aphelion_typed` (Length) and `inclination`/`node_typed`/`argp_typed`/`varpi_typed` (Angle).
- **p9-2021-detached-inclinations**: `DetachedParticle::{semi_major_axis,perihelion_typed,observed_inclination_typed}`, `forcing::{forced_inclination_typed (Angle), giant_planet_frequency_typed, planet_nine_frequency_typed (AngularVelocity, rad/yr)}`, and `reference::p9_inclination` (Angle).

Skips: none — every crate in the batch exposed at least one dimensional public scalar. Pure statistics/flux/temperature/solid-angle/magnitude outputs were intentionally left untyped (no constructor in the units API or genuinely dimensionless).

All seven crates pass `cargo build` and `cargo test`; `cargo fmt` applied.