### PR TITLE
Add typed uom accessors to 2024-2025 paper crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1843,6 +1843,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1856,6 +1857,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1868,6 +1870,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1881,6 +1884,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1894,6 +1898,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1904,6 +1909,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1914,6 +1920,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]

--- a/crates/p9-2024-primordial-alignment/Cargo.toml
+++ b/crates/p9-2024-primordial-alignment/Cargo.toml
@@ -11,3 +11,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2024-primordial-alignment/src/convergence.rs
+++ b/crates/p9-2024-primordial-alignment/src/convergence.rs
@@ -41,6 +41,7 @@
 use crate::precession::apsidal_precession_rate;
 use p9_core::analysis::circular::mean_resultant_length;
 use p9_core::data::etno::{Etno, BROWN_2017_SAMPLE};
+use p9_core::units::{julian_year, radians, Angle, AngularVelocity};
 
 /// Published reference: the sednoids' apsides converge near solar-system
 /// formation, ~4.5 Gyr ago (Huang & Gladman 2024).
@@ -60,6 +61,21 @@ impl Precessor {
     /// (τ ≥ 0): ϖ(−τ) = ϖ₀ − ϖ̇·τ.
     pub fn varpi_at_lookback(&self, tau_yr: f64) -> f64 {
         self.varpi0 - self.rate_rad_per_yr * tau_yr
+    }
+
+    /// Present-day longitude of perihelion ϖ₀ as a dimension-checked [`Angle`].
+    pub fn varpi0_angle(&self) -> Angle {
+        radians(self.varpi0)
+    }
+
+    /// Apsidal precession rate as a typed [`AngularVelocity`] (rad/yr storage).
+    pub fn rate(&self) -> AngularVelocity {
+        (radians(self.rate_rad_per_yr) / julian_year()).into()
+    }
+
+    /// Longitude of perihelion at look-back time `tau_yr` years as an [`Angle`].
+    pub fn varpi_at_lookback_typed(&self, tau_yr: f64) -> Angle {
+        radians(self.varpi_at_lookback(tau_yr))
     }
 }
 
