### PR TITLE
Typed uom accessors for 2022-2024 crate boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,6 +1760,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1771,6 +1772,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1784,6 +1786,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1795,6 +1798,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1807,6 +1811,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1819,6 +1824,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1833,6 +1839,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]

--- a/crates/p9-2022-iras-candidate/Cargo.toml
+++ b/crates/p9-2022-iras-candidate/Cargo.toml
@@ -11,3 +11,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2022-iras-candidate/src/distance.rs
+++ b/crates/p9-2022-iras-candidate/src/distance.rs
@@ -19,6 +19,7 @@
 
 use p9_2025_iras_akari::thermal_model::P9ThermalParams;
 use p9_core::analysis::photometry::mass_radius_neptunian;
+use p9_core::units::{au, Length};
 
 /// 1 AU in metres (matches `p9_2025_iras_akari::thermal_model`).
 const AU_M: f64 = 1.495_978_707e11;
@@ -79,6 +80,13 @@ pub struct CandidateInversion {
     pub flux_100um_jy: f64,
 }
 
+impl CandidateInversion {
+    /// Implied heliocentric distance as a typed [`Length`].
+    pub fn distance(&self) -> Length {
+        au(self.distance_au)
+    }
+}
+
 /// Invert a 60 µm candidate flux for distance, then evaluate the forward
 /// fluxes in both IRAS bands at that distance.
 pub fn invert_candidate(flux_60um_jy: f64, t_eff_k: f64, mass_earth: f64) -> CandidateInversion {
@@ -95,6 +103,21 @@ mod tests {
     use super::*;
     use crate::REF_CANDIDATE;
     use approx::assert_relative_eq;
+
+    #[test]
+    fn inversion_distance_typed_matches_f64() {
+        use uom::si::length::astronomical_unit;
+        let inv = invert_candidate(
+            REF_CANDIDATE.flux_60um_jy,
+            REF_CANDIDATE.t_eff_k,
+            REF_CANDIDATE.mass_earth,
+        );
+        assert_relative_eq!(
+            inv.distance().get::<astronomical_unit>(),
+            inv.distance_au,
+            epsilon = 1e-12
+        );
+    }
 
     #[test]
     fn reference_candidate_implies_published_distance() {

--- a/crates/p9-2022-iras-candidate/src/lib.rs
+++ b/crates/p9-2022-iras-candidate/src/lib.rs
@@ -49,6 +49,8 @@
 pub mod chance;
 pub mod distance;
 
+use p9_core::units::{au, earth_masses, Length, Mass};
+
 /// Labelled reference quantities for the surviving IRAS candidate from
 /// Rowan-Robinson (2022). The distance and mass are the paper's *fitted*
 /// values; the flux and temperature are the self-consistent inputs that
@@ -92,7 +94,68 @@ pub const REF_CANDIDATE: CandidateReference = CandidateReference {
     flux_100um_jy: 0.858,
 };
 
+impl CandidateReference {
+    /// Fitted heliocentric distance as a typed [`Length`].
+    pub fn distance(&self) -> Length {
+        au(self.distance_au)
+    }
+    /// 1-σ distance uncertainty as a typed [`Length`].
+    pub fn distance_err(&self) -> Length {
+        au(self.distance_err_au)
+    }
+    /// Fitted mass midpoint as a typed [`Mass`].
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+    /// Lower fitted mass as a typed [`Mass`].
+    pub fn mass_lo(&self) -> Mass {
+        earth_masses(self.mass_lo_earth)
+    }
+    /// Upper fitted mass as a typed [`Mass`].
+    pub fn mass_hi(&self) -> Mass {
+        earth_masses(self.mass_hi_earth)
+    }
+}
+
 /// IRAS 60 µm wavelength in metres.
 pub const LAMBDA_60UM_M: f64 = 60.0e-6;
 /// IRAS 100 µm wavelength in metres.
 pub const LAMBDA_100UM_M: f64 = 100.0e-6;
+
+#[cfg(test)]
+mod typed_tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use uom::si::length::astronomical_unit;
+    use uom::si::mass::kilogram;
+
+    #[test]
+    fn candidate_reference_typed_accessors_match_f64() {
+        let c = REF_CANDIDATE;
+        assert_relative_eq!(
+            c.distance().get::<astronomical_unit>(),
+            c.distance_au,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            c.distance_err().get::<astronomical_unit>(),
+            c.distance_err_au,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            c.mass().get::<kilogram>(),
+            earth_masses(c.mass_earth).get::<kilogram>(),
+            epsilon = 1.0
+        );
+        assert_relative_eq!(
+            c.mass_lo().get::<kilogram>(),
+            earth_masses(c.mass_lo_earth).get::<kilogram>(),
+            epsilon = 1.0
+        );
+        assert_relative_eq!(
+            c.mass_hi().get::<kilogram>(),
+            earth_masses(c.mass_hi_earth).get::<kilogram>(),
+            epsilon = 1.0
+        );
+    }
+}

--- a/crates/p9-2022-uranus-tilt/Cargo.toml
+++ b/crates/p9-2022-uranus-tilt/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2022-uranus-tilt/src/lib.rs
+++ b/crates/p9-2022-uranus-tilt/src/lib.rs
@@ -27,6 +27,7 @@ pub mod resonance_capture;
 pub mod spin_axis;
 
 use p9_core::constants::DEG2RAD;
+use p9_core::units::{degrees, Angle};
 
 /// Uranus' observed obliquity (deg). IAU value; the paper's target is 98°.
 pub const URANUS_OBLIQUITY_DEG: f64 = 97.77;
@@ -34,6 +35,27 @@ pub const URANUS_OBLIQUITY_DEG: f64 = 97.77;
 /// Uranus' observed obliquity (rad).
 pub fn uranus_obliquity_rad() -> f64 {
     URANUS_OBLIQUITY_DEG * DEG2RAD
+}
+
+/// Uranus' observed obliquity as a typed [`Angle`].
+pub fn uranus_obliquity() -> Angle {
+    degrees(URANUS_OBLIQUITY_DEG)
+}
+
+#[cfg(test)]
+mod typed_tests {
+    use super::*;
+    use approx::assert_relative_eq;
+    use uom::si::angle::radian;
+
+    #[test]
+    fn obliquity_typed_matches_rad() {
+        assert_relative_eq!(
+            uranus_obliquity().get::<radian>(),
+            uranus_obliquity_rad(),
+            epsilon = 1e-12
+        );
+    }
 }
 
 /// Lu & Laughlin (2022) headline spin-axis precession constant for Uranus

--- a/crates/p9-2022-uranus-tilt/src/resonance_capture.rs
+++ b/crates/p9-2022-uranus-tilt/src/resonance_capture.rs
@@ -28,8 +28,15 @@
 
 use std::f64::consts::PI;
 
+use p9_core::units::{julian_year, radians, Angle, AngularVelocity, Time};
+
 /// arcsec/yr → rad/yr.
 pub const ARCSEC_PER_YR_TO_RAD: f64 = PI / (180.0 * 3600.0);
+
+/// Angular velocity (rad per Julian year) as a typed [`AngularVelocity`].
+fn rad_per_year(rate: f64) -> AngularVelocity {
+    (radians(rate) / julian_year()).into()
+}
 
 /// Snapshot of the Colombo-top state during the integration.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -44,6 +51,25 @@ pub struct SpinSnapshot {
     pub g: f64,
     /// Resonance ratio α/|g|.
     pub ratio: f64,
+}
+
+impl SpinSnapshot {
+    /// Time as a typed [`Time`] (Julian years).
+    pub fn time(&self) -> Time {
+        julian_year() * self.t
+    }
+    /// Obliquity θ as a typed [`Angle`].
+    pub fn obliquity(&self) -> Angle {
+        radians(self.obliquity)
+    }
+    /// Precession phase ψ as a typed [`Angle`].
+    pub fn psi(&self) -> Angle {
+        radians(self.psi)
+    }
+    /// Nodal-precession frequency g as a typed [`AngularVelocity`].
+    pub fn g(&self) -> AngularVelocity {
+        rad_per_year(self.g)
+    }
 }
 
 /// Configuration for an adiabatic-sweep capture run.
@@ -64,6 +90,33 @@ pub struct SweepConfig {
     pub t_total: f64,
     /// Time step (yr).
     pub dt: f64,
+}
+
+impl SweepConfig {
+    /// Spin-axis precession constant α as a typed [`AngularVelocity`].
+    pub fn alpha(&self) -> AngularVelocity {
+        rad_per_year(self.alpha)
+    }
+    /// Orbital inclination I as a typed [`Angle`].
+    pub fn inclination(&self) -> Angle {
+        radians(self.inclination)
+    }
+    /// Initial nodal frequency g₀ as a typed [`AngularVelocity`].
+    pub fn g_initial(&self) -> AngularVelocity {
+        rad_per_year(self.g_initial)
+    }
+    /// Final nodal frequency g_f as a typed [`AngularVelocity`].
+    pub fn g_final(&self) -> AngularVelocity {
+        rad_per_year(self.g_final)
+    }
+    /// Total sweep time as a typed [`Time`] (Julian years).
+    pub fn t_total(&self) -> Time {
+        julian_year() * self.t_total
+    }
+    /// Time step as a typed [`Time`] (Julian years).
+    pub fn dt(&self) -> Time {
+        julian_year() * self.dt
+    }
 }
 
 /// Residual of the ψ = π Cassini condition α cos θ sin θ + g sin(θ − I)
@@ -234,6 +287,50 @@ mod tests {
 
     fn deg(theta: f64) -> f64 {
         theta * RAD2DEG
+    }
+
+    #[test]
+    fn typed_accessors_match_f64() {
+        use approx::assert_relative_eq;
+        use uom::si::angle::radian;
+        use uom::si::angular_velocity::radian_per_second;
+        use uom::si::time::second;
+        let sec_per_yr = 365.25 * 86_400.0;
+        let cfg = uranus_sweep(5.0);
+        let snaps = run_sweep(&cfg, cfg.t_total / 20.0);
+        let s = snaps.last().unwrap();
+        assert_relative_eq!(s.obliquity().get::<radian>(), s.obliquity, epsilon = 1e-12);
+        assert_relative_eq!(s.psi().get::<radian>(), s.psi, epsilon = 1e-12);
+        assert_relative_eq!(
+            s.time().get::<second>(),
+            s.t * sec_per_yr,
+            max_relative = 1e-9
+        );
+        assert_relative_eq!(
+            s.g().get::<radian_per_second>(),
+            s.g / sec_per_yr,
+            max_relative = 1e-9
+        );
+        assert_relative_eq!(
+            cfg.alpha().get::<radian_per_second>(),
+            cfg.alpha / sec_per_yr,
+            max_relative = 1e-9
+        );
+        assert_relative_eq!(
+            cfg.inclination().get::<radian>(),
+            cfg.inclination,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            cfg.t_total().get::<second>(),
+            cfg.t_total * sec_per_yr,
+            max_relative = 1e-9
+        );
+        assert_relative_eq!(
+            cfg.dt().get::<second>(),
+            cfg.dt * sec_per_yr,
+            max_relative = 1e-9
+        );
     }
 
     #[test]

--- a/crates/p9-2022-uranus-tilt/src/spin_axis.rs
+++ b/crates/p9-2022-uranus-tilt/src/spin_axis.rs
@@ -20,12 +20,20 @@
 use std::f64::consts::PI;
 
 use p9_core::constants::{J2_URANUS, RAD2DEG, RADIUS_URANUS_AU};
+use p9_core::units::{arcseconds, julian_year, km, AngularVelocity, Length};
 
 /// A regular satellite: (mass in kg, semi-major axis in km).
 #[derive(Debug, Clone, Copy)]
 pub struct Satellite {
     pub mass_kg: f64,
     pub a_km: f64,
+}
+
+impl Satellite {
+    /// Orbital semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        km(self.a_km)
+    }
 }
 
 /// Uranus' polar mass in kg (JPL).
@@ -132,6 +140,11 @@ pub fn alpha_arcsec_per_yr() -> f64 {
     alpha_rad_per_yr() * RAD2DEG * 3600.0
 }
 
+/// α as a typed [`AngularVelocity`] (arcsec per Julian year).
+pub fn alpha_typed() -> AngularVelocity {
+    (arcseconds(alpha_arcsec_per_yr()) / julian_year()).into()
+}
+
 /// Spin-axis precession period Tα = 2π / (α cos θ) in Myr at obliquity θ.
 pub fn precession_period_myr(theta_rad: f64) -> f64 {
     let rate = alpha_rad_per_yr() * theta_rad.cos().abs();
@@ -148,6 +161,22 @@ pub fn radius_consistency_ratio() -> f64 {
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
+
+    #[test]
+    fn typed_accessors_match_f64() {
+        use uom::si::angular_velocity::radian_per_second;
+        use uom::si::length::kilometer;
+        let moon = URANUS_MOONS[0];
+        assert_relative_eq!(
+            moon.semi_major_axis().get::<kilometer>(),
+            moon.a_km,
+            epsilon = 1e-9
+        );
+        // α typed (arcsec/yr) read back in rad/s matches the f64 source.
+        let alpha_rad_s = alpha_typed().get::<radian_per_second>();
+        let expect = alpha_rad_per_yr() / (365.25 * 86_400.0);
+        assert_relative_eq!(alpha_rad_s, expect, max_relative = 1e-9);
+    }
 
     #[test]
     fn radius_km_matches_core_radius_au() {

--- a/crates/p9-2023-lsst-strategy/Cargo.toml
+++ b/crates/p9-2023-lsst-strategy/Cargo.toml
@@ -14,3 +14,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2023-lsst-strategy/src/strategy.rs
+++ b/crates/p9-2023-lsst-strategy/src/strategy.rs
@@ -27,6 +27,7 @@
 //! computed from a real reference Planet Nine population in
 //! [`crate::discoverable`].
 
+use p9_core::units::{degrees, Angle};
 use serde::{Deserialize, Serialize};
 
 /// Published LSST single-visit and co-added depths and footprint parameters,
@@ -94,6 +95,19 @@ pub struct LsstStrategy {
 }
 
 impl LsstStrategy {
+    /// Southern declination limit as a typed [`Angle`].
+    pub fn dec_min(&self) -> Angle {
+        degrees(self.dec_min_deg)
+    }
+    /// Northern declination limit as a typed [`Angle`].
+    pub fn dec_max(&self) -> Angle {
+        degrees(self.dec_max_deg)
+    }
+    /// Galactic-plane avoidance limit as a typed [`Angle`].
+    pub fn galactic_lat_min(&self) -> Angle {
+        degrees(self.galactic_lat_min_deg)
+    }
+
     /// The baseline LSST strategy from the [`published`] reference constants.
     /// Detection uses the single-visit depth (a slow mover must be detectable
     /// on individual nights to be *linked*).
@@ -196,6 +210,19 @@ pub fn binomial_survival(n: u32, k: u32, p: f64) -> f64 {
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
+
+    #[test]
+    fn typed_declination_accessors_match_f64() {
+        use uom::si::angle::degree;
+        let s = LsstStrategy::baseline();
+        assert_relative_eq!(s.dec_min().get::<degree>(), s.dec_min_deg, epsilon = 1e-12);
+        assert_relative_eq!(s.dec_max().get::<degree>(), s.dec_max_deg, epsilon = 1e-12);
+        assert_relative_eq!(
+            s.galactic_lat_min().get::<degree>(),
+            s.galactic_lat_min_deg,
+            epsilon = 1e-12
+        );
+    }
 
     #[test]
     fn baseline_matches_published_reference_constants() {

--- a/crates/p9-2023-mond-efe/Cargo.toml
+++ b/crates/p9-2023-mond-efe/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2023-mond-efe/src/efe.rs
+++ b/crates/p9-2023-mond-efe/src/efe.rs
@@ -33,6 +33,7 @@
 use nalgebra::Vector3;
 
 use p9_core::coords::sky;
+use p9_core::units::{degrees, Angle};
 
 /// MOND acceleration scale `a0`, in m/s² (Milgrom 1983; Brown & Mathur 2023
 /// adopt the canonical value). Labelled reference constant; not used to set the
@@ -72,6 +73,16 @@ pub fn galactic_center_ecliptic_lat_deg() -> f64 {
     (n.z / n.norm()).asin().to_degrees()
 }
 
+/// Ecliptic longitude of the galactic-center direction as a typed [`Angle`].
+pub fn galactic_center_ecliptic_lon() -> Angle {
+    degrees(galactic_center_ecliptic_lon_deg())
+}
+
+/// Ecliptic latitude of the galactic-center direction as a typed [`Angle`].
+pub fn galactic_center_ecliptic_lat() -> Angle {
+    degrees(galactic_center_ecliptic_lat_deg())
+}
+
 /// EFE quadrupole perturbing potential per unit mass (AU²/day²) at a
 /// heliocentric ecliptic position `r` (AU):
 ///
@@ -99,6 +110,21 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use p9_core::coords::sky;
+
+    #[test]
+    fn typed_galactic_center_angles_match_f64() {
+        use uom::si::angle::degree;
+        assert_relative_eq!(
+            galactic_center_ecliptic_lon().get::<degree>(),
+            galactic_center_ecliptic_lon_deg(),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            galactic_center_ecliptic_lat().get::<degree>(),
+            galactic_center_ecliptic_lat_deg(),
+            epsilon = 1e-12
+        );
+    }
 
     #[test]
     fn test_galactic_center_is_unit_and_round_trips() {

--- a/crates/p9-2023-mond-efe/src/secular.rs
+++ b/crates/p9-2023-mond-efe/src/secular.rs
@@ -30,6 +30,7 @@ use std::f64::consts::{PI, TAU};
 use nalgebra::Vector3;
 
 use p9_core::constants::GM_SUN;
+use p9_core::units::{days, radians, AngularVelocity};
 
 use crate::efe::efe_potential;
 
@@ -110,6 +111,11 @@ pub fn averaged_disturbing(
 /// Mean motion n = sqrt(GM_sun / a³) (rad/day).
 pub fn mean_motion(a: f64) -> f64 {
     (GM_SUN / (a * a * a)).sqrt()
+}
+
+/// Mean motion as a typed [`AngularVelocity`] (rad per day).
+pub fn mean_motion_typed(a: f64) -> AngularVelocity {
+    (radians(mean_motion(a)) / days(1.0)).into()
 }
 
 /// Secular apsidal precession rate dϖ/dt (rad/day) from Lagrange's planetary
@@ -259,6 +265,18 @@ mod tests {
     /// directly comparable quantity.
     fn ecliptic_plane() -> PlaneGeometry {
         PlaneGeometry::from_normal(Vector3::new(0.0, 0.0, 1.0))
+    }
+
+    #[test]
+    fn typed_mean_motion_matches_f64() {
+        use uom::si::angular_velocity::radian_per_second;
+        let a = 500.0;
+        // rad/day read back as rad/s matches mean_motion / seconds-per-day.
+        assert_relative_eq!(
+            mean_motion_typed(a).get::<radian_per_second>(),
+            mean_motion(a) / 86_400.0,
+            max_relative = 1e-9
+        );
     }
 
     #[test]

--- a/crates/p9-2024-neptune-crossing/Cargo.toml
+++ b/crates/p9-2024-neptune-crossing/Cargo.toml
@@ -15,3 +15,6 @@ approx = { workspace = true }
 # Live JPL SBDB refresh path for the frozen sample table (see
 # `observed_tnos`); default builds and tests stay offline.
 sbdb-refresh = ["p9-core/sbdb-refresh"]
+
+[dev-dependencies]
+uom = "0.38.0"

--- a/crates/p9-2024-neptune-crossing/src/observed_tnos.rs
+++ b/crates/p9-2024-neptune-crossing/src/observed_tnos.rs
@@ -18,6 +18,7 @@
 //! fabricated entries ("2016 QV89" is a ~30 m NEA, "2014 LU28" is a
 //! retrograde centaur); both are gone.
 
+use p9_core::units::{au, degrees, Angle, Length};
 use serde::{Deserialize, Serialize};
 
 /// Provenance statement for the table below (tested non-empty and SBDB-sourced).
@@ -40,11 +41,41 @@ pub struct NeptuneCrossingTno {
     pub q: f64,
 }
 
+impl NeptuneCrossingTno {
+    /// Semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
+    }
+    /// Inclination as a typed [`Angle`].
+    pub fn inclination(&self) -> Angle {
+        degrees(self.i)
+    }
+    /// Perihelion distance as a typed [`Length`].
+    pub fn perihelion(&self) -> Length {
+        au(self.q)
+    }
+}
+
 /// Selection criteria for the Neptune-crossing TNO sample.
 pub struct SelectionCriteria {
     pub a_min: f64,
     pub i_max: f64,
     pub q_max: f64,
+}
+
+impl SelectionCriteria {
+    /// Minimum semi-major axis as a typed [`Length`].
+    pub fn a_min(&self) -> Length {
+        au(self.a_min)
+    }
+    /// Maximum inclination as a typed [`Angle`].
+    pub fn i_max(&self) -> Angle {
+        degrees(self.i_max)
+    }
+    /// Maximum perihelion as a typed [`Length`].
+    pub fn q_max(&self) -> Length {
+        au(self.q_max)
+    }
 }
 
 /// Returns the selection criteria used in the paper.
@@ -230,6 +261,37 @@ mod tests {
     #[test]
     fn test_sample_size() {
         assert_eq!(observed_sample().len(), 17);
+    }
+
+    #[test]
+    fn typed_accessors_match_f64() {
+        use approx::assert_relative_eq;
+        use uom::si::angle::degree;
+        use uom::si::length::astronomical_unit;
+        let t = &observed_sample()[0];
+        assert_relative_eq!(
+            t.semi_major_axis().get::<astronomical_unit>(),
+            t.a,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(t.inclination().get::<degree>(), t.i, epsilon = 1e-12);
+        assert_relative_eq!(
+            t.perihelion().get::<astronomical_unit>(),
+            t.q,
+            epsilon = 1e-12
+        );
+        let c = selection_criteria();
+        assert_relative_eq!(
+            c.a_min().get::<astronomical_unit>(),
+            c.a_min,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(c.i_max().get::<degree>(), c.i_max, epsilon = 1e-12);
+        assert_relative_eq!(
+            c.q_max().get::<astronomical_unit>(),
+            c.q_max,
+            epsilon = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2024-neptune-crossing/src/simulation.rs
+++ b/crates/p9-2024-neptune-crossing/src/simulation.rs
@@ -18,13 +18,14 @@
 //! linearly with the perturber mass); the paper-scale configuration runs in
 //! the `#[ignore]`d `full_scale` test.
 
-use p9_core::constants::{DEG2RAD, GM_SUN, YEAR_DAYS};
+use p9_core::constants::{DEG2RAD, GM_SUN, GYR_DAYS, YEAR_DAYS};
 use p9_core::forces::ExtraForce;
 use p9_core::initial_conditions::planets::neptune_j2000;
 use p9_core::integrator::whm::WhmIntegrator;
 use p9_core::types::{
     cartesian_to_elements, elements_to_cartesian, OrbitalElements, P9Params, SimConfig, StateVector,
 };
+use p9_core::units::{au, days, degrees, Angle, Length, Time};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
@@ -40,6 +41,11 @@ pub struct P9InclusiveConfig {
 }
 
 impl P9InclusiveConfig {
+    /// Integration time as a typed [`Time`].
+    pub fn integration_time(&self) -> Time {
+        days(self.t_gyr * GYR_DAYS)
+    }
+
     /// Default configuration matching the paper: m=5 ME, a=500, e=0.25,
     /// i=20 deg, ~2000 particles, 4 Gyr.
     pub fn default_paper() -> Self {
@@ -71,6 +77,11 @@ pub struct P9FreeConfig {
 }
 
 impl P9FreeConfig {
+    /// Integration time as a typed [`Time`].
+    pub fn integration_time(&self) -> Time {
+        days(self.t_gyr * GYR_DAYS)
+    }
+
     /// Default null model configuration.
     pub fn default_paper() -> Self {
         Self {
@@ -109,6 +120,15 @@ pub struct SimulationOptions {
 }
 
 impl SimulationOptions {
+    /// Total integration time as a typed [`Time`].
+    pub fn total_time(&self) -> Time {
+        days(self.t_days)
+    }
+    /// WHM timestep as a typed [`Time`].
+    pub fn timestep(&self) -> Time {
+        days(self.dt_days)
+    }
+
     /// Reduced-scale options used by `quick_test_simulation`: 24 particles,
     /// 3 Myr, Neptune absorbed into the ring (20,000-day steps), and P9's
     /// mass boosted 60x (300 M_earth) so the run applies the secular forcing
@@ -158,6 +178,21 @@ pub struct Footprint {
     pub q: f64,
     /// Inclination (deg)
     pub i_deg: f64,
+}
+
+impl Footprint {
+    /// Semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
+    }
+    /// Perihelion as a typed [`Length`].
+    pub fn perihelion(&self) -> Length {
+        au(self.q)
+    }
+    /// Inclination as a typed [`Angle`].
+    pub fn inclination(&self) -> Angle {
+        degrees(self.i_deg)
+    }
 }
 
 /// Result of a simulation run, storing orbital footprint statistics.
@@ -354,6 +389,43 @@ pub fn quick_test_simulation(with_p9: bool) -> SimulationResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn typed_accessors_match_f64() {
+        use approx::assert_relative_eq;
+        use uom::si::angle::degree;
+        use uom::si::length::astronomical_unit;
+        use uom::si::time::day;
+        let cfg = P9InclusiveConfig::default_paper();
+        assert_relative_eq!(
+            cfg.integration_time().get::<day>(),
+            cfg.t_gyr * GYR_DAYS,
+            max_relative = 1e-12
+        );
+        let opts = SimulationOptions::reduced_scale(true);
+        assert_relative_eq!(
+            opts.total_time().get::<day>(),
+            opts.t_days,
+            max_relative = 1e-9
+        );
+        assert_relative_eq!(opts.timestep().get::<day>(), opts.dt_days, epsilon = 1e-9);
+        let fp = Footprint {
+            a: 150.0,
+            q: 28.0,
+            i_deg: 12.0,
+        };
+        assert_relative_eq!(
+            fp.semi_major_axis().get::<astronomical_unit>(),
+            fp.a,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            fp.perihelion().get::<astronomical_unit>(),
+            fp.q,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(fp.inclination().get::<degree>(), fp.i_deg, epsilon = 1e-12);
+    }
 
     #[test]
     fn test_p9_inclusive_config() {

--- a/crates/p9-2024-oort-selfgrav/Cargo.toml
+++ b/crates/p9-2024-oort-selfgrav/Cargo.toml
@@ -13,3 +13,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2024-oort-selfgrav/src/vzlk.rs
+++ b/crates/p9-2024-oort-selfgrav/src/vzlk.rs
@@ -19,6 +19,7 @@
 use serde::{Deserialize, Serialize};
 
 use p9_core::constants::{GM_SUN, GYR_DAYS};
+use p9_core::units::{au, days, radians, Angle, Length, Time};
 
 use crate::hamiltonian::{secular_hamiltonian, HamiltonianParams};
 
@@ -31,6 +32,17 @@ pub struct VzlkPoint {
     pub q: f64,
     /// Hamiltonian value
     pub h_value: f64,
+}
+
+impl VzlkPoint {
+    /// Argument of perihelion as a typed [`Angle`].
+    pub fn omega(&self) -> Angle {
+        radians(self.omega)
+    }
+    /// Perihelion distance as a typed [`Length`].
+    pub fn perihelion(&self) -> Length {
+        au(self.q)
+    }
 }
 
 /// A point along an integrated secular trajectory.
@@ -48,6 +60,25 @@ pub struct TrajectoryPoint {
     pub q: f64,
     /// Hamiltonian value (conserved along the trajectory)
     pub h_value: f64,
+}
+
+impl TrajectoryPoint {
+    /// Time as a typed [`Time`].
+    pub fn time(&self) -> Time {
+        days(self.t_days)
+    }
+    /// Argument of perihelion as a typed [`Angle`].
+    pub fn omega(&self) -> Angle {
+        radians(self.omega)
+    }
+    /// Inclination as a typed [`Angle`].
+    pub fn inclination(&self) -> Angle {
+        radians(self.i)
+    }
+    /// Perihelion distance as a typed [`Length`].
+    pub fn perihelion(&self) -> Length {
+        au(self.q)
+    }
 }
 
 /// Configuration for vZLK phase portrait.
@@ -68,6 +99,19 @@ pub struct VzlkConfig {
 }
 
 impl VzlkConfig {
+    /// Fixed semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
+    }
+    /// Minimum perihelion as a typed [`Length`].
+    pub fn q_min(&self) -> Length {
+        au(self.q_min)
+    }
+    /// Maximum perihelion as a typed [`Length`].
+    pub fn q_max(&self) -> Length {
+        au(self.q_max)
+    }
+
     /// Configuration for a typical IOC object at a=1000 AU.
     pub fn default_paper() -> Self {
         Self {
@@ -300,6 +344,57 @@ mod tests {
             n_quadrature: 64,
             ..HamiltonianParams::default_paper()
         }
+    }
+
+    #[test]
+    fn typed_accessors_match_f64() {
+        use approx::assert_relative_eq;
+        use uom::si::angle::radian;
+        use uom::si::length::astronomical_unit;
+        use uom::si::time::day;
+        let cfg = VzlkConfig::default_paper();
+        assert_relative_eq!(
+            cfg.semi_major_axis().get::<astronomical_unit>(),
+            cfg.a,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            cfg.q_min().get::<astronomical_unit>(),
+            cfg.q_min,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            cfg.q_max().get::<astronomical_unit>(),
+            cfg.q_max,
+            epsilon = 1e-12
+        );
+        let p = VzlkPoint {
+            omega: 1.2,
+            q: 200.0,
+            h_value: 0.0,
+        };
+        assert_relative_eq!(p.omega().get::<radian>(), p.omega, epsilon = 1e-12);
+        assert_relative_eq!(
+            p.perihelion().get::<astronomical_unit>(),
+            p.q,
+            epsilon = 1e-12
+        );
+        let tp = TrajectoryPoint {
+            t_days: 1.0e6,
+            omega: 0.5,
+            e: 0.9,
+            i: 0.7,
+            q: 150.0,
+            h_value: 0.0,
+        };
+        assert_relative_eq!(tp.time().get::<day>(), tp.t_days, max_relative = 1e-12);
+        assert_relative_eq!(tp.omega().get::<radian>(), tp.omega, epsilon = 1e-12);
+        assert_relative_eq!(tp.inclination().get::<radian>(), tp.i, epsilon = 1e-12);
+        assert_relative_eq!(
+            tp.perihelion().get::<astronomical_unit>(),
+            tp.q,
+            epsilon = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2024-panstarrs/Cargo.toml
+++ b/crates/p9-2024-panstarrs/Cargo.toml
@@ -12,3 +12,6 @@ serde_json = { workspace = true }
 approx = { workspace = true }
 p9-2021-ztf = { version = "0.1.0", path = "../p9-2021-ztf" }
 p9-2022-des = { version = "0.1.0", path = "../p9-2022-des" }
+
+[dev-dependencies]
+uom = "0.38.0"

--- a/crates/p9-2024-panstarrs/src/combined_exclusion.rs
+++ b/crates/p9-2024-panstarrs/src/combined_exclusion.rs
@@ -19,6 +19,7 @@ use p9_core::constants::DEG2RAD;
 use p9_core::coords::observer::{EarthProvider, EarthState};
 use p9_core::data::reference_population::{generate_reference_population, heliocentric_distance};
 use p9_core::types::{OrbitalElements, P9Params};
+use p9_core::units::{au, earth_masses, Length, Mass};
 
 use crate::detection_pipeline::{
     detection_probability_for_orbit, detection_probability_for_orbit_with_earth,
@@ -88,6 +89,31 @@ impl UpdatedParameters {
             omega_big: 97.0 * DEG2RAD,
             mean_anomaly: 0.0,
         }
+    }
+
+    /// Median semi-major axis as a typed [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_median)
+    }
+    /// Upper semi-major axis uncertainty as a typed [`Length`].
+    pub fn a_upper(&self) -> Length {
+        au(self.a_upper)
+    }
+    /// Lower semi-major axis uncertainty as a typed [`Length`].
+    pub fn a_lower(&self) -> Length {
+        au(self.a_lower)
+    }
+    /// Median mass as a typed [`Mass`].
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth_median)
+    }
+    /// Upper mass uncertainty as a typed [`Mass`].
+    pub fn mass_upper(&self) -> Mass {
+        earth_masses(self.mass_upper)
+    }
+    /// Lower mass uncertainty as a typed [`Mass`].
+    pub fn mass_lower(&self) -> Mass {
+        earth_masses(self.mass_lower)
     }
 }
 
@@ -256,6 +282,43 @@ pub fn remaining_parameter_space(exclusion: &CombinedExclusion) -> f64 {
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
+
+    #[test]
+    fn updated_parameters_typed_accessors_match_f64() {
+        use uom::si::length::astronomical_unit;
+        use uom::si::mass::kilogram;
+        let p = UpdatedParameters::paper_values();
+        assert_relative_eq!(
+            p.semi_major_axis().get::<astronomical_unit>(),
+            p.a_median,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            p.a_upper().get::<astronomical_unit>(),
+            p.a_upper,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            p.a_lower().get::<astronomical_unit>(),
+            p.a_lower,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            p.mass().get::<kilogram>(),
+            earth_masses(p.mass_earth_median).get::<kilogram>(),
+            epsilon = 1.0
+        );
+        assert_relative_eq!(
+            p.mass_upper().get::<kilogram>(),
+            earth_masses(p.mass_upper).get::<kilogram>(),
+            epsilon = 1.0
+        );
+        assert_relative_eq!(
+            p.mass_lower().get::<kilogram>(),
+            earth_masses(p.mass_lower).get::<kilogram>(),
+            epsilon = 1.0
+        );
+    }
 
     #[test]
     fn paper_exclusion_values_from_shared_table() {


### PR DESCRIPTION
Adopts the `p9_core::units` typed (uom) boundary additively across seven crates. Every change is a new `pub fn` accessor returning the proper `uom` quantity alongside the existing `f64` field/function — no existing fields, signatures, or reference values were altered. Each crate gained `uom` as a dev-dependency and a round-trip test pinning each typed accessor against its `f64` source with `assert_relative_eq!`.

## Per crate

- **p9-2022-iras-candidate**: `CandidateReference::{distance, distance_err, mass, mass_lo, mass_hi}` and `CandidateInversion::distance` (Length/Mass). Flux (Jy) and temperature (K) left untyped — no constructors.
- **p9-2022-uranus-tilt**: `Satellite::semi_major_axis` (Length), `SpinSnapshot::{time, obliquity, psi, g}` and `SweepConfig::{alpha, inclination, g_initial, g_final, t_total, dt}` (Time/Angle/AngularVelocity), plus `spin_axis::alpha_typed` and `uranus_obliquity` siblings. `Satellite::mass_kg` left untyped — no kilogram constructor.
- **p9-2023-lsst-strategy**: `LsstStrategy::{dec_min, dec_max, galactic_lat_min}` (Angle). Depths/magnitudes, fractions and probabilities left untyped (dimensionless).
- **p9-2023-mond-efe**: `efe::{galactic_center_ecliptic_lon, galactic_center_ecliptic_lat}` (Angle) and `secular::mean_motion_typed` (AngularVelocity) siblings. Vector3 fields and AU^2/day^2 potentials untouched.
- **p9-2024-neptune-crossing**: `NeptuneCrossingTno::{semi_major_axis, inclination, perihelion}`, `SelectionCriteria::{a_min, i_max, q_max}`, `Footprint::{semi_major_axis, perihelion, inclination}`, `SimulationOptions::{total_time, timestep}`, `P9InclusiveConfig`/`P9FreeConfig::integration_time`.
- **p9-2024-oort-selfgrav**: `VzlkPoint::{omega, perihelion}`, `TrajectoryPoint::{time, omega, inclination, perihelion}`, `VzlkConfig::{semi_major_axis, q_min, q_max}`.
- **p9-2024-panstarrs**: `UpdatedParameters::{semi_major_axis, a_upper, a_lower, mass, mass_upper, mass_lower}` (Length/Mass). V-magnitudes and exclusion fractions left untyped (dimensionless).

## Skips
None of the seven crates were skipped; each had at least one dimensional public scalar. Pure-statistics surfaces within them (probabilities, counts, magnitudes, exclusion fractions, dimensionless Hamiltonian values) were intentionally left untyped.

## Verification
`cargo build` and `cargo test` pass for all seven crates; `cargo fmt` applied.