### PR TITLE
Adopt typed units boundary in batch-7 crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1672,6 +1672,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1685,6 +1686,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1699,6 +1701,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1711,6 +1714,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1724,6 +1728,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1736,6 +1741,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]

--- a/crates/p9-2021-napier-critique/Cargo.toml
+++ b/crates/p9-2021-napier-critique/Cargo.toml
@@ -13,3 +13,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2021-napier-critique/src/critique.rs
+++ b/crates/p9-2021-napier-critique/src/critique.rs
@@ -24,6 +24,7 @@
 
 use p9_core::analysis::circular::{mean_resultant_length, rayleigh_p_value};
 use p9_core::constants::{DEG2RAD, TWO_PI};
+use p9_core::units::{radians, Angle};
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
@@ -97,6 +98,16 @@ impl SelectionFunction {
         let w =
             1.0 + self.a1 * (varpi - self.phi1).cos() + self.a2 * (2.0 * (varpi - self.phi2)).cos();
         w.max(0.0)
+    }
+
+    /// First-harmonic phase ϕ₁ as a dimension-checked [`Angle`].
+    pub fn phi1_angle(&self) -> Angle {
+        radians(self.phi1)
+    }
+
+    /// Second-harmonic phase ϕ₂ as a dimension-checked [`Angle`].
+    pub fn phi2_angle(&self) -> Angle {
+        radians(self.phi2)
     }
 
     /// Maximum of w over the circle, used as the rejection-sampling
@@ -189,9 +200,18 @@ pub fn run_critique<R: Rng>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use p9_core::data::etno::longitudes_of_perihelion;
     use rand::rngs::StdRng;
     use rand::SeedableRng;
+    use uom::si::angle::radian;
+
+    #[test]
+    fn typed_phase_accessors_match_f64() {
+        let sel = SelectionFunction::default();
+        assert_relative_eq!(sel.phi1_angle().get::<radian>(), sel.phi1, epsilon = 1e-12);
+        assert_relative_eq!(sel.phi2_angle().get::<radian>(), sel.phi2, epsilon = 1e-12);
+    }
 
     #[test]
     fn test_selection_weight_positive_and_normalizable() {

--- a/crates/p9-2021-oort-cloud/Cargo.toml
+++ b/crates/p9-2021-oort-cloud/Cargo.toml
@@ -11,3 +11,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 approx = { workspace = true }
 nalgebra.workspace = true
+
+[dev-dependencies]
+uom = "0.38.0"

--- a/crates/p9-2021-oort-cloud/src/injection_simulation.rs
+++ b/crates/p9-2021-oort-cloud/src/injection_simulation.rs
@@ -33,6 +33,7 @@ use p9_core::analysis::circular::wrap_to_pi;
 use p9_core::constants::*;
 use p9_core::forces::ExtraForce;
 use p9_core::types::{cartesian_to_elements, OrbitalElements, P9Params};
+use p9_core::units::{au, days, julian_year, Length, Time};
 
 use crate::oort_cloud::{generate_ioc_population, generate_scattered_disk, OortCloudConfig};
 
@@ -116,6 +117,25 @@ impl InjectionConfig {
             n_scattered: 100,
         }
     }
+
+    // ---- typed boundary accessors (dimension-checked views of the f64 fields) ----
+
+    /// Perihelion threshold for "injected" classification as a [`Length`].
+    pub fn injection_perihelion_threshold(&self) -> Length {
+        au(self.q_injection_threshold)
+    }
+    /// Distant-Kuiper-belt minimum semi-major axis as a [`Length`].
+    pub fn min_dkb_semi_major_axis(&self) -> Length {
+        au(self.a_dkb_min)
+    }
+    /// Full-scale (equivalent) simulation duration as a [`Time`].
+    pub fn duration(&self) -> Time {
+        julian_year() * (self.duration_gyr * 1.0e9)
+    }
+    /// Integration timestep as a [`Time`].
+    pub fn timestep(&self) -> Time {
+        days(self.dt_days)
+    }
 }
 
 /// Outcome of the secular evolution for a single particle.
@@ -126,6 +146,13 @@ pub struct ParticleOutcome {
     pub final_elements: Option<OrbitalElements>,
     /// Minimum perihelion distance reached at any element check (AU)
     pub min_q: f64,
+}
+
+impl ParticleOutcome {
+    /// Minimum perihelion distance reached during the run as a [`Length`].
+    pub fn min_perihelion(&self) -> Length {
+        au(self.min_q)
+    }
 }
 
 /// Integrate a population under the Sun (+ optionally Planet Nine's
@@ -344,8 +371,54 @@ pub fn simulate_injection<R: Rng>(config: &InjectionConfig, rng: &mut R) -> Inje
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use rand::rngs::StdRng;
     use rand::SeedableRng;
+    use uom::si::length::astronomical_unit;
+    use uom::si::time::day;
+
+    #[test]
+    fn typed_config_accessors_match_f64() {
+        let c = InjectionConfig::nominal();
+        assert_relative_eq!(
+            c.injection_perihelion_threshold()
+                .get::<astronomical_unit>(),
+            c.q_injection_threshold,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            c.min_dkb_semi_major_axis().get::<astronomical_unit>(),
+            c.a_dkb_min,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(c.timestep().get::<day>(), c.dt_days, epsilon = 1e-6);
+        assert_relative_eq!(
+            c.duration().get::<day>(),
+            c.duration_gyr * 1.0e9 * julian_year().get::<day>(),
+            epsilon = 1.0
+        );
+    }
+
+    #[test]
+    fn typed_outcome_accessor_matches_f64() {
+        let outcome = ParticleOutcome {
+            initial: OrbitalElements {
+                a: 5000.0,
+                e: 0.9,
+                i: 0.5,
+                omega_big: 0.0,
+                omega: 0.0,
+                mean_anomaly: 0.0,
+            },
+            final_elements: None,
+            min_q: 73.5,
+        };
+        assert_relative_eq!(
+            outcome.min_perihelion().get::<astronomical_unit>(),
+            outcome.min_q,
+            epsilon = 1e-9
+        );
+    }
 
     #[test]
     fn test_injection_config_nominal() {

--- a/crates/p9-2021-oort-cloud/src/oort_cloud.rs
+++ b/crates/p9-2021-oort-cloud/src/oort_cloud.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 
 use p9_core::constants::*;
 use p9_core::types::OrbitalElements;
+use p9_core::units::{au, days, radians, solar_masses, Angle, Length, Mass, Time, Velocity};
 
 /// Birth cluster parameters for IOC generation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -77,6 +78,45 @@ impl OortCloudConfig {
         let r_au = self.cluster_radius_pc * PC_AU;
         let sigma_v = self.velocity_dispersion_au_day();
         r_au / sigma_v
+    }
+
+    // ---- typed boundary accessors (dimension-checked views of the f64 fields) ----
+
+    /// Total cluster mass as a [`Mass`].
+    pub fn cluster_mass(&self) -> Mass {
+        solar_masses(self.cluster_mass_msun)
+    }
+    /// Plummer characteristic radius as a [`Length`].
+    pub fn cluster_radius(&self) -> Length {
+        au(self.cluster_radius_pc * PC_AU)
+    }
+    /// Minimum IOC semi-major axis as a [`Length`].
+    pub fn min_semi_major_axis(&self) -> Length {
+        au(self.a_min)
+    }
+    /// Maximum IOC semi-major axis as a [`Length`].
+    pub fn max_semi_major_axis(&self) -> Length {
+        au(self.a_max)
+    }
+    /// Minimum perihelion distance as a [`Length`].
+    pub fn min_perihelion(&self) -> Length {
+        au(self.q_min)
+    }
+    /// Maximum perihelion distance as a [`Length`].
+    pub fn max_perihelion(&self) -> Length {
+        au(self.q_max)
+    }
+    /// Inclination dispersion as an [`Angle`].
+    pub fn inclination_dispersion(&self) -> Angle {
+        radians(self.sigma_i)
+    }
+    /// Cluster velocity dispersion as a [`Velocity`].
+    pub fn velocity_dispersion(&self) -> Velocity {
+        au(self.velocity_dispersion_au_day()) / days(1.0)
+    }
+    /// Encounter timescale as a [`Time`].
+    pub fn encounter_timescale(&self) -> Time {
+        days(self.encounter_timescale_days())
     }
 }
 
@@ -172,8 +212,65 @@ pub fn generate_scattered_disk<R: Rng>(n: usize, rng: &mut R) -> Vec<OrbitalElem
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use rand::rngs::StdRng;
     use rand::SeedableRng;
+    use uom::si::angle::radian;
+    use uom::si::length::astronomical_unit;
+    use uom::si::mass::kilogram;
+    use uom::si::time::day;
+    use uom::si::velocity::meter_per_second;
+
+    #[test]
+    fn typed_config_accessors_match_f64() {
+        let c = OortCloudConfig::nominal();
+        assert_relative_eq!(
+            c.cluster_mass().get::<kilogram>(),
+            solar_masses(c.cluster_mass_msun).get::<kilogram>(),
+            epsilon = 1.0
+        );
+        assert_relative_eq!(
+            c.cluster_radius().get::<astronomical_unit>(),
+            c.cluster_radius_pc * PC_AU,
+            epsilon = 1e-6
+        );
+        assert_relative_eq!(
+            c.min_semi_major_axis().get::<astronomical_unit>(),
+            c.a_min,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            c.max_semi_major_axis().get::<astronomical_unit>(),
+            c.a_max,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            c.min_perihelion().get::<astronomical_unit>(),
+            c.q_min,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            c.max_perihelion().get::<astronomical_unit>(),
+            c.q_max,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            c.inclination_dispersion().get::<radian>(),
+            c.sigma_i,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            c.encounter_timescale().get::<day>(),
+            c.encounter_timescale_days(),
+            epsilon = 1e-6
+        );
+        let v_expected = au(c.velocity_dispersion_au_day()) / days(1.0);
+        assert_relative_eq!(
+            c.velocity_dispersion().get::<meter_per_second>(),
+            v_expected.get::<meter_per_second>(),
+            epsilon = 1e-9
+        );
+    }
 
     #[test]
     fn test_nominal_config() {

--- a/crates/p9-2021-oort-cloud/src/population_comparison.rs
+++ b/crates/p9-2021-oort-cloud/src/population_comparison.rs
@@ -13,6 +13,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use p9_core::units::{au, Length};
+
 use crate::injection_simulation::{simulate_injection, InjectionConfig, InjectionResult};
 
 /// Comparison of confinement between IOC-injected and scattered disk populations.
@@ -79,6 +81,17 @@ pub struct SmaBin {
     pub count_scattered: usize,
 }
 
+impl SmaBin {
+    /// Lower bin edge as a [`Length`].
+    pub fn lower_edge(&self) -> Length {
+        au(self.a_low)
+    }
+    /// Upper bin edge as a [`Length`].
+    pub fn upper_edge(&self) -> Length {
+        au(self.a_high)
+    }
+}
+
 /// Build a semi-major axis distribution histogram from the simulated
 /// populations in an injection result (injected IOC end-state a vs the
 /// simulated scattered-disk end-state a).
@@ -142,6 +155,28 @@ pub fn fraction_above_threshold(result: &InjectionResult, a_threshold: f64) -> f
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+    use uom::si::length::astronomical_unit;
+
+    #[test]
+    fn typed_bin_edges_match_f64() {
+        let bin = SmaBin {
+            a_low: 150.0,
+            a_high: 220.0,
+            count_ioc: 3,
+            count_scattered: 5,
+        };
+        assert_relative_eq!(
+            bin.lower_edge().get::<astronomical_unit>(),
+            bin.a_low,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            bin.upper_edge().get::<astronomical_unit>(),
+            bin.a_high,
+            epsilon = 1e-9
+        );
+    }
 
     fn sample_result() -> InjectionResult {
         InjectionResult {

--- a/crates/p9-2021-orbit/Cargo.toml
+++ b/crates/p9-2021-orbit/Cargo.toml
@@ -12,3 +12,6 @@ serde_json = { workspace = true }
 approx = { workspace = true }
 rayon = { workspace = true }
 nalgebra = { workspace = true }
+
+[dev-dependencies]
+uom = "0.38.0"

--- a/crates/p9-2021-orbit/src/sim_grid.rs
+++ b/crates/p9-2021-orbit/src/sim_grid.rs
@@ -49,6 +49,7 @@ use p9_core::integrator::whm::WhmIntegrator;
 use p9_core::types::{
     cartesian_to_elements, OrbitalElements, P9Params, SimConfig as CoreSimConfig, StateVector,
 };
+use p9_core::units::{au, days, degrees, earth_masses, radians, Angle, Length, Mass, Time};
 
 /// The paper's Planet Nine mass grid (Earth masses), Brown & Batygin (2021)
 /// Section 2.
@@ -123,6 +124,21 @@ impl GridPoint {
             mean_anomaly: 0.0,
         }
     }
+
+    // ---- typed boundary accessors (dimension-checked views of the f64 fields) ----
+
+    /// Planet Nine mass as a [`Mass`].
+    pub fn mass(&self) -> Mass {
+        earth_masses(self.m9)
+    }
+    /// Planet Nine semi-major axis as a [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a9)
+    }
+    /// Planet Nine inclination as an [`Angle`].
+    pub fn inclination(&self) -> Angle {
+        degrees(self.i9_deg)
+    }
 }
 
 /// Configuration for the simulation grid (Model 1).
@@ -185,6 +201,33 @@ impl SimGridConfig {
     /// `#[ignore]`d entry point only — estimated CPU-days.
     pub fn paper() -> Self {
         Self::base(GridScale::Paper, 16_800, 4.0, 10.0)
+    }
+
+    // ---- typed boundary accessors (dimension-checked views of the f64 fields) ----
+
+    /// Integration time as a [`Time`].
+    pub fn integration_time(&self) -> Time {
+        days(self.t_gyr * GYR_DAYS)
+    }
+    /// Integration timestep as a [`Time`].
+    pub fn timestep(&self) -> Time {
+        days(self.dt_days)
+    }
+    /// Interval between pooled element snapshots as a [`Time`].
+    pub fn snapshot_interval(&self) -> Time {
+        days(self.snapshot_interval_days)
+    }
+    /// Maximum initial-disk inclination as an [`Angle`].
+    pub fn max_disk_inclination(&self) -> Angle {
+        degrees(self.disk_i_max_deg)
+    }
+    /// Inner removal boundary as a [`Length`].
+    pub fn inner_removal_radius(&self) -> Length {
+        au(self.r_remove_inner)
+    }
+    /// Outer removal boundary as a [`Length`].
+    pub fn outer_removal_radius(&self) -> Length {
+        au(self.r_remove_outer)
     }
 
     /// The grid points for this scale (deterministic, no RNG involved).
@@ -270,6 +313,25 @@ pub struct ElementSample {
     pub delta_varpi: f64,
     /// Omega_particle - Omega_P9, wrapped to [0, 2 pi)
     pub delta_omega_big: f64,
+}
+
+impl ElementSample {
+    /// Semi-major axis as a [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
+    }
+    /// Inclination as an [`Angle`].
+    pub fn inclination(&self) -> Angle {
+        radians(self.i)
+    }
+    /// Apsidal offset Δϖ relative to Planet Nine as an [`Angle`].
+    pub fn delta_varpi_angle(&self) -> Angle {
+        radians(self.delta_varpi)
+    }
+    /// Nodal offset ΔΩ relative to Planet Nine as an [`Angle`].
+    pub fn delta_omega_big_angle(&self) -> Angle {
+        radians(self.delta_omega_big)
+    }
 }
 
 /// Result of integrating one grid point.
@@ -413,6 +475,90 @@ pub fn run_grid(config: &SimGridConfig) -> Vec<GridPointResult> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+    use uom::si::angle::{degree, radian};
+    use uom::si::length::astronomical_unit;
+    use uom::si::mass::kilogram;
+    use uom::si::time::day;
+
+    #[test]
+    fn typed_grid_point_accessors_match_f64() {
+        let gp = GridPoint {
+            m9: 6.2,
+            a9: 380.0,
+            e9: 0.2,
+            i9_deg: 16.0,
+        };
+        assert_relative_eq!(
+            gp.mass().get::<kilogram>(),
+            earth_masses(gp.m9).get::<kilogram>(),
+            epsilon = 1.0
+        );
+        assert_relative_eq!(
+            gp.semi_major_axis().get::<astronomical_unit>(),
+            gp.a9,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(gp.inclination().get::<degree>(), gp.i9_deg, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn typed_config_accessors_match_f64() {
+        let c = SimGridConfig::reduced();
+        assert_relative_eq!(
+            c.integration_time().get::<day>(),
+            c.t_gyr * GYR_DAYS,
+            epsilon = 1e-6
+        );
+        assert_relative_eq!(c.timestep().get::<day>(), c.dt_days, epsilon = 1e-6);
+        assert_relative_eq!(
+            c.snapshot_interval().get::<day>(),
+            c.snapshot_interval_days,
+            epsilon = 1e-6
+        );
+        assert_relative_eq!(
+            c.max_disk_inclination().get::<degree>(),
+            c.disk_i_max_deg,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            c.inner_removal_radius().get::<astronomical_unit>(),
+            c.r_remove_inner,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            c.outer_removal_radius().get::<astronomical_unit>(),
+            c.r_remove_outer,
+            epsilon = 1e-9
+        );
+    }
+
+    #[test]
+    fn typed_element_sample_accessors_match_f64() {
+        let s = ElementSample {
+            a: 250.0,
+            e: 0.3,
+            i: 0.4,
+            delta_varpi: 1.2,
+            delta_omega_big: 2.4,
+        };
+        assert_relative_eq!(
+            s.semi_major_axis().get::<astronomical_unit>(),
+            s.a,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(s.inclination().get::<radian>(), s.i, epsilon = 1e-12);
+        assert_relative_eq!(
+            s.delta_varpi_angle().get::<radian>(),
+            s.delta_varpi,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            s.delta_omega_big_angle().get::<radian>(),
+            s.delta_omega_big,
+            epsilon = 1e-12
+        );
+    }
 
     #[test]
     fn test_grid_point_counts() {

--- a/crates/p9-2021-orbit/src/statistical_measures.rs
+++ b/crates/p9-2021-orbit/src/statistical_measures.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 use p9_core::analysis::circular::{circular_mean, mean_resultant_length, rayleigh_p_value};
 use p9_core::constants::{DEG2RAD, TWO_PI};
 use p9_core::data::etno::longitudes_of_perihelion;
+use p9_core::units::{radians, Angle};
 
 /// Result of the clustering confidence analysis.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -35,6 +36,13 @@ pub struct ClusteringConfidence {
     pub confidence: f64,
     /// Number of objects analyzed
     pub n_objects: usize,
+}
+
+impl ClusteringConfidence {
+    /// Mean direction of clustering as a dimension-checked [`Angle`].
+    pub fn mean_direction_angle(&self) -> Angle {
+        radians(self.mean_direction)
+    }
 }
 
 /// Compute clustering significance using the (analytic, small-n-corrected)
@@ -162,6 +170,17 @@ pub fn paper_clustering_confidence() -> ClusteringConfidence {
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
+    use uom::si::angle::radian;
+
+    #[test]
+    fn typed_mean_direction_matches_f64() {
+        let result = compute_clustering_significance(&[0.7, 0.8, 0.9, 1.0]);
+        assert_relative_eq!(
+            result.mean_direction_angle().get::<radian>(),
+            result.mean_direction,
+            epsilon = 1e-12
+        );
+    }
 
     #[test]
     fn test_perfectly_clustered() {

--- a/crates/p9-2021-perihelion-gap/Cargo.toml
+++ b/crates/p9-2021-perihelion-gap/Cargo.toml
@@ -12,3 +12,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2021-perihelion-gap/src/sample.rs
+++ b/crates/p9-2021-perihelion-gap/src/sample.rs
@@ -24,6 +24,7 @@
 //! gap regression.
 
 use p9_core::data::etno::BROWN_2017_SAMPLE;
+use p9_core::units::{au, Length};
 
 /// A distant high-e TNO entered by (a, e). Only the perihelion q = a(1−e) and
 /// the eccentricity are used by the gap analysis, so we keep the record
@@ -41,6 +42,16 @@ impl DistantTno {
     /// Perihelion distance q = a(1 − e) in AU.
     pub fn perihelion(&self) -> f64 {
         self.a * (1.0 - self.e)
+    }
+
+    /// Semi-major axis as a dimension-checked [`Length`].
+    pub fn semi_major_axis(&self) -> Length {
+        au(self.a)
+    }
+
+    /// Perihelion distance q = a(1 − e) as a dimension-checked [`Length`].
+    pub fn perihelion_typed(&self) -> Length {
+        au(self.perihelion())
     }
 }
 
@@ -154,6 +165,27 @@ pub fn high_e_perihelia(e_floor: f64) -> Vec<f64> {
 mod tests {
     use super::*;
     use crate::published::{ETNO_Q_FLOOR_AU, GAP_ECCENTRICITY_FLOOR, IOC_Q_FLOOR_AU};
+    use approx::assert_relative_eq;
+    use uom::si::length::astronomical_unit;
+
+    #[test]
+    fn typed_accessors_match_f64() {
+        let t = DistantTno {
+            name: "test",
+            a: 500.0,
+            e: 0.9,
+        };
+        assert_relative_eq!(
+            t.semi_major_axis().get::<astronomical_unit>(),
+            t.a,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            t.perihelion_typed().get::<astronomical_unit>(),
+            t.perihelion(),
+            epsilon = 1e-9
+        );
+    }
 
     #[test]
     fn extended_table_has_no_brown_duplicates() {

--- a/crates/p9-2021-perihelion-gap/src/synthetic.rs
+++ b/crates/p9-2021-perihelion-gap/src/synthetic.rs
@@ -11,6 +11,8 @@
 use rand::SeedableRng;
 use rand_distr::{Distribution, Normal, Uniform};
 
+use p9_core::units::{au, Length};
+
 /// Parameters of the seeded two-component (scattering + detached) population.
 #[derive(Debug, Clone, Copy)]
 pub struct TwoPopulationParams {
@@ -52,6 +54,35 @@ impl Default for TwoPopulationParams {
     }
 }
 
+impl TwoPopulationParams {
+    // ---- typed boundary accessors (dimension-checked views of the f64 fields) ----
+
+    /// Mean perihelion of the scattering component as a [`Length`].
+    pub fn scattering_mean_perihelion(&self) -> Length {
+        au(self.scattering_q_mean)
+    }
+    /// Perihelion spread of the scattering component as a [`Length`].
+    pub fn scattering_perihelion_sigma(&self) -> Length {
+        au(self.scattering_q_sigma)
+    }
+    /// Mean perihelion of the detached component as a [`Length`].
+    pub fn detached_mean_perihelion(&self) -> Length {
+        au(self.detached_q_mean)
+    }
+    /// Perihelion spread of the detached component as a [`Length`].
+    pub fn detached_perihelion_sigma(&self) -> Length {
+        au(self.detached_q_sigma)
+    }
+    /// Lower edge of the bridge perihelion window as a [`Length`].
+    pub fn bridge_lower(&self) -> Length {
+        au(self.bridge_lo)
+    }
+    /// Upper edge of the bridge perihelion window as a [`Length`].
+    pub fn bridge_upper(&self) -> Length {
+        au(self.bridge_hi)
+    }
+}
+
 /// Draw a seeded two-component perihelion population (AU). Perihelia are
 /// clamped to be positive; the two Gaussian components flank the gap and the
 /// bridge populates it sparsely.
@@ -88,6 +119,43 @@ mod tests {
     use super::*;
     use crate::distribution::{dip_statistic, locate_gap_center, Histogram};
     use crate::published::{GAP_Q_CENTER_AU, GAP_Q_HIGH_AU, GAP_Q_LOW_AU};
+    use approx::assert_relative_eq;
+    use uom::si::length::astronomical_unit;
+
+    #[test]
+    fn typed_param_accessors_match_f64() {
+        let p = TwoPopulationParams::default();
+        assert_relative_eq!(
+            p.scattering_mean_perihelion().get::<astronomical_unit>(),
+            p.scattering_q_mean,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            p.scattering_perihelion_sigma().get::<astronomical_unit>(),
+            p.scattering_q_sigma,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            p.detached_mean_perihelion().get::<astronomical_unit>(),
+            p.detached_q_mean,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            p.detached_perihelion_sigma().get::<astronomical_unit>(),
+            p.detached_q_sigma,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            p.bridge_lower().get::<astronomical_unit>(),
+            p.bridge_lo,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            p.bridge_upper().get::<astronomical_unit>(),
+            p.bridge_hi,
+            epsilon = 1e-9
+        );
+    }
 
     #[test]
     fn two_population_is_reproducible() {

--- a/crates/p9-2021-stability/Cargo.toml
+++ b/crates/p9-2021-stability/Cargo.toml
@@ -14,3 +14,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
+uom = "0.38.0"

--- a/crates/p9-2021-stability/src/diffusion.rs
+++ b/crates/p9-2021-stability/src/diffusion.rs
@@ -14,6 +14,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use p9_core::units::{au, Length};
+
 use crate::stability::diffusion_coefficient;
 
 /// Result of a diffusion measurement for a single configuration.
@@ -27,6 +29,17 @@ pub struct DiffusionMeasurement {
     pub d_measured: f64,
     /// Analytical prediction (AU^2/yr)
     pub d_analytical: f64,
+}
+
+impl DiffusionMeasurement {
+    /// Initial semi-major axis as a [`Length`].
+    pub fn initial_semi_major_axis(&self) -> Length {
+        au(self.a_initial)
+    }
+    /// Initial perihelion distance as a [`Length`].
+    pub fn initial_perihelion(&self) -> Length {
+        au(self.q_initial)
+    }
 }
 
 /// Fit of the mean-squared displacement curve.
@@ -180,8 +193,30 @@ pub fn measurement_from_ensemble(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use rand::rngs::StdRng;
     use rand::{Rng, SeedableRng};
+    use uom::si::length::astronomical_unit;
+
+    #[test]
+    fn typed_measurement_accessors_match_f64() {
+        let m = DiffusionMeasurement {
+            a_initial: 250.0,
+            q_initial: 36.0,
+            d_measured: 1e-3,
+            d_analytical: 1.1e-3,
+        };
+        assert_relative_eq!(
+            m.initial_semi_major_axis().get::<astronomical_unit>(),
+            m.a_initial,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            m.initial_perihelion().get::<astronomical_unit>(),
+            m.q_initial,
+            epsilon = 1e-9
+        );
+    }
 
     #[test]
     fn test_measure_diffusion_constant() {

--- a/crates/p9-2021-stability/src/resonance_chain.rs
+++ b/crates/p9-2021-stability/src/resonance_chain.rs
@@ -13,6 +13,7 @@
 
 use p9_core::analysis::hansen::hansen_x_neg3_2_neptune_chain;
 use p9_core::constants::{A_NEPTUNE_AU, GM_SUN, MASS_NEPTUNE_SOLAR};
+use p9_core::units::{au, Length};
 use serde::{Deserialize, Serialize};
 
 /// A single 2:j resonance with Neptune.
@@ -26,6 +27,17 @@ pub struct NeptuneResonance {
     pub delta_a: f64,
     /// Hansen coefficient X_j^{-3,2}
     pub hansen_coeff: f64,
+}
+
+impl NeptuneResonance {
+    /// Nominal semi-major axis as a [`Length`].
+    pub fn nominal_semi_major_axis(&self) -> Length {
+        au(self.a_nominal)
+    }
+    /// Resonance half-width in semi-major axis as a [`Length`].
+    pub fn half_width(&self) -> Length {
+        au(self.delta_a)
+    }
 }
 
 /// Compute the nominal semi-major axis for a 2:j resonance with Neptune.
@@ -89,7 +101,24 @@ pub fn pendulum_hamiltonian(phi: f64, phi_tilde: f64, j: i64, q: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use p9_core::analysis::resonance::chirikov_overlap_parameter;
+    use uom::si::length::astronomical_unit;
+
+    #[test]
+    fn typed_resonance_accessors_match_f64() {
+        let res = build_resonance_chain(3, 3, 40.0)[0].clone();
+        assert_relative_eq!(
+            res.nominal_semi_major_axis().get::<astronomical_unit>(),
+            res.a_nominal,
+            epsilon = 1e-9
+        );
+        assert_relative_eq!(
+            res.half_width().get::<astronomical_unit>(),
+            res.delta_a,
+            epsilon = 1e-9
+        );
+    }
 
     #[test]
     fn test_resonance_semimajor_j2() {

--- a/crates/p9-2021-stability/src/stability.rs
+++ b/crates/p9-2021-stability/src/stability.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 
 use p9_core::analysis::resonance::chirikov_overlap_parameter;
 use p9_core::constants::{A_NEPTUNE_AU, GM_SUN, MASS_NEPTUNE_SOLAR};
+use p9_core::units::{days, Time};
 
 use crate::chirikov::OVERLAP_GLOBAL_CHAOS;
 
@@ -47,6 +48,12 @@ pub fn classify(a: f64, q: f64) -> StabilityClass {
 /// Units: days (using GM_SUN in AU^3/day^2).
 pub fn lyapunov_time_days(a: f64) -> f64 {
     std::f64::consts::TAU * (a * a * a / GM_SUN).sqrt()
+}
+
+/// Lyapunov time as a dimension-checked [`Time`] for the semi-major axis `a`
+/// (in AU). Typed sibling of [`lyapunov_time_days`].
+pub fn lyapunov_time(a: f64) -> Time {
+    days(lyapunov_time_days(a))
 }
 
 /// Semi-major axis diffusion coefficient (AU^2/yr).
@@ -107,7 +114,18 @@ impl StabilityMap {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
     use p9_core::analysis::resonance::{critical_perihelion, is_chaotic};
+    use uom::si::time::day;
+
+    #[test]
+    fn typed_lyapunov_time_matches_f64() {
+        assert_relative_eq!(
+            lyapunov_time(500.0).get::<day>(),
+            lyapunov_time_days(500.0),
+            epsilon = 1e-6
+        );
+    }
 
     #[test]
     fn test_chaotic_near_neptune() {

--- a/crates/p9-2021-ztf/Cargo.toml
+++ b/crates/p9-2021-ztf/Cargo.toml
@@ -10,3 +10,6 @@ rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 approx = { workspace = true }
+
+[dev-dependencies]
+uom = "0.38.0"

--- a/crates/p9-2021-ztf/src/sky.rs
+++ b/crates/p9-2021-ztf/src/sky.rs
@@ -10,6 +10,7 @@
 use p9_core::constants::{DEG2RAD, GM_SUN};
 use p9_core::coords::sky::ecliptic_vec_declination;
 use p9_core::types::OrbitalElements;
+use p9_core::units::{degrees, Angle};
 
 /// Heliocentric ecliptic longitude, latitude (radians) and distance (AU)
 /// for orbital elements at their stored mean anomaly.
@@ -27,6 +28,12 @@ pub fn declination_deg(elem: &OrbitalElements) -> f64 {
     ecliptic_vec_declination(&state.pos) / DEG2RAD
 }
 
+/// Declination of an orbit's current sky position as a dimension-checked
+/// [`Angle`]. Typed sibling of [`declination_deg`].
+pub fn declination(elem: &OrbitalElements) -> Angle {
+    degrees(declination_deg(elem))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -41,6 +48,18 @@ mod tests {
             omega_big: omega_big_deg * DEG2RAD,
             mean_anomaly: m_deg * DEG2RAD,
         }
+    }
+
+    #[test]
+    fn typed_declination_matches_f64() {
+        use approx::assert_relative_eq;
+        use uom::si::angle::degree;
+        let e = elem(15.0, 30.0, 45.0, 60.0);
+        assert_relative_eq!(
+            declination(&e).get::<degree>(),
+            declination_deg(&e),
+            epsilon = 1e-12
+        );
     }
 
     #[test]

--- a/crates/p9-2021-ztf/src/survey_model.rs
+++ b/crates/p9-2021-ztf/src/survey_model.rs
@@ -6,6 +6,7 @@
 //! survey table in `p9_core::analysis::surveys`.
 
 use p9_core::analysis::surveys::limiting_magnitude;
+use p9_core::units::{degrees, Angle};
 use serde::{Deserialize, Serialize};
 
 /// ZTF survey model parameters for Planet Nine detection.
@@ -45,6 +46,12 @@ impl ZtfSurvey {
         dec_deg > self.dec_limit_deg
     }
 
+    /// Southern declination limit of the footprint as a dimension-checked
+    /// [`Angle`].
+    pub fn dec_limit(&self) -> Angle {
+        degrees(self.dec_limit_deg)
+    }
+
     /// Tracklet-linking efficiency measured from known asteroid recoveries.
     ///
     /// Brown & Batygin (2021) report 99.66% linking efficiency for objects
@@ -57,12 +64,24 @@ impl ZtfSurvey {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use approx::assert_relative_eq;
+    use uom::si::angle::degree;
 
     #[test]
     fn default_matches_shared_survey_table() {
         let survey = ZtfSurvey::default();
         assert!((survey.depth_limit - 20.5).abs() < 1e-10);
         assert!((survey.dec_limit_deg - (-30.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn typed_dec_limit_matches_f64() {
+        let survey = ZtfSurvey::default();
+        assert_relative_eq!(
+            survey.dec_limit().get::<degree>(),
+            survey.dec_limit_deg,
+            epsilon = 1e-12
+        );
     }
 
     #[test]


### PR DESCRIPTION
Additively adopts the `p9_core::units` typed (uom) boundary across the batch-7
crates. No existing `f64` fields, signatures, test values, or inner physics were
changed; every addition is a new dimension-checked accessor plus a round-trip
test pinning it to its `f64` source. `uom@0.38.0` added as a dev-dependency to
each crate whose tests name units.

## Per-crate

- **p9-2021-napier-critique** — `SelectionFunction::{phi1_angle, phi2_angle}` → `Angle`.
- **p9-2021-oort-cloud** — `OortCloudConfig` (cluster_mass, cluster_radius,
  min/max_semi_major_axis, min/max_perihelion, inclination_dispersion,
  velocity_dispersion, encounter_timescale); `InjectionConfig`
  (injection_perihelion_threshold, min_dkb_semi_major_axis, duration, timestep);
  `ParticleOutcome::min_perihelion`; `SmaBin::{lower_edge, upper_edge}`.
- **p9-2021-orbit** — `GridPoint::{mass, semi_major_axis, inclination}`;
  `SimGridConfig` (integration_time, timestep, snapshot_interval,
  max_disk_inclination, inner/outer_removal_radius); `ElementSample`
  (semi_major_axis, inclination, delta_varpi_angle, delta_omega_big_angle);
  `ClusteringConfidence::mean_direction_angle`.
- **p9-2021-perihelion-gap** — `DistantTno::{semi_major_axis, perihelion_typed}`;
  `TwoPopulationParams` scattering/detached mean+sigma and bridge lower/upper → `Length`.
- **p9-2021-stability** — `lyapunov_time` typed sibling of `lyapunov_time_days`;
  `NeptuneResonance::{nominal_semi_major_axis, half_width}`;
  `DiffusionMeasurement::{initial_semi_major_axis, initial_perihelion}`.
  (Diffusion coefficients AU^2/yr left untyped — no named uom quantity / constructor.)
- **p9-2021-ztf** — `ZtfSurvey::dec_limit` → `Angle`; `sky::declination` typed
  sibling of `declination_deg`.

## Skipped

- **p9-2022-des** — its only dimensional public scalars are the footprint solid
  angle (`footprint_area`, `solid_angle_deg2`, deg^2; no `SolidAngle` quantity in
  the units API) and observing-epoch times buried inside `Vec<(band, days, ...)>`
  tuples (cannot get a clean additive scalar accessor without changing the
  signature). Everything else is magnitudes / colors / counts / probabilities.