@@ -159,6 +175,29 @@ pub fn primordial_convergence_epoch(age_gyr: f64, n_steps: usize) -> Convergence
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+    use uom::si::angle::radian;
+    use uom::si::angular_velocity::radian_per_second;
+    use uom::si::time::second;
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        let p = observed_sednoids()[0];
+        // Angle accessors read back exactly in radians.
+        assert_relative_eq!(p.varpi0_angle().get::<radian>(), p.varpi0, epsilon = 1e-12);
+        assert_relative_eq!(
+            p.varpi_at_lookback_typed(1.0e8).get::<radian>(),
+            p.varpi_at_lookback(1.0e8),
+            epsilon = 1e-9
+        );
+        // The rad/yr rate, read back in rad/s, equals the f64 rate / seconds-per-year.
+        let yr_s = julian_year().get::<second>();
+        assert_relative_eq!(
+            p.rate().get::<radian_per_second>(),
+            p.rate_rad_per_yr / yr_s,
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn test_primordial_alignment_back_converges_at_birth_epoch() {

--- a/crates/p9-2024-siraj-orbit/Cargo.toml
+++ b/crates/p9-2024-siraj-orbit/Cargo.toml
@@ -13,3 +13,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2024-siraj-orbit/src/posterior.rs
+++ b/crates/p9-2024-siraj-orbit/src/posterior.rs
@@ -23,6 +23,7 @@
 use crate::confinement::observed_forcing;
 use crate::forcing::forcing_strength;
 use p9_core::data::ephemeris_constraint::{SIRAJ_2024_A_AU, SIRAJ_2024_MASS_EARTH};
+use p9_core::units::{au, earth_masses, Length, Mass};
 
 /// A point in the (mass, semi-major axis) inference space.
 #[derive(Debug, Clone, Copy)]
@@ -31,6 +32,18 @@ pub struct OrbitPoint {
     pub mass_earth: f64,
     /// Perturber semi-major axis in AU.
     pub a_p: f64,
+}
+
+impl OrbitPoint {
+    /// Perturber mass as a dimension-checked [`Mass`].
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+
+    /// Perturber semi-major axis as a dimension-checked [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_p)
+    }
 }
 
 /// The (m, a_p) posterior model.
@@ -138,7 +151,30 @@ pub fn calibrated_posterior(angles: &[f64]) -> ForcingPosterior {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use p9_core::data::etno::longitudes_of_perihelion;
+    use uom::si::length::astronomical_unit;
+    use uom::si::mass::kilogram;
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        let p = OrbitPoint {
+            mass_earth: SIRAJ_2024_MASS_EARTH,
+            a_p: SIRAJ_2024_A_AU,
+        };
+        assert_relative_eq!(
+            p.semi_major_axis().get::<astronomical_unit>(),
+            p.a_p,
+            epsilon = 1e-12
+        );
+        // Mass reads back in Earth masses via the kg ratio.
+        let earth_kg = earth_masses(1.0).get::<kilogram>();
+        assert_relative_eq!(
+            p.mass().get::<kilogram>() / earth_kg,
+            p.mass_earth,
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn test_neg2_log_post_minimized_on_ridge_at_aref() {

--- a/crates/p9-2025-akari-refutation/Cargo.toml
+++ b/crates/p9-2025-akari-refutation/Cargo.toml
@@ -12,3 +12,4 @@ nalgebra.workspace = true
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2025-akari-refutation/src/consistency.rs
+++ b/crates/p9-2025-akari-refutation/src/consistency.rs
@@ -45,6 +45,7 @@ use p9_core::coords::candidate_pair::{
     annual_proper_motion_circular, implied_distance_circular, transverse_rate_rad_day,
 };
 use p9_core::coords::observer::{EarthProvider, EarthState, Time, Timescale};
+use p9_core::units::{self, arcseconds, au, days, Angle, Length};
 
 /// Arcminutes per radian.
 const ARCMIN_PER_RAD: f64 = RAD2DEG * 60.0;
@@ -175,6 +176,11 @@ pub fn baseline_days() -> f64 {
     t2.tdb() - t1.tdb()
 }
 
+/// The two-epoch baseline as a dimension-checked [`units::Time`].
+pub fn baseline_duration() -> units::Time {
+    days(baseline_days())
+}
+
 /// Result of the bound-object consistency check at one assumed distance.
 #[derive(Debug, Clone)]
 pub struct ConsistencyVerdict {
@@ -192,6 +198,29 @@ pub struct ConsistencyVerdict {
     /// Whether the observed separation lies inside the bound-object
     /// envelope at all (i.e. reproducible only at the envelope extreme).
     pub within_bound_envelope: bool,
+}
+
+impl ConsistencyVerdict {
+    /// Assumed heliocentric distance as a dimension-checked [`Length`].
+    pub fn distance(&self) -> Length {
+        au(self.d_au)
+    }
+
+    /// Observed candidate separation as a dimension-checked [`Angle`].
+    pub fn observed_separation(&self) -> Angle {
+        arcseconds(self.observed_arcmin * 60.0)
+    }
+
+    /// Maximum bound-object parallax at the real epochs as an [`Angle`].
+    pub fn max_parallax(&self) -> Angle {
+        arcseconds(self.max_parallax_arcmin * 60.0)
+    }
+
+    /// Maximum bound-object total (parallax + proper motion) separation as
+    /// an [`Angle`].
+    pub fn max_bound_total(&self) -> Angle {
+        arcseconds(self.max_bound_total_arcmin * 60.0)
+    }
 }
 
 /// Run the full consistency check at distance `d_au` using Earth states from
@@ -231,8 +260,43 @@ pub fn max_circular_proper_motion(d_min: f64, _d_max: f64) -> f64 {
 mod tests {
     use super::*;
     use crate::published;
+    use approx::assert_relative_eq;
     use p9_core::constants::YEAR_DAYS;
     use p9_core::coords::observer::CircularEarth;
+    use uom::si::angle::minute;
+    use uom::si::length::astronomical_unit;
+    use uom::si::time::day;
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        let mut circ = CircularEarth;
+        let v = check(&mut circ, 600.0, 0.7);
+        assert_relative_eq!(
+            v.distance().get::<astronomical_unit>(),
+            v.d_au,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            v.observed_separation().get::<minute>(),
+            v.observed_arcmin,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            v.max_parallax().get::<minute>(),
+            v.max_parallax_arcmin,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            v.max_bound_total().get::<minute>(),
+            v.max_bound_total_arcmin,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            baseline_duration().get::<day>(),
+            baseline_days(),
+            epsilon = 1e-9
+        );
+    }
 
     /// Earth states from the ephemeris when available, else the analytic
     /// circular-Earth fallback (the parallax budget is set by Earth's

--- a/crates/p9-2025-akari-refutation/src/expected_motion.rs
+++ b/crates/p9-2025-akari-refutation/src/expected_motion.rs
@@ -18,6 +18,7 @@
 
 use p9_core::constants::RAD2DEG;
 use p9_core::coords::candidate_pair::transverse_rate_arcmin_yr;
+use p9_core::units::{arcseconds, Angle};
 
 /// Arcminutes per radian.
 const ARCMIN_PER_RAD: f64 = RAD2DEG * 60.0;
@@ -39,6 +40,11 @@ pub fn parallax_six_month_arcmin(d_au: f64) -> f64 {
     2.0 * parallax_half_amplitude_arcmin(d_au)
 }
 
+/// Six-month parallactic swing as a dimension-checked [`Angle`].
+pub fn parallax_six_month(d_au: f64) -> Angle {
+    arcseconds(parallax_six_month_arcmin(d_au) * 60.0)
+}
+
 /// Six-month proper motion (arcmin) for an object at heliocentric distance
 /// `r_au` on an orbit (`a_au`, `e`), from the heliocentric transverse rate.
 /// For a circular orbit pass `a_au == r_au`, `e == 0`.
@@ -49,6 +55,11 @@ pub fn proper_motion_six_month_arcmin(r_au: f64, a_au: f64, e: f64) -> f64 {
 /// Circular-orbit six-month proper motion (arcmin) at distance `d_au`.
 pub fn proper_motion_six_month_circular_arcmin(d_au: f64) -> f64 {
     proper_motion_six_month_arcmin(d_au, d_au, 0.0)
+}
+
+/// Circular-orbit six-month proper motion as a dimension-checked [`Angle`].
+pub fn proper_motion_six_month_circular(d_au: f64) -> Angle {
+    arcseconds(proper_motion_six_month_circular_arcmin(d_au) * 60.0)
 }
 
 /// The six-month parallax range (arcmin) over a distance interval
@@ -81,6 +92,22 @@ mod tests {
     use super::*;
     use crate::published;
     use approx::assert_relative_eq;
+    use uom::si::angle::minute;
+
+    #[test]
+    fn typed_accessors_match_arcmin_sources() {
+        // The typed angles read back in arcminutes exactly.
+        assert_relative_eq!(
+            parallax_six_month(600.0).get::<minute>(),
+            parallax_six_month_arcmin(600.0),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            proper_motion_six_month_circular(600.0).get::<minute>(),
+            proper_motion_six_month_circular_arcmin(600.0),
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn parallax_half_amplitude_at_600au_is_5_73_arcmin() {

--- a/crates/p9-2025-clustering/Cargo.toml
+++ b/crates/p9-2025-clustering/Cargo.toml
@@ -14,3 +14,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2025-clustering/src/clone_generation.rs
+++ b/crates/p9-2025-clustering/src/clone_generation.rs
@@ -24,6 +24,7 @@
 use p9_core::constants::{A_NEPTUNE_AU, DEG2RAD, TWO_PI};
 use p9_core::data::etno::BROWN_2017_SAMPLE;
 use p9_core::types::OrbitalElements;
+use p9_core::units::{au, radians, Angle, Length};
 use rand::Rng;
 use rand_distr::{Distribution, Normal, Uniform};
 use serde::{Deserialize, Serialize};
@@ -70,6 +71,26 @@ impl ObservedTno {
     pub fn varpi(&self) -> f64 {
         (self.omega + self.omega_big).rem_euclid(TWO_PI)
     }
+
+    /// Semi-major axis as a dimension-checked [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
+    }
+
+    /// Perihelion distance `q = a(1 − e)` as a dimension-checked [`Length`].
+    pub fn perihelion_typed(&self) -> Length {
+        au(self.perihelion())
+    }
+
+    /// Inclination as a dimension-checked [`Angle`].
+    pub fn inclination_typed(&self) -> Angle {
+        radians(self.i)
+    }
+
+    /// Longitude of perihelion ϖ as a dimension-checked [`Angle`].
+    pub fn varpi_typed(&self) -> Angle {
+        radians(self.varpi())
+    }
 }
 
 /// A clone of a TNO with sampled orbital elements (all six, including the
@@ -101,6 +122,16 @@ impl TnoClone {
     /// Longitude of perihelion ϖ = ω + Ω (rad), wrapped to [0, 2π).
     pub fn varpi(&self) -> f64 {
         (self.omega + self.omega_big).rem_euclid(TWO_PI)
+    }
+
+    /// Perihelion distance `q = a(1 − e)` as a dimension-checked [`Length`].
+    pub fn perihelion_typed(&self) -> Length {
+        au(self.perihelion())
+    }
+
+    /// Longitude of perihelion ϖ as a dimension-checked [`Angle`].
+    pub fn varpi_typed(&self) -> Angle {
+        radians(self.varpi())
     }
 
     /// Full orbital element set for integration.
@@ -207,7 +238,48 @@ fn passes_selection_ref(tno: &ObservedTno) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use rand::SeedableRng;
+    use uom::si::angle::radian;
+    use uom::si::length::astronomical_unit;
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        let tno = &distant_tno_sample()[0];
+        assert_relative_eq!(
+            tno.semi_major_axis().get::<astronomical_unit>(),
+            tno.a,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            tno.perihelion_typed().get::<astronomical_unit>(),
+            tno.perihelion(),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            tno.inclination_typed().get::<radian>(),
+            tno.i,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            tno.varpi_typed().get::<radian>(),
+            tno.varpi(),
+            epsilon = 1e-12
+        );
+
+        let mut rng = rand::rngs::StdRng::seed_from_u64(1);
+        let clone = &generate_clones(tno, 1, &mut rng)[0];
+        assert_relative_eq!(
+            clone.perihelion_typed().get::<astronomical_unit>(),
+            clone.perihelion(),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            clone.varpi_typed().get::<radian>(),
+            clone.varpi(),
+            epsilon = 1e-12
+        );
+    }
 
     #[test]
     fn test_sample_from_vetted_table() {

--- a/crates/p9-2025-clustering/src/orbital_poles.rs
+++ b/crates/p9-2025-clustering/src/orbital_poles.rs
@@ -19,6 +19,7 @@ use p9_core::constants::GM_SUN;
 use p9_core::coords::sky::angular_distance;
 use p9_core::initial_conditions::planets::{giant_planets_at, giant_planets_j2000, Time};
 use p9_core::types::{cartesian_to_elements, MassiveBody};
+use p9_core::units::{julian_year, radians, Angle, AngularVelocity};
 use serde::{Deserialize, Serialize};
 
 /// Orbital pole, stored as inclination + node with the planar projection
@@ -49,6 +50,16 @@ impl OrbitalPole {
     /// Position angle (longitude of ascending node in rad).
     pub fn omega_big(&self) -> f64 {
         self.y.atan2(self.x)
+    }
+
+    /// Inclination as a dimension-checked [`Angle`].
+    pub fn inclination_typed(&self) -> Angle {
+        radians(self.inclination())
+    }
+
+    /// Longitude of ascending node as a dimension-checked [`Angle`].
+    pub fn omega_big_typed(&self) -> Angle {
+        radians(self.omega_big())
     }
 
     /// Unit vector of the orbit normal in ecliptic coordinates:
@@ -148,10 +159,43 @@ pub fn nodal_precession_rate(a: f64, e: f64, i: f64) -> f64 {
     rate_day * 365.25 // Convert to rad/yr
 }
 
+/// Nodal precession rate as a typed [`AngularVelocity`] (the rad/yr value of
+/// [`nodal_precession_rate`] carried with units).
+pub fn nodal_precession_rate_typed(a: f64, e: f64, i: f64) -> AngularVelocity {
+    (radians(nodal_precession_rate(a, e, i)) / julian_year()).into()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use p9_core::constants::DEG2RAD;
+    use uom::si::angle::radian;
+    use uom::si::angular_velocity::radian_per_second;
+    use uom::si::time::second;
+
+    #[test]
+    fn typed_pole_and_rate_match_f64_sources() {
+        let pole = OrbitalPole::from_elements("t", 30.0 * DEG2RAD, 45.0 * DEG2RAD);
+        assert_relative_eq!(
+            pole.inclination_typed().get::<radian>(),
+            pole.inclination(),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            pole.omega_big_typed().get::<radian>(),
+            pole.omega_big(),
+            epsilon = 1e-12
+        );
+        // rad/yr rate read back in rad/s matches the f64 rate / seconds-per-year.
+        let yr_s = julian_year().get::<second>();
+        let (a, e, i) = (300.0, 0.7, 20.0 * DEG2RAD);
+        assert_relative_eq!(
+            nodal_precession_rate_typed(a, e, i).get::<radian_per_second>(),
+            nodal_precession_rate(a, e, i) / yr_s,
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn test_orbital_pole_from_elements() {

--- a/crates/p9-2025-clustering/src/pipeline.rs
+++ b/crates/p9-2025-clustering/src/pipeline.rs
@@ -19,6 +19,7 @@ use p9_core::forces::ExtraForce;
 use p9_core::initial_conditions::planets::neptune_j2000;
 use p9_core::integrator::whm::WhmIntegrator;
 use p9_core::types::{cartesian_to_elements, P9Params, SimConfig, StateVector};
+use p9_core::units::{days, julian_year, radians, Angle, Time};
 use rand::SeedableRng;
 use serde::{Deserialize, Serialize};
 
@@ -75,6 +76,21 @@ impl PipelineConfig {
             p9: None,
         }
     }
+
+    /// Total integration time as a dimension-checked [`Time`].
+    pub fn total_time(&self) -> Time {
+        julian_year() * self.t_total_yr
+    }
+
+    /// Integration timestep as a dimension-checked [`Time`].
+    pub fn timestep(&self) -> Time {
+        days(self.dt_days)
+    }
+
+    /// Snapshot cadence as a dimension-checked [`Time`].
+    pub fn snapshot_interval(&self) -> Time {
+        julian_year() * self.snapshot_interval_yr
+    }
 }
 
 /// Per-TNO pipeline output.
@@ -93,6 +109,13 @@ pub struct TnoResult {
     pub class: StabilityClass,
     /// Clones lost to the integration boundaries
     pub n_escaped: usize,
+}
+
+impl TnoResult {
+    /// Observed longitude of perihelion ϖ as a dimension-checked [`Angle`].
+    pub fn varpi_typed(&self) -> Angle {
+        radians(self.varpi)
+    }
 }
 
 /// Computed pipeline results (no hard-coded paper numbers).
@@ -257,6 +280,41 @@ pub fn run_pipeline(config: &PipelineConfig) -> PipelineResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+    use uom::si::angle::radian;
+    use uom::si::time::day;
+
+    #[test]
+    fn config_typed_times_match_f64_sources() {
+        let c = PipelineConfig::smoke();
+        assert_relative_eq!(c.timestep().get::<day>(), c.dt_days, epsilon = 1e-9);
+        // Years convert through the Julian-year length.
+        let yr_d = julian_year().get::<day>();
+        assert_relative_eq!(
+            c.total_time().get::<day>(),
+            c.t_total_yr * yr_d,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            c.snapshot_interval().get::<day>(),
+            c.snapshot_interval_yr * yr_d,
+            max_relative = 1e-12
+        );
+    }
+
+    #[test]
+    fn tno_result_varpi_typed_matches_f64() {
+        let r = TnoResult {
+            name: "x",
+            varpi: 1.234,
+            d_mean: 0.0,
+            d_std: 0.0,
+            d_analytical: 0.0,
+            class: StabilityClass::Stable,
+            n_escaped: 0,
+        };
+        assert_relative_eq!(r.varpi_typed().get::<radian>(), r.varpi, epsilon = 1e-12);
+    }
 
     /// Reduced-scale smoke run: real integration, real statistics.
     #[test]

--- a/crates/p9-2025-iras-akari/Cargo.toml
+++ b/crates/p9-2025-iras-akari/Cargo.toml
@@ -11,3 +11,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 approx = { workspace = true }
 nalgebra.workspace = true
+
+[dev-dependencies]
+uom = "0.38.0"

--- a/crates/p9-2025-iras-akari/src/candidate_search.rs
+++ b/crates/p9-2025-iras-akari/src/candidate_search.rs
@@ -13,6 +13,7 @@
 //! The paper finds 13 pairs after step 4, and 1 good candidate after step 6.
 
 use p9_core::coords::candidate_pair::implied_distance;
+use p9_core::units::{arcseconds, au, Angle, Length};
 use serde::{Deserialize, Serialize};
 
 use crate::survey_model::{angular_separation_arcmin, FirSource};
@@ -33,6 +34,18 @@ pub struct SelectionCriteria {
     /// positional uncertainty (the catalogued 20"/30" errors were
     /// previously carried but never used in the match).
     pub pos_err_n_sigma: f64,
+}
+
+impl SelectionCriteria {
+    /// Minimum angular separation as a dimension-checked [`Angle`].
+    pub fn sep_min(&self) -> Angle {
+        arcseconds(self.sep_min_arcmin * 60.0)
+    }
+
+    /// Maximum angular separation as a dimension-checked [`Angle`].
+    pub fn sep_max(&self) -> Angle {
+        arcseconds(self.sep_max_arcmin * 60.0)
+    }
 }
 
 impl SelectionCriteria {
@@ -80,6 +93,23 @@ pub struct CandidatePair {
     pub implied_distance_au: f64,
     /// Flux ratio (IRAS 60µm / AKARI 90µm)
     pub flux_ratio: f64,
+}
+
+impl CandidatePair {
+    /// Angular separation as a dimension-checked [`Angle`].
+    pub fn separation(&self) -> Angle {
+        arcseconds(self.separation_arcmin * 60.0)
+    }
+
+    /// Combined 1σ positional uncertainty as a dimension-checked [`Angle`].
+    pub fn combined_pos_err(&self) -> Angle {
+        arcseconds(self.combined_pos_err_arcmin * 60.0)
+    }
+
+    /// Implied heliocentric distance as a dimension-checked [`Length`].
+    pub fn implied_distance(&self) -> Length {
+        au(self.implied_distance_au)
+    }
 }
 
 /// Result of the candidate search.
@@ -249,7 +279,44 @@ pub fn false_alarm_probability(expected_pairs: f64) -> f64 {
 mod tests {
     use super::*;
     use crate::survey_model::Survey;
+    use approx::assert_relative_eq;
     use rand::{Rng, SeedableRng};
+    use uom::si::angle::minute;
+    use uom::si::length::astronomical_unit;
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        let criteria = SelectionCriteria::default();
+        assert_relative_eq!(
+            criteria.sep_min().get::<minute>(),
+            criteria.sep_min_arcmin,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            criteria.sep_max().get::<minute>(),
+            criteria.sep_max_arcmin,
+            max_relative = 1e-12
+        );
+
+        let iras = vec![make_iras_source(180.0, 45.0, 0.5)];
+        let akari = vec![make_akari_source(180.0, 46.0, 0.6)];
+        let pair = &search_candidates(&iras, &akari, &criteria, 23.0).candidates[0];
+        assert_relative_eq!(
+            pair.separation().get::<minute>(),
+            pair.separation_arcmin,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            pair.combined_pos_err().get::<minute>(),
+            pair.combined_pos_err_arcmin,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            pair.implied_distance().get::<astronomical_unit>(),
+            pair.implied_distance_au,
+            epsilon = 1e-9
+        );
+    }
 
     fn make_iras_source(ra: f64, dec: f64, flux: f64) -> FirSource {
         FirSource {

--- a/crates/p9-2025-iras-akari/src/orbital_constraints.rs
+++ b/crates/p9-2025-iras-akari/src/orbital_constraints.rs
@@ -14,6 +14,7 @@
 
 use crate::survey_model::angular_separation_arcmin;
 use p9_core::coords::candidate_pair;
+use p9_core::units::{arcseconds, au, degrees, julian_year, Angle, AngularVelocity, Length, Time};
 
 /// The candidate pair from Phan et al. (2025) Table 2.
 pub struct CandidatePair {
@@ -74,6 +75,38 @@ pub struct TwoEpochConstraints {
     pub delta_dec_arcmin: f64,
 }
 
+impl TwoEpochConstraints {
+    /// Angular separation as a dimension-checked [`Angle`].
+    pub fn separation(&self) -> Angle {
+        arcseconds(self.separation_arcmin * 60.0)
+    }
+
+    /// Annual proper motion as a typed [`AngularVelocity`].
+    pub fn proper_motion(&self) -> AngularVelocity {
+        (arcseconds(self.proper_motion_arcmin_yr * 60.0) / julian_year()).into()
+    }
+
+    /// Position angle of motion as a dimension-checked [`Angle`].
+    pub fn position_angle(&self) -> Angle {
+        degrees(self.position_angle_deg)
+    }
+
+    /// Epoch baseline as a dimension-checked [`Time`].
+    pub fn baseline(&self) -> Time {
+        julian_year() * self.baseline_years
+    }
+
+    /// RA component of motion as a dimension-checked [`Angle`].
+    pub fn delta_ra(&self) -> Angle {
+        arcseconds(self.delta_ra_arcmin * 60.0)
+    }
+
+    /// Dec component of motion as a dimension-checked [`Angle`].
+    pub fn delta_dec(&self) -> Angle {
+        arcseconds(self.delta_dec_arcmin * 60.0)
+    }
+}
+
 /// Distance-orbit constraints for a grid of assumed semi-major axes.
 #[derive(Debug, Clone)]
 pub struct DistanceOrbitConstraint {
@@ -86,6 +119,18 @@ pub struct DistanceOrbitConstraint {
     pub implied_eccentricity: f64,
     /// Whether this (a, e) combination is physically plausible
     pub plausible: bool,
+}
+
+impl DistanceOrbitConstraint {
+    /// Assumed semi-major axis as a dimension-checked [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a_au)
+    }
+
+    /// Heliocentric distance at observation as a dimension-checked [`Length`].
+    pub fn distance(&self) -> Length {
+        au(self.r_au)
+    }
 }
 
 /// Compute two-epoch constraints from the candidate pair.
@@ -191,7 +236,63 @@ pub fn explore_orbit_space(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use p9_core::coords::sky::equatorial_to_ecliptic_deg;
+    use uom::si::angle::{degree, minute, radian};
+    use uom::si::angular_velocity::radian_per_second;
+    use uom::si::length::astronomical_unit;
+    use uom::si::time::{day, second};
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        let c = derive_constraints(&CandidatePair::paper_candidate());
+        assert_relative_eq!(
+            c.separation().get::<minute>(),
+            c.separation_arcmin,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            c.position_angle().get::<degree>(),
+            c.position_angle_deg,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            c.delta_ra().get::<minute>(),
+            c.delta_ra_arcmin,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            c.delta_dec().get::<minute>(),
+            c.delta_dec_arcmin,
+            max_relative = 1e-12
+        );
+        // Baseline (years) reads back through the Julian-year day count.
+        let yr_d = julian_year().get::<day>();
+        assert_relative_eq!(
+            c.baseline().get::<day>(),
+            c.baseline_years * yr_d,
+            max_relative = 1e-12
+        );
+        // Proper motion arcmin/yr read back in rad/s.
+        let yr_s = julian_year().get::<second>();
+        assert_relative_eq!(
+            c.proper_motion().get::<radian_per_second>(),
+            arcseconds(c.proper_motion_arcmin_yr * 60.0).get::<radian>() / yr_s,
+            max_relative = 1e-9
+        );
+
+        let orbits = explore_orbit_space(&c, &[700.0]);
+        assert_relative_eq!(
+            orbits[0].semi_major_axis().get::<astronomical_unit>(),
+            orbits[0].a_au,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            orbits[0].distance().get::<astronomical_unit>(),
+            orbits[0].r_au,
+            epsilon = 1e-9
+        );
+    }
 
     #[test]
     fn candidate_separation_matches_paper() {

--- a/crates/p9-2025-iras-akari/src/survey_model.rs
+++ b/crates/p9-2025-iras-akari/src/survey_model.rs
@@ -18,6 +18,7 @@
 
 use p9_core::constants::YEAR_DAYS;
 use p9_core::coords::observer::{Time, Timescale};
+use p9_core::units::{self, arcseconds, julian_year, Angle};
 use serde::{Deserialize, Serialize};
 
 /// A far-infrared point source detection from either survey.
@@ -141,6 +142,11 @@ pub fn epoch_baseline(iras: &IrasSurvey, akari: &AkariFisSurvey) -> f64 {
     (akari.mid_epoch(&ts).tdb() - iras.mid_epoch(&ts).tdb()) / YEAR_DAYS
 }
 
+/// The IRAS–AKARI epoch baseline as a dimension-checked [`units::Time`].
+pub fn epoch_baseline_time(iras: &IrasSurvey, akari: &AkariFisSurvey) -> units::Time {
+    julian_year() * epoch_baseline(iras, akari)
+}
+
 /// Angular separation between two sky positions in arcminutes.
 ///
 /// Uses the Vincenty formula for great-circle distance, accurate at all
@@ -162,9 +168,34 @@ pub fn angular_separation_arcmin(ra1_deg: f64, dec1_deg: f64, ra2_deg: f64, dec2
     angle_rad.to_degrees() * 60.0 // convert degrees to arcminutes
 }
 
+/// Angular separation between two sky positions as a dimension-checked
+/// [`Angle`] (the typed sibling of [`angular_separation_arcmin`]).
+pub fn angular_separation(ra1_deg: f64, dec1_deg: f64, ra2_deg: f64, dec2_deg: f64) -> Angle {
+    arcseconds(angular_separation_arcmin(ra1_deg, dec1_deg, ra2_deg, dec2_deg) * 60.0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+    use uom::si::angle::minute;
+    use uom::si::time::day;
+
+    #[test]
+    fn typed_siblings_match_f64_sources() {
+        let (iras, akari) = (IrasSurvey::default(), AkariFisSurvey::default());
+        let yr_d = julian_year().get::<day>();
+        assert_relative_eq!(
+            epoch_baseline_time(&iras, &akari).get::<day>(),
+            epoch_baseline(&iras, &akari) * yr_d,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            angular_separation(10.0, 20.0, 11.0, 21.0).get::<minute>(),
+            angular_separation_arcmin(10.0, 20.0, 11.0, 21.0),
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn iras_default_matches_paper() {

--- a/crates/p9-2025-iras-akari/src/thermal_model.rs
+++ b/crates/p9-2025-iras-akari/src/thermal_model.rs
@@ -18,6 +18,7 @@
 
 use p9_core::analysis::photometry::mass_radius_neptunian;
 use p9_core::analysis::thermal::{planck_bnu, solar_equilibrium_temp, thermal_flux_jy, C_LIGHT};
+use p9_core::units::{au, earth_masses, meters, Length, Mass};
 
 use crate::survey_model::{AkariFisSurvey, IrasSurvey};
 
@@ -41,6 +42,21 @@ impl P9ThermalParams {
     /// docs for sources).
     pub fn radius_m(&self) -> f64 {
         mass_radius_neptunian(self.mass_earth) * R_EARTH
+    }
+
+    /// Mass as a dimension-checked [`Mass`].
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.mass_earth)
+    }
+
+    /// Heliocentric distance as a dimension-checked [`Length`].
+    pub fn distance(&self) -> Length {
+        au(self.distance_au)
+    }
+
+    /// Physical radius as a dimension-checked [`Length`].
+    pub fn radius(&self) -> Length {
+        meters(self.radius_m())
     }
 
     /// Planck function B_ν(T) in W/m²/Hz/sr at frequency `nu_hz`.
@@ -135,6 +151,34 @@ pub fn is_detectable(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+    use uom::si::length::{astronomical_unit, meter};
+    use uom::si::mass::kilogram;
+
+    #[test]
+    fn typed_accessors_match_f64_sources() {
+        let p = P9ThermalParams {
+            mass_earth: 10.0,
+            distance_au: 600.0,
+            t_eff: 40.0,
+        };
+        assert_relative_eq!(
+            p.distance().get::<astronomical_unit>(),
+            p.distance_au,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            p.radius().get::<meter>(),
+            p.radius_m(),
+            max_relative = 1e-12
+        );
+        let earth_kg = earth_masses(1.0).get::<kilogram>();
+        assert_relative_eq!(
+            p.mass().get::<kilogram>() / earth_kg,
+            p.mass_earth,
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn planck_peak_shifts_with_temperature() {

--- a/crates/p9-2025-new-discoveries/Cargo.toml
+++ b/crates/p9-2025-new-discoveries/Cargo.toml
@@ -11,3 +11,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2025-new-discoveries/src/discoveries.rs
+++ b/crates/p9-2025-new-discoveries/src/discoveries.rs
@@ -10,6 +10,7 @@
 //! the same arc the papers report.
 
 use p9_core::data::etno::Etno;
+use p9_core::units::{au, Length};
 
 /// A new discovery with its discovery-paper headline reference numbers kept
 /// separately from the computed orbit.
@@ -26,6 +27,18 @@ pub struct NewDiscovery {
     pub paper_q_au: f64,
     /// One-line note on why this object stresses the clustering hypothesis.
     pub note: &'static str,
+}
+
+impl NewDiscovery {
+    /// Paper-headline semi-major axis as a dimension-checked [`Length`].
+    pub fn paper_a(&self) -> Length {
+        au(self.paper_a_au)
+    }
+
+    /// Paper-headline perihelion distance as a dimension-checked [`Length`].
+    pub fn paper_q(&self) -> Length {
+        au(self.paper_q_au)
+    }
 }
 
 /// 2017 OF201 — Cheng, Yang, et al. 2025 (arXiv:2505.15806).
@@ -88,6 +101,22 @@ pub const AMMONITE_SEDNOID_RANK: u32 = 4;
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
+    use uom::si::length::astronomical_unit;
+
+    #[test]
+    fn paper_lengths_match_f64_sources() {
+        let d = of201();
+        assert_relative_eq!(
+            d.paper_a().get::<astronomical_unit>(),
+            d.paper_a_au,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            d.paper_q().get::<astronomical_unit>(),
+            d.paper_q_au,
+            epsilon = 1e-12
+        );
+    }
 
     #[test]
     fn of201_is_very_distant() {

--- a/crates/p9-2025-new-discoveries/src/stress.rs
+++ b/crates/p9-2025-new-discoveries/src/stress.rs
@@ -15,6 +15,7 @@
 use p9_core::analysis::circular::{circular_mean, mean_resultant_length, rayleigh_p_value};
 use p9_core::constants::{RAD2DEG, TWO_PI};
 use p9_core::data::etno::{Etno, BROWN_2017_SAMPLE};
+use p9_core::units::{degrees, Angle};
 
 use crate::discoveries::NewDiscovery;
 
@@ -29,6 +30,13 @@ pub struct ClusteringStat {
     pub rayleigh_p: f64,
     /// Circular mean of ϖ (degrees, [0, 360)).
     pub mean_varpi_deg: f64,
+}
+
+impl ClusteringStat {
+    /// Circular mean of ϖ as a dimension-checked [`Angle`].
+    pub fn mean_varpi(&self) -> Angle {
+        degrees(self.mean_varpi_deg)
+    }
 }
 
 /// Compute R̄, the Rayleigh p-value and the circular mean ϖ for a slice of
@@ -55,6 +63,12 @@ pub fn varpi_offset_deg(object: &Etno, reference_varpi: f64) -> f64 {
     d * RAD2DEG
 }
 
+/// Angular offset of an object's ϖ from a reference longitude of perihelion as
+/// a dimension-checked [`Angle`] (the typed sibling of [`varpi_offset_deg`]).
+pub fn varpi_offset(object: &Etno, reference_varpi: f64) -> Angle {
+    degrees(varpi_offset_deg(object, reference_varpi))
+}
+
 /// Full stress analysis: baseline, +OF201, +Ammonite, +both, plus each
 /// object's ϖ offset from the baseline circular mean.
 #[derive(Debug, Clone, Copy)]
@@ -71,6 +85,18 @@ pub struct StressResult {
     pub of201_offset_deg: f64,
     /// Ammonite ϖ offset from the baseline circular mean (deg).
     pub ammonite_offset_deg: f64,
+}
+
+impl StressResult {
+    /// 2017 OF201 ϖ offset from the baseline mean as a dimension-checked [`Angle`].
+    pub fn of201_offset(&self) -> Angle {
+        degrees(self.of201_offset_deg)
+    }
+
+    /// Ammonite ϖ offset from the baseline mean as a dimension-checked [`Angle`].
+    pub fn ammonite_offset(&self) -> Angle {
+        degrees(self.ammonite_offset_deg)
+    }
 }
 
 /// Run the stress analysis on the vetted baseline sample and the two new
@@ -105,9 +131,38 @@ pub fn run_stress(of201: &NewDiscovery, ammonite: &NewDiscovery) -> StressResult
 mod tests {
     use super::*;
     use crate::discoveries::{ammonite, of201};
+    use approx::assert_relative_eq;
+    use uom::si::angle::degree;
 
     fn result() -> StressResult {
         run_stress(&of201(), &ammonite())
+    }
+
+    #[test]
+    fn typed_angles_match_deg_sources() {
+        let r = result();
+        assert_relative_eq!(
+            r.baseline.mean_varpi().get::<degree>(),
+            r.baseline.mean_varpi_deg,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            r.of201_offset().get::<degree>(),
+            r.of201_offset_deg,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            r.ammonite_offset().get::<degree>(),
+            r.ammonite_offset_deg,
+            max_relative = 1e-12
+        );
+        // The free-function typed sibling agrees with its f64 source.
+        let baseline_mean = r.baseline.mean_varpi_deg / RAD2DEG;
+        assert_relative_eq!(
+            varpi_offset(&of201().etno, baseline_mean).get::<degree>(),
+            varpi_offset_deg(&of201().etno, baseline_mean),
+            max_relative = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2025-parallax-search/Cargo.toml
+++ b/crates/p9-2025-parallax-search/Cargo.toml
@@ -11,3 +11,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2025-parallax-search/src/discrimination.rs
+++ b/crates/p9-2025-parallax-search/src/discrimination.rs
@@ -16,6 +16,7 @@
 //!    scale.
 
 use crate::parallax::{epoch_parallax_arcsec, half_parallax_arcsec};
+use p9_core::units::{arcseconds, au, Angle, Length};
 
 /// Contrast ratio between a Planet Nine at `distance_au` and a background star of
 /// parallax `star_parallax_arcsec`, using the **half-angle** (annual) parallax of
@@ -51,6 +52,15 @@ pub fn max_tolerable_error_arcsec(distance_au: f64, snr: f64, epoch_separation_d
     epoch_parallax_arcsec(distance_au, epoch_separation_days) / snr
 }
 
+/// Maximum tolerable per-epoch astrometric error as a dimension-checked [`Angle`].
+pub fn max_tolerable_error(distance_au: f64, snr: f64, epoch_separation_days: f64) -> Angle {
+    arcseconds(max_tolerable_error_arcsec(
+        distance_au,
+        snr,
+        epoch_separation_days,
+    ))
+}
+
 /// The same demanded precision expressed in detector pixels for a given plate
 /// scale (arcsec/pixel). Smaller is harder; the value falls as `1/d`.
 pub fn required_precision_pixels(
@@ -73,12 +83,38 @@ pub fn max_detectable_distance_au(sigma_arcsec: f64, snr: f64, epoch_separation_
     k / (snr * sigma_arcsec)
 }
 
+/// Largest detectable heliocentric distance as a dimension-checked [`Length`].
+pub fn max_detectable_distance(sigma_arcsec: f64, snr: f64, epoch_separation_days: f64) -> Length {
+    au(max_detectable_distance_au(
+        sigma_arcsec,
+        snr,
+        epoch_separation_days,
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::parallax::YEAR_DAYS;
     use crate::published;
     use approx::assert_relative_eq;
+    use uom::si::angle::second as arcsecond;
+    use uom::si::length::astronomical_unit;
+
+    #[test]
+    fn typed_siblings_match_f64_sources() {
+        let base = YEAR_DAYS / 2.0;
+        assert_relative_eq!(
+            max_tolerable_error(700.0, 5.0, base).get::<arcsecond>(),
+            max_tolerable_error_arcsec(700.0, 5.0, base),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            max_detectable_distance(1.0, 5.0, base).get::<astronomical_unit>(),
+            max_detectable_distance_au(1.0, 5.0, base),
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn contrast_against_field_star_is_thousands() {

--- a/crates/p9-2025-parallax-search/src/parallax.rs
+++ b/crates/p9-2025-parallax-search/src/parallax.rs
@@ -15,6 +15,7 @@
 
 use p9_core::constants::{AU_KM, PC_AU};
 use p9_core::coords::parallax::{annual_parallax_arcsec, parallax_arcsec};
+use p9_core::units::{arcseconds, au, Angle, Length};
 
 /// Arcseconds per arcminute.
 pub const ARCSEC_PER_ARCMIN: f64 = 60.0;
@@ -32,6 +33,11 @@ pub fn half_parallax_arcsec(distance_au: f64) -> f64 {
     PC_AU / distance_au
 }
 
+/// Reflex-parallax half-angle as a dimension-checked [`Angle`].
+pub fn half_parallax(distance_au: f64) -> Angle {
+    arcseconds(half_parallax_arcsec(distance_au))
+}
+
 /// Reflex-parallax half-angle in **arcminutes** — the paper's order-of-arcmin
 /// headline for a 500–700 AU body.
 pub fn half_parallax_arcmin(distance_au: f64) -> f64 {
@@ -44,6 +50,11 @@ pub fn annual_parallax_arcmin(distance_au: f64) -> f64 {
     annual_parallax_arcsec(distance_au) / ARCSEC_PER_ARCMIN
 }
 
+/// Full annual peak-to-peak parallax as a dimension-checked [`Angle`].
+pub fn annual_parallax(distance_au: f64) -> Angle {
+    arcseconds(annual_parallax_arcsec(distance_au))
+}
+
 /// Projected Earth-orbit baseline (AU) between two epochs separated by
 /// `epoch_separation_days`, for a circular 1 AU orbit. Two positions separated
 /// by orbital phase `Δθ` are `2 * sin(Δθ/2)` AU apart (chord length). A
@@ -54,12 +65,23 @@ pub fn projected_baseline_au(epoch_separation_days: f64) -> f64 {
     2.0 * (dtheta / 2.0).sin().abs()
 }
 
+/// Projected Earth-orbit baseline as a dimension-checked [`Length`].
+pub fn projected_baseline(epoch_separation_days: f64) -> Length {
+    au(projected_baseline_au(epoch_separation_days))
+}
+
 /// Parallactic displacement (arcsec) of a body at `distance_au` observed at two
 /// epochs separated by `epoch_separation_days`, using the chord baseline above.
 /// This is the quantity the search actually measures between two visits.
 pub fn epoch_parallax_arcsec(distance_au: f64, epoch_separation_days: f64) -> f64 {
     let baseline_km = projected_baseline_au(epoch_separation_days) * AU_KM;
     parallax_arcsec(baseline_km, distance_au)
+}
+
+/// Parallactic displacement over an epoch separation as a dimension-checked
+/// [`Angle`].
+pub fn epoch_parallax(distance_au: f64, epoch_separation_days: f64) -> Angle {
+    arcseconds(epoch_parallax_arcsec(distance_au, epoch_separation_days))
 }
 
 /// Same, in arcminutes.
@@ -82,6 +104,33 @@ mod tests {
     use super::*;
     use crate::published;
     use approx::assert_relative_eq;
+    use uom::si::angle::second as arcsecond;
+    use uom::si::length::astronomical_unit;
+
+    #[test]
+    fn typed_siblings_match_f64_sources() {
+        let d = published::REFERENCE_DISTANCE_AU;
+        assert_relative_eq!(
+            half_parallax(d).get::<arcsecond>(),
+            half_parallax_arcsec(d),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            annual_parallax(d).get::<arcsecond>(),
+            annual_parallax_arcsec(d),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            epoch_parallax(d, 30.0).get::<arcsecond>(),
+            epoch_parallax_arcsec(d, 30.0),
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            projected_baseline(30.0).get::<astronomical_unit>(),
+            projected_baseline_au(30.0),
+            max_relative = 1e-12
+        );
+    }
 
     #[test]
     fn half_parallax_is_arcminutes_at_p9_distance() {


### PR DESCRIPTION
Adds a dimension-checked, additive typed boundary (`p9_core::units`, `uom`) to
the public surface of seven paper-reproduction crates. No existing `f64`
fields, signatures, test reference values, or inner physics arithmetic were
changed — only new typed accessor methods / typed sibling functions, each
pinned against its `f64` source with `assert_relative_eq!`. `uom@0.38.0` added
as a dev-dependency to every touched crate.

Per crate:

- **p9-2024-primordial-alignment** — `Precessor::{varpi0_angle (Angle), rate (AngularVelocity, rad/yr), varpi_at_lookback_typed (Angle)}`.
- **p9-2024-siraj-orbit** — `OrbitPoint::{mass (Mass), semi_major_axis (Length)}`.
- **p9-2025-akari-refutation** — `ConsistencyVerdict::{distance (Length), observed_separation/max_parallax/max_bound_total (Angle)}`, `baseline_duration (Time)`, plus `expected_motion::{parallax_six_month, proper_motion_six_month_circular}` (Angle siblings).
- **p9-2025-clustering** — `PipelineConfig::{total_time, timestep, snapshot_interval (Time)}`, `TnoResult::varpi_typed (Angle)`, `OrbitalPole::{inclination_typed, omega_big_typed (Angle)}`, `nodal_precession_rate_typed (AngularVelocity)`, `ObservedTno::{semi_major_axis, perihelion_typed (Length), inclination_typed, varpi_typed (Angle)}`, `TnoClone::{perihelion_typed (Length), varpi_typed (Angle)}`.
- **p9-2025-iras-akari** — `SelectionCriteria::{sep_min, sep_max (Angle)}`, `CandidatePair::{separation, combined_pos_err (Angle), implied_distance (Length)}`, `TwoEpochConstraints::{separation/position_angle/delta_ra/delta_dec (Angle), proper_motion (AngularVelocity), baseline (Time)}`, `DistanceOrbitConstraint::{semi_major_axis, distance (Length)}`, `P9ThermalParams::{mass (Mass), distance, radius (Length)}`, `survey_model::{epoch_baseline_time (Time), angular_separation (Angle)}`.
- **p9-2025-new-discoveries** — `NewDiscovery::{paper_a, paper_q (Length)}`, `ClusteringStat::mean_varpi (Angle)`, `StressResult::{of201_offset, ammonite_offset (Angle)}`, `stress::varpi_offset (Angle sibling)`.
- **p9-2025-parallax-search** — `parallax::{half_parallax, annual_parallax, epoch_parallax (Angle), projected_baseline (Length)}`, `discrimination::{max_tolerable_error (Angle), max_detectable_distance (Length)}`.

No crate was skipped — each exposes dimensional public scalars. Pure
statistics/probabilities/counts/magnitudes/flux were left untyped.

`cargo build` + `cargo test` pass for all seven crates; `cargo fmt` applied.