### PR TITLE
Drop f64 accessor twins; typed uom boundary only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+.claude/
 papers/
 review_article.html
 figure_*.svg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,6 +1189,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1201,6 +1202,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1240,6 +1242,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1262,6 +1265,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1368,6 +1372,7 @@ dependencies = [
  "p9-core",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1403,6 +1408,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1416,6 +1422,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,6 +1215,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]
@@ -1427,6 +1428,7 @@ dependencies = [
  "rand_distr",
  "serde",
  "serde_json",
+ "uom 0.38.0",
 ]
 
 [[package]]

--- a/crates/p9-2016-cassini-ranging/Cargo.toml
+++ b/crates/p9-2016-cassini-ranging/Cargo.toml
@@ -9,6 +9,7 @@ p9-core = { path = "../p9-core" }
 nalgebra = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/crates/p9-2016-cassini-ranging/src/perturbation.rs
+++ b/crates/p9-2016-cassini-ranging/src/perturbation.rs
@@ -311,42 +311,28 @@ impl RangePerturbationCurve {
         best
     }
 
-    /// True anomaly (radians) that minimizes the range perturbation.
-    pub fn argmin_true_anomaly(&self) -> f64 {
-        self.true_anomaly[self.argmin()]
-    }
-
     /// True anomaly (degrees) that minimizes the range perturbation.
     pub fn argmin_true_anomaly_deg(&self) -> f64 {
-        self.argmin_true_anomaly().to_degrees()
-    }
-
-    /// Minimum amplitude (km).
-    pub fn min_amplitude_km(&self) -> f64 {
-        self.amplitude_km[self.argmin()]
-    }
-
-    /// Maximum amplitude (km).
-    pub fn max_amplitude_km(&self) -> f64 {
-        self.amplitude_km
-            .iter()
-            .copied()
-            .fold(f64::NEG_INFINITY, f64::max)
+        self.true_anomaly[self.argmin()].to_degrees()
     }
 
     /// True anomaly that minimizes the range perturbation, as a typed [`Angle`].
     pub fn argmin_true_anomaly_typed(&self) -> Angle {
-        radians(self.argmin_true_anomaly())
+        radians(self.true_anomaly[self.argmin()])
     }
 
     /// Minimum range-perturbation amplitude as a typed [`Length`].
     pub fn min_amplitude(&self) -> Length {
-        km(self.min_amplitude_km())
+        km(self.amplitude_km[self.argmin()])
     }
 
     /// Maximum range-perturbation amplitude as a typed [`Length`].
     pub fn max_amplitude(&self) -> Length {
-        km(self.max_amplitude_km())
+        km(self
+            .amplitude_km
+            .iter()
+            .copied()
+            .fold(f64::NEG_INFINITY, f64::max))
     }
 }
 
@@ -487,10 +473,10 @@ mod tests {
         p_close.a = 400.0;
         let mut p_far = brown_batygin_orbit();
         p_far.a = 800.0;
-        let max_close = range_perturbation_curve(&p_close, 360).max_amplitude_km();
-        let max_far = range_perturbation_curve(&p_far, 360).max_amplitude_km();
+        let max_close = range_perturbation_curve(&p_close, 360).max_amplitude();
+        let max_far = range_perturbation_curve(&p_far, 360).max_amplitude();
         // Doubling a roughly doubles distance → tidal ~1/r³ → factor several.
-        let ratio = max_close / max_far;
+        let ratio = (max_close / max_far).value;
         assert!(ratio > 4.0, "distance falloff too weak: ratio = {ratio:.2}");
     }
 
@@ -499,19 +485,25 @@ mod tests {
         use approx::assert_relative_eq;
         let p = brown_batygin_orbit();
         let curve = range_perturbation_curve(&p, 64);
+        let argmin = curve.argmin();
         assert_relative_eq!(
             (curve.min_amplitude() / km(1.0)).value,
-            curve.min_amplitude_km(),
+            curve.amplitude_km[argmin],
             max_relative = 1e-12
         );
+        let max_km = curve
+            .amplitude_km
+            .iter()
+            .copied()
+            .fold(f64::NEG_INFINITY, f64::max);
         assert_relative_eq!(
             (curve.max_amplitude() / km(1.0)).value,
-            curve.max_amplitude_km(),
+            max_km,
             max_relative = 1e-12
         );
         assert_relative_eq!(
             (curve.argmin_true_anomaly_typed() / radians(1.0)).value,
-            curve.argmin_true_anomaly(),
+            curve.true_anomaly[argmin],
             max_relative = 1e-12
         );
     }

--- a/crates/p9-2016-commensurabilities/Cargo.toml
+++ b/crates/p9-2016-commensurabilities/Cargo.toml
@@ -9,6 +9,7 @@ rand = { workspace = true }
 rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/crates/p9-2016-commensurabilities/src/commensurability.rs
+++ b/crates/p9-2016-commensurabilities/src/commensurability.rs
@@ -36,18 +36,12 @@ use p9_core::units::{julian_year, Time};
 /// p/q. de la Fuente Marcos et al. emphasize low-order commensurabilities.
 pub const DEFAULT_MAX_INTEGER: u32 = 9;
 
-/// Heliocentric orbital period (years) from semi-major axis (AU): Kepler's
-/// third law for a one-solar-mass primary, P = a^{3/2}. The neglected ~1e-4
-/// planet/ETNO masses are far below the precision of a commensurability
-/// argument.
-pub fn orbital_period_years(a_au: f64) -> f64 {
-    a_au.powf(1.5)
-}
-
 /// Heliocentric orbital period as a typed [`Time`] from semi-major axis (AU):
-/// the [`orbital_period_years`] value scaled into Julian years.
+/// Kepler's third law for a one-solar-mass primary, P = a^{3/2}, scaled into
+/// Julian years. The neglected ~1e-4 planet/ETNO masses are far below the
+/// precision of a commensurability argument.
 pub fn orbital_period(a_au: f64) -> Time {
-    julian_year() * orbital_period_years(a_au)
+    julian_year() * a_au.powf(1.5)
 }
 
 /// Distance of a period ratio `ratio` (≥ 1) to the nearest small-integer ratio
@@ -80,11 +74,11 @@ pub fn distance_to_nearest_commensurability(ratio: f64, max_int: u32) -> f64 {
 
 /// Period ratio of two bodies, longer period over shorter (≥ 1).
 pub fn period_ratio(a_i: f64, a_j: f64) -> f64 {
-    let (pi, pj) = (orbital_period_years(a_i), orbital_period_years(a_j));
+    let (pi, pj) = (orbital_period(a_i), orbital_period(a_j));
     if pi >= pj {
-        pi / pj
+        (pi / pj).value
     } else {
-        pj / pi
+        (pj / pi).value
     }
 }
 
@@ -371,7 +365,7 @@ mod tests {
         for &a in &[300.0, 500.0, 700.0] {
             assert_relative_eq!(
                 (orbital_period(a) / julian_year()).value,
-                orbital_period_years(a),
+                a.powf(1.5),
                 max_relative = 1e-12
             );
         }

--- a/crates/p9-2016-constraints/Cargo.toml
+++ b/crates/p9-2016-constraints/Cargo.toml
@@ -12,6 +12,7 @@ rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 rayon = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/crates/p9-2016-constraints/src/clustering_metric.rs
+++ b/crates/p9-2016-constraints/src/clustering_metric.rs
@@ -18,6 +18,7 @@ use p9_core::constants::*;
 use p9_core::data::etno::longitudes_of_perihelion;
 use p9_core::data::stable_kbos::{longitude_of_perihelion, stable_kbos};
 use p9_core::types::OrbitalElements;
+use uom::si::length::astronomical_unit;
 
 /// Sedna-like "high perihelion" threshold (AU). Detached objects lifted to
 /// q > 60 AU are dynamically decoupled from Neptune (q_Neptune-scattering
@@ -123,7 +124,7 @@ pub fn confinement_probability(
         .filter(|e| {
             e.a >= 300.0
                 && e.a <= 700.0
-                && e.perihelion() < 80.0
+                && e.perihelion_typed().get::<astronomical_unit>() < 80.0
                 && e.i < 50.0 * DEG2RAD
                 && e.e < 1.0
         })

--- a/crates/p9-2016-constraints/src/detection_limits.rs
+++ b/crates/p9-2016-constraints/src/detection_limits.rs
@@ -27,14 +27,8 @@ pub fn predicted_v_magnitude(p9: &P9Params, true_anomaly: f64, albedo: f64, radi
 /// mass-radius relation (the previous local 3.0 R⊕ · M^0.27 fit made a
 /// 10 M⊕ planet larger than Neptune, ~40% too big, skewing detectability
 /// optimistic).
-pub fn estimate_radius_km(mass_earth: f64) -> f64 {
-    photometry::mass_radius_neptunian(mass_earth) * EARTH_RADIUS_KM
-}
-
-/// Planet Nine's physical radius as a typed [`Length`] (the [`estimate_radius_km`]
-/// value, in kilometers).
 pub fn estimate_radius(mass_earth: f64) -> Length {
-    km(estimate_radius_km(mass_earth))
+    km(photometry::mass_radius_neptunian(mass_earth) * EARTH_RADIUS_KM)
 }
 
 /// Compute the sky position (ecliptic longitude, latitude) of Planet Nine
@@ -71,7 +65,7 @@ pub fn sky_position(p9: &P9Params, true_anomaly: f64) -> (f64, f64) {
 
 /// Brightness curve: V magnitude vs true anomaly for the full orbit.
 pub fn brightness_curve(p9: &P9Params, albedo: f64, n_points: usize) -> Vec<(f64, f64, f64)> {
-    let radius_km = estimate_radius_km(p9.mass_earth);
+    let radius_km = (estimate_radius(p9.mass_earth) / km(1.0)).value;
 
     (0..n_points)
         .map(|i| {
@@ -98,7 +92,7 @@ pub fn survey_depths() -> Vec<(&'static str, f64)> {
 /// Fraction of the orbit brighter than a given V magnitude limit.
 pub fn detectable_fraction(p9: &P9Params, v_limit: f64, albedo: f64) -> f64 {
     let n = 1000;
-    let radius_km = estimate_radius_km(p9.mass_earth);
+    let radius_km = (estimate_radius(p9.mass_earth) / km(1.0)).value;
     let n_detectable = (0..n)
         .filter(|&i| {
             let nu = (i as f64 / n as f64) * 2.0 * PI - PI;
@@ -117,7 +111,7 @@ mod tests {
     fn test_brightness_at_perihelion_vs_aphelion() {
         let p9 = P9Params::nominal_2016();
 
-        let radius_km = estimate_radius_km(p9.mass_earth);
+        let radius_km = (estimate_radius(p9.mass_earth) / km(1.0)).value;
         let v_peri = predicted_v_magnitude(&p9, 0.0, 0.5, radius_km);
         let v_apo = predicted_v_magnitude(&p9, PI, 0.5, radius_km);
 
@@ -143,7 +137,7 @@ mod tests {
         for &m in &[1.0, 10.0, 20.0] {
             assert_relative_eq!(
                 (estimate_radius(m) / km(1.0)).value,
-                estimate_radius_km(m),
+                photometry::mass_radius_neptunian(m) * EARTH_RADIUS_KM,
                 max_relative = 1e-12
             );
         }
@@ -151,8 +145,8 @@ mod tests {
 
     #[test]
     fn test_radius_estimate() {
-        let r_10 = estimate_radius_km(10.0);
-        let r_1 = estimate_radius_km(1.0);
+        let r_10 = (estimate_radius(10.0) / km(1.0)).value;
+        let r_1 = (estimate_radius(1.0) / km(1.0)).value;
 
         // 10 Earth mass should have larger radius than 1 Earth mass
         assert!(r_10 > r_1);

--- a/crates/p9-2016-evidence/Cargo.toml
+++ b/crates/p9-2016-evidence/Cargo.toml
@@ -12,6 +12,7 @@ rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 rayon = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/crates/p9-2016-holman-payne/Cargo.toml
+++ b/crates/p9-2016-holman-payne/Cargo.toml
@@ -10,6 +10,7 @@ p9-2016-cassini-ranging = { path = "../p9-2016-cassini-ranging" }
 nalgebra = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/crates/p9-2016-holman-payne/examples/exclusion_map.rs
+++ b/crates/p9-2016-holman-payne/examples/exclusion_map.rs
@@ -4,9 +4,10 @@
 //! Run with: `cargo run -p p9-2016-holman-payne --example exclusion_map`
 
 use p9_2016_holman_payne::{
-    exclusion::ExclusionMap, favored_sky_position, published, range_residual_m,
+    exclusion::ExclusionMap, favored_sky_position, published, range_residual,
 };
 use p9_core::data::ephemeris_constraint::brown_batygin_orbit;
+use p9_core::units::meters;
 
 fn main() {
     let p = brown_batygin_orbit();
@@ -32,7 +33,7 @@ fn main() {
         println!(
             "{:>5.0}  {:>14.3e}",
             k as f64 * 20.0,
-            range_residual_m(&p, nu)
+            (range_residual(&p, nu) / meters(1.0)).value
         );
     }
 

--- a/crates/p9-2016-holman-payne/src/exclusion.rs
+++ b/crates/p9-2016-holman-payne/src/exclusion.rs
@@ -12,30 +12,28 @@ use p9_core::types::P9Params;
 use p9_core::units::{au, earth_masses, meters, Length, Mass};
 
 use crate::published::CASSINI_RANGE_PRECISION_M;
-use crate::signal::range_residual_m;
+use crate::signal::range_residual;
 
 /// Number of true-anomaly samples used to find a P9's peak range residual.
 const PERIHELION_ARC_SAMPLES: usize = 180;
 
-/// The strongest range residual (METRES) P9 can produce anywhere on its orbit.
+/// The strongest range residual P9 can produce anywhere on its orbit, as a
+/// typed [`Length`].
 ///
 /// The signal is largest on the perihelion-facing arc (closest approach to
 /// Saturn), so we scan true anomaly and take the maximum. This is the quantity
 /// compared against the Cassini precision: if even the worst-case phase stays
 /// below precision, the planet is unconstrained.
-pub fn peak_range_residual_m(params: &P9Params) -> f64 {
-    let mut peak = 0.0_f64;
+pub fn peak_range_residual(params: &P9Params) -> Length {
+    let mut peak = meters(0.0);
     for k in 0..PERIHELION_ARC_SAMPLES {
         let nu = std::f64::consts::TAU * (k as f64) / (PERIHELION_ARC_SAMPLES as f64);
-        peak = peak.max(range_residual_m(params, nu));
+        let residual = range_residual(params, nu);
+        if residual > peak {
+            peak = residual;
+        }
     }
     peak
-}
-
-/// The strongest range residual P9 can produce anywhere on its orbit, as a
-/// typed [`Length`] — the [`peak_range_residual_m`] value in metres.
-pub fn peak_range_residual(params: &P9Params) -> Length {
-    meters(peak_range_residual_m(params))
 }
 
 /// Verdict for a candidate Planet Nine.
@@ -49,7 +47,7 @@ pub enum ExclusionVerdict {
 
 /// Whether `params` is excluded by the Cassini range precision.
 pub fn excluded(params: &P9Params) -> ExclusionVerdict {
-    if peak_range_residual_m(params) > CASSINI_RANGE_PRECISION_M {
+    if peak_range_residual(params) > meters(CASSINI_RANGE_PRECISION_M) {
         ExclusionVerdict::Excluded
     } else {
         ExclusionVerdict::Allowed
@@ -67,7 +65,7 @@ pub fn max_allowed_mass_earth(template: &P9Params, a_au: f64) -> f64 {
     let mut p = *template;
     p.a = a_au;
     p.mass_earth = 1.0;
-    let peak_per_earth_mass = peak_range_residual_m(&p);
+    let peak_per_earth_mass = (peak_range_residual(&p) / meters(1.0)).value;
     CASSINI_RANGE_PRECISION_M / peak_per_earth_mass
 }
 
@@ -180,11 +178,17 @@ mod tests {
 
     #[test]
     fn typed_exclusion_accessors_match_f64() {
+        use crate::signal::range_residual;
         use approx::assert_relative_eq;
         let template = brown_batygin_orbit();
+        let mut peak_m = 0.0_f64;
+        for k in 0..PERIHELION_ARC_SAMPLES {
+            let nu = std::f64::consts::TAU * (k as f64) / (PERIHELION_ARC_SAMPLES as f64);
+            peak_m = peak_m.max((range_residual(&template, nu) / meters(1.0)).value);
+        }
         assert_relative_eq!(
             (peak_range_residual(&template) / meters(1.0)).value,
-            peak_range_residual_m(&template),
+            peak_m,
             max_relative = 1e-12
         );
         assert_relative_eq!(

--- a/crates/p9-2016-holman-payne/src/lib.rs
+++ b/crates/p9-2016-holman-payne/src/lib.rs
@@ -85,5 +85,5 @@ pub mod published {
 }
 
 pub use exclusion::{excluded, max_allowed_mass_earth, ExclusionMap, ExclusionVerdict};
-pub use signal::{favored_true_anomaly, range_residual_m};
+pub use signal::{favored_true_anomaly, range_residual};
 pub use sky::{favored_sky_position, SkyPosition};

--- a/crates/p9-2016-holman-payne/src/signal.rs
+++ b/crates/p9-2016-holman-payne/src/signal.rs
@@ -17,22 +17,15 @@ use p9_2016_cassini_ranging::perturbation::{
 /// Metres per kilometre.
 const M_PER_KM: f64 = 1_000.0;
 
-/// Post-fit Earth–Saturn range-residual amplitude (METRES) for P9 at true
-/// anomaly `nu` (radians) on the orbit `params`.
+/// Post-fit Earth–Saturn range-residual amplitude as a typed [`Length`], for P9
+/// at true anomaly `nu` (radians) on the orbit `params`.
 ///
 /// Thin unit wrapper over the sibling crate's
 /// [`range_perturbation_amplitude`] (which returns kilometres). The amplitude
 /// scales LINEARLY with P9 mass (through `GM_p9`) and falls STEEPLY (≈`1/d³`)
 /// with P9 heliocentric distance — the two scalings Holman & Payne emphasize.
-pub fn range_residual_m(params: &P9Params, nu: f64) -> f64 {
-    range_perturbation_amplitude(params, nu) * M_PER_KM
-}
-
-/// Post-fit Earth–Saturn range-residual amplitude as a typed [`Length`], for P9
-/// at true anomaly `nu` (radians) on the orbit `params` — the [`range_residual_m`]
-/// value in metres.
 pub fn range_residual(params: &P9Params, nu: f64) -> Length {
-    meters(range_residual_m(params, nu))
+    meters(range_perturbation_amplitude(params, nu) * M_PER_KM)
 }
 
 /// The favored true anomaly (radians) on the near (post-perihelion) arc — the
@@ -57,9 +50,10 @@ mod tests {
         let mut p20 = brown_batygin_orbit();
         p20.mass_earth = 20.0;
         let nu = 20.0_f64.to_radians(); // perihelion-facing, high signal
-        let r10 = range_residual_m(&p10, nu);
-        let r20 = range_residual_m(&p20, nu);
-        assert!((r20 / r10 - 2.0).abs() < 1e-9, "ratio = {}", r20 / r10);
+        let r10 = range_residual(&p10, nu);
+        let r20 = range_residual(&p20, nu);
+        let ratio = (r20 / r10).value;
+        assert!((ratio - 2.0).abs() < 1e-9, "ratio = {ratio}");
     }
 
     #[test]
@@ -73,12 +67,12 @@ mod tests {
         p_close.a = 400.0;
         let mut p_far = brown_batygin_orbit();
         p_far.a = 800.0;
-        let close = range_residual_m(&p_close, nu);
-        let far = range_residual_m(&p_far, nu);
+        let close = range_residual(&p_close, nu);
+        let far = range_residual(&p_far, nu);
         let r_close = position_at_true_anomaly(&p_close, nu).distance;
         let r_far = position_at_true_anomaly(&p_far, nu).distance;
         // Effective falloff exponent from the two samples.
-        let n_eff = (close / far).ln() / (r_far / r_close).ln();
+        let n_eff = (close / far).value.ln() / (r_far / r_close).ln();
         assert!(
             n_eff > 2.5,
             "distance falloff too shallow: n_eff = {n_eff:.2} (r {r_close:.0}→{r_far:.0} AU)"
@@ -91,7 +85,8 @@ mod tests {
         let p = brown_batygin_orbit();
         let nu = 30.0_f64.to_radians();
         let km = range_perturbation_amplitude(&p, nu);
-        assert!((range_residual_m(&p, nu) - km * 1000.0).abs() < 1e-12);
+        let residual_m = (range_residual(&p, nu) / meters(1.0)).value;
+        assert!((residual_m - km * 1000.0).abs() < 1e-12);
     }
 
     #[test]
@@ -101,7 +96,7 @@ mod tests {
         let nu = 30.0_f64.to_radians();
         assert_relative_eq!(
             (range_residual(&p, nu) / meters(1.0)).value,
-            range_residual_m(&p, nu),
+            range_perturbation_amplitude(&p, nu) * M_PER_KM,
             max_relative = 1e-12
         );
     }

--- a/crates/p9-2016-inclination-instability/Cargo.toml
+++ b/crates/p9-2016-inclination-instability/Cargo.toml
@@ -8,7 +8,7 @@ description = "Reproduction of Madigan & McCourt (2016) 'The inclination instabi
 p9-core = { path = "../p9-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2016-inclination-instability/src/growth.rs
+++ b/crates/p9-2016-inclination-instability/src/growth.rs
@@ -42,10 +42,10 @@ use p9_core::units::{days, radians, AngularVelocity, Time};
 /// pinned in the tests and documented in the crate's residual notes.
 pub const C_GROWTH: f64 = TWO_PI;
 
-/// Mean motion n = sqrt(GM_sun / a^3) in rad/day for an orbit of semi-major
-/// axis `a` (AU), reusing `p9_core`'s element machinery so the Kepler
-/// convention is shared with the rest of the workspace.
-pub fn mean_motion(a: f64) -> f64 {
+/// Mean motion n = sqrt(GM_sun / a^3) as a typed [`AngularVelocity`] for an
+/// orbit of semi-major axis `a` (AU), reusing `p9_core`'s element machinery so
+/// the Kepler convention is shared with the rest of the workspace.
+pub fn mean_motion_typed(a: f64) -> AngularVelocity {
     let elem = OrbitalElements {
         a,
         e: 0.0,
@@ -54,80 +54,49 @@ pub fn mean_motion(a: f64) -> f64 {
         omega: 0.0,
         mean_anomaly: 0.0,
     };
-    elem.mean_motion(GM_SUN)
+    (radians(elem.mean_motion(GM_SUN)) / days(1.0)).into()
 }
 
-/// Orbital period P = 2 pi sqrt(a^3 / GM_sun) in days.
-pub fn orbital_period(a: f64) -> f64 {
-    TWO_PI / mean_motion(a)
+/// Orbital period P = 2 pi sqrt(a^3 / GM_sun) as a typed [`Time`].
+pub fn orbital_period_typed(a: f64) -> Time {
+    let n_rad_per_day = (mean_motion_typed(a) * days(1.0)) / radians(1.0);
+    days(TWO_PI / n_rad_per_day.value)
 }
 
 /// Disc self-gravity secular precession frequency omega_sec = (M_d/M_sun) * n
-/// [rad/day]. This is the rate compared against the giant planets in the
-/// suppression criterion. `m_disk_solar`: disc mass in solar masses;
-/// `a`: characteristic semi-major axis (AU).
-pub fn secular_frequency(m_disk_solar: f64, a: f64) -> f64 {
-    m_disk_solar * mean_motion(a)
+/// as a typed [`AngularVelocity`]. This is the rate compared against the giant
+/// planets in the suppression criterion. `m_disk_solar`: disc mass in solar
+/// masses; `a`: characteristic semi-major axis (AU).
+pub fn secular_frequency_typed(m_disk_solar: f64, a: f64) -> AngularVelocity {
+    m_disk_solar * mean_motion_typed(a)
 }
 
-/// Disc secular time t_sec = (M_sun/M_d) * P [days].
-pub fn secular_time_days(m_disk_solar: f64, a: f64) -> f64 {
-    orbital_period(a) / m_disk_solar
+/// Disc secular time t_sec = (M_sun/M_d) * P as a typed [`Time`].
+pub fn secular_time_typed(m_disk_solar: f64, a: f64) -> Time {
+    orbital_period_typed(a) / m_disk_solar
 }
 
-/// Linear-theory growth rate gamma = (M_d/M_sun) * n / C_GROWTH  [1/day].
-/// Monotonically increasing in `m_disk_solar`.
-pub fn growth_rate(m_disk_solar: f64, a: f64) -> f64 {
-    secular_frequency(m_disk_solar, a) / C_GROWTH
+/// Linear-theory growth rate gamma = (M_d/M_sun) * n / C_GROWTH as a typed
+/// [`AngularVelocity`]. Monotonically increasing in `m_disk_solar`.
+pub fn growth_rate_typed(m_disk_solar: f64, a: f64) -> AngularVelocity {
+    secular_frequency_typed(m_disk_solar, a) / C_GROWTH
 }
 
-/// E-folding time tau = 1/gamma  [days]. Decreases with disc mass.
-pub fn efolding_time_days(m_disk_solar: f64, a: f64) -> f64 {
-    1.0 / growth_rate(m_disk_solar, a)
+/// E-folding time tau = 1/gamma as a typed [`Time`]. Decreases with disc mass.
+pub fn efolding_time_typed(m_disk_solar: f64, a: f64) -> Time {
+    radians(1.0) / growth_rate_typed(m_disk_solar, a)
 }
 
 /// E-folding time in millions of years.
 pub fn efolding_time_myr(m_disk_solar: f64, a: f64) -> f64 {
-    efolding_time_days(m_disk_solar, a) / (YEAR_DAYS * 1.0e6)
+    let tau_days = efolding_time_typed(m_disk_solar, a) / days(1.0);
+    tau_days.value / (YEAR_DAYS * 1.0e6)
 }
 
 /// E-folding time in billions of years (Gyr).
 pub fn efolding_time_gyr(m_disk_solar: f64, a: f64) -> f64 {
-    efolding_time_days(m_disk_solar, a) / GYR_DAYS
-}
-
-// ---- typed (uom) boundary: dimension-checked views of the rates/times above ----
-
-/// Mean motion [`n`](mean_motion) as a typed [`AngularVelocity`].
-pub fn mean_motion_typed(a: f64) -> AngularVelocity {
-    (radians(mean_motion(a)) / days(1.0)).into()
-}
-
-/// Orbital period [`P`](orbital_period) as a typed [`Time`].
-pub fn orbital_period_typed(a: f64) -> Time {
-    days(orbital_period(a))
-}
-
-/// Disc secular precession frequency [`omega_sec`](secular_frequency) as a
-/// typed [`AngularVelocity`].
-pub fn secular_frequency_typed(m_disk_solar: f64, a: f64) -> AngularVelocity {
-    (radians(secular_frequency(m_disk_solar, a)) / days(1.0)).into()
-}
-
-/// Disc secular time [`t_sec`](secular_time_days) as a typed [`Time`].
-pub fn secular_time_typed(m_disk_solar: f64, a: f64) -> Time {
-    days(secular_time_days(m_disk_solar, a))
-}
-
-/// Linear-theory growth rate [`gamma`](growth_rate) as a typed
-/// [`AngularVelocity`].
-pub fn growth_rate_typed(m_disk_solar: f64, a: f64) -> AngularVelocity {
-    (radians(growth_rate(m_disk_solar, a)) / days(1.0)).into()
-}
-
-/// E-folding time [`tau`](efolding_time_days) as a typed [`Time`].
-pub fn efolding_time_typed(m_disk_solar: f64, a: f64) -> Time {
-    days(efolding_time_days(m_disk_solar, a))
+    let tau_days = efolding_time_typed(m_disk_solar, a) / days(1.0);
+    tau_days.value / GYR_DAYS
 }
 
 #[cfg(test)]
@@ -138,36 +107,48 @@ mod tests {
     use uom::si::angular_velocity::radian_per_second;
     use uom::si::time::day;
 
+    /// Inline reference mean motion n [rad/day] from the shared Kepler machinery.
+    fn ref_mean_motion(a: f64) -> f64 {
+        let elem = OrbitalElements {
+            a,
+            e: 0.0,
+            i: 0.0,
+            omega_big: 0.0,
+            omega: 0.0,
+            mean_anomaly: 0.0,
+        };
+        elem.mean_motion(GM_SUN)
+    }
+
     #[test]
-    fn typed_accessors_match_f64_sources() {
+    fn typed_accessors_match_inline_formulas() {
         let m = 20.0 * EARTH_MASS_SOLAR;
         let a = 250.0;
         // rates: rad/day -> compare in rad/s
         let per_day_to_per_s = 1.0 / 86_400.0;
+        let n = ref_mean_motion(a);
         assert_relative_eq!(
             mean_motion_typed(a).get::<radian_per_second>(),
-            mean_motion(a) * per_day_to_per_s,
+            n * per_day_to_per_s,
             epsilon = 1e-30
         );
         assert_relative_eq!(
             secular_frequency_typed(m, a).get::<radian_per_second>(),
-            secular_frequency(m, a) * per_day_to_per_s,
+            (m * n) * per_day_to_per_s,
             epsilon = 1e-30
         );
         assert_relative_eq!(
             growth_rate_typed(m, a).get::<radian_per_second>(),
-            growth_rate(m, a) * per_day_to_per_s,
+            (m * n / C_GROWTH) * per_day_to_per_s,
             epsilon = 1e-30
         );
         // times: days
-        assert_relative_eq!(orbital_period_typed(a).get::<day>(), orbital_period(a));
-        assert_relative_eq!(
-            secular_time_typed(m, a).get::<day>(),
-            secular_time_days(m, a)
-        );
+        assert_relative_eq!(orbital_period_typed(a).get::<day>(), TWO_PI / n);
+        assert_relative_eq!(secular_time_typed(m, a).get::<day>(), (TWO_PI / n) / m);
         assert_relative_eq!(
             efolding_time_typed(m, a).get::<day>(),
-            efolding_time_days(m, a)
+            1.0 / (m * n / C_GROWTH),
+            max_relative = 1e-12
         );
     }
 
@@ -187,7 +168,7 @@ mod tests {
         let masses = [1.0, 5.0, 10.0, 20.0, 50.0];
         let mut prev = 0.0;
         for &m_e in &masses {
-            let g = growth_rate(m_e * EARTH_MASS_SOLAR, a);
+            let g = (growth_rate_typed(m_e * EARTH_MASS_SOLAR, a) * days(1.0) / radians(1.0)).value;
             assert!(g > prev, "growth rate not increasing at {m_e} M_earth");
             prev = g;
         }
@@ -240,9 +221,9 @@ mod tests {
         // time t_sec = (M_sun/M_d) P exactly.
         let m = fiducial_mass_solar();
         let a = FIDUCIAL_A_AU;
-        let tau = efolding_time_days(m, a);
-        let t_sec = secular_time_days(m, a);
-        assert!((tau / t_sec - 1.0).abs() < 1e-12);
+        let tau = efolding_time_typed(m, a);
+        let t_sec = secular_time_typed(m, a);
+        assert!(((tau / t_sec).value - 1.0).abs() < 1e-12);
     }
 
     #[test]
@@ -252,8 +233,8 @@ mod tests {
         let m = fiducial_mass_solar();
         let a1 = 250.0;
         let a2 = a1 * 2.0_f64.powf(2.0 / 3.0); // period doubles
-        let w1 = secular_frequency(m, a1);
-        let w2 = secular_frequency(m, a2);
-        assert!((w1 / w2 - 2.0).abs() < 1e-9);
+        let w1 = secular_frequency_typed(m, a1);
+        let w2 = secular_frequency_typed(m, a2);
+        assert!(((w1 / w2).value - 2.0).abs() < 1e-9);
     }
 }

--- a/crates/p9-2016-inclination-instability/src/suppression.rs
+++ b/crates/p9-2016-inclination-instability/src/suppression.rs
@@ -33,9 +33,9 @@
 
 use p9_core::constants::{A_NEPTUNE_AU, EARTH_MASS_SOLAR, MASS_NEPTUNE_SOLAR};
 use p9_core::forces::j2_secular::{combined_j2_jsu, effective_j2};
-use p9_core::units::{days, radians, solar_masses, AngularVelocity, Mass};
+use p9_core::units::{solar_masses, AngularVelocity, Mass};
 
-use crate::growth::{mean_motion, secular_frequency};
+use crate::growth::{mean_motion_typed, secular_frequency_typed};
 
 /// Effective J2 (AU^2) of the four giant planets: (1/2) sum_p (m_p/M_sun) a_p^2,
 /// built from the shared `p9_core` J2 helpers (J+S+U) plus Neptune. Identical
@@ -45,12 +45,13 @@ pub fn giant_planet_j2_eff() -> f64 {
     j2_jsu + effective_j2(MASS_NEPTUNE_SOLAR, A_NEPTUNE_AU, 1.0)
 }
 
-/// Giant-planet secular apsidal precession rate for a disc orbit at (a, e)
-/// [rad/day]:  g = (3/2) n J2_eff / [a^2 (1-e^2)^2].
-pub fn giant_planet_precession_rate(a: f64, e: f64) -> f64 {
+/// Giant-planet secular apsidal precession rate for a disc orbit at (a, e) as a
+/// typed [`AngularVelocity`]:  g = (3/2) n J2_eff / [a^2 (1-e^2)^2].
+pub fn giant_planet_precession_rate_typed(a: f64, e: f64) -> AngularVelocity {
     let j2_eff = giant_planet_j2_eff();
     let eta2 = 1.0 - e * e;
-    1.5 * mean_motion(a) * j2_eff / (a * a * eta2 * eta2)
+    let scale = 1.5 * j2_eff / (a * a * eta2 * eta2);
+    scale * mean_motion_typed(a)
 }
 
 /// Critical disc mass (solar masses) above which the inclination instability
@@ -66,12 +67,6 @@ pub fn critical_mass_solar(a: f64, e: f64) -> f64 {
 /// Critical disc mass in Earth masses.
 pub fn critical_mass_earth(a: f64, e: f64) -> f64 {
     critical_mass_solar(a, e) / EARTH_MASS_SOLAR
-}
-
-/// Giant-planet precession rate [`g`](giant_planet_precession_rate) as a typed
-/// [`AngularVelocity`].
-pub fn giant_planet_precession_rate_typed(a: f64, e: f64) -> AngularVelocity {
-    (radians(giant_planet_precession_rate(a, e)) / days(1.0)).into()
 }
 
 /// Critical disc mass [`M_crit`](critical_mass_solar) as a typed [`Mass`].
@@ -91,8 +86,8 @@ pub enum Stability {
 /// Apply the Das & Batygin suppression criterion: compare the disc self-gravity
 /// secular frequency against the giant-planet precession rate at (a, e).
 pub fn classify(m_disk_solar: f64, a: f64, e: f64) -> Stability {
-    let omega_disk = secular_frequency(m_disk_solar, a);
-    let g_planet = giant_planet_precession_rate(a, e);
+    let omega_disk = secular_frequency_typed(m_disk_solar, a);
+    let g_planet = giant_planet_precession_rate_typed(a, e);
     if omega_disk > g_planet {
         Stability::Unstable
     } else {
@@ -112,10 +107,17 @@ mod tests {
     const E_DISK: f64 = 0.6;
 
     #[test]
-    fn typed_accessors_match_f64_sources() {
+    fn typed_accessors_match_inline_formulas() {
+        // Inline reference g [rad/day] = (3/2) n J2_eff / [a^2 (1-e^2)^2].
+        let n = (mean_motion_typed(A_AU) * p9_core::units::days(1.0)
+            / p9_core::units::radians(1.0))
+        .value;
+        let j2_eff = giant_planet_j2_eff();
+        let eta2 = 1.0 - E_DISK * E_DISK;
+        let g_ref = 1.5 * n * j2_eff / (A_AU * A_AU * eta2 * eta2);
         assert_relative_eq!(
             giant_planet_precession_rate_typed(A_AU, E_DISK).get::<radian_per_second>(),
-            giant_planet_precession_rate(A_AU, E_DISK) / 86_400.0,
+            g_ref / 86_400.0,
             epsilon = 1e-30
         );
         assert_relative_eq!(

--- a/crates/p9-2016-inclined-tnos/Cargo.toml
+++ b/crates/p9-2016-inclined-tnos/Cargo.toml
@@ -12,7 +12,7 @@ rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 rayon = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2016-obliquity-gomes/Cargo.toml
+++ b/crates/p9-2016-obliquity-gomes/Cargo.toml
@@ -9,7 +9,7 @@ p9-core = { path = "../p9-core" }
 nalgebra = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2016-obliquity-gomes/src/lib.rs
+++ b/crates/p9-2016-obliquity-gomes/src/lib.rs
@@ -38,17 +38,11 @@ pub mod precession_model;
 
 /// Published reference constants from Gomes, Deienno & Morbidelli (2016).
 pub mod reference {
-    use p9_core::constants::DEG2RAD;
     use p9_core::units::{degrees, Angle};
 
     /// Observed solar obliquity: the tilt of the Sun's equator relative to the
     /// invariable (giant-planet) plane, ≈ 6° (degrees).
     pub const OBSERVED_SOLAR_OBLIQUITY_DEG: f64 = 6.0;
-
-    /// Observed solar obliquity in radians.
-    pub fn observed_solar_obliquity_rad() -> f64 {
-        OBSERVED_SOLAR_OBLIQUITY_DEG * DEG2RAD
-    }
 
     /// Observed solar obliquity as a typed [`Angle`].
     pub fn observed_solar_obliquity() -> Angle {

--- a/crates/p9-2016-obliquity-gomes/src/precession_model.rs
+++ b/crates/p9-2016-obliquity-gomes/src/precession_model.rs
@@ -121,15 +121,10 @@ pub fn l_total(p: &GomesParams) -> f64 {
 ///
 /// This is the half-angle of the cone on which L_p precesses. The maximum
 /// achievable obliquity over a full precession cycle is 2·i_p.
-pub fn forced_inclination(p: &GomesParams) -> f64 {
+pub fn forced_inclination_typed(p: &GomesParams) -> Angle {
     let l9 = l_p9(p);
     let ltot = l_total(p);
-    ((l9 / ltot) * p.i9.sin()).clamp(-1.0, 1.0).asin()
-}
-
-/// [`forced_inclination`] as a typed [`Angle`].
-pub fn forced_inclination_typed(p: &GomesParams) -> Angle {
-    radians(forced_inclination(p))
+    radians(((l9 / ltot) * p.i9.sin()).clamp(-1.0, 1.0).asin())
 }
 
 /// Quadrupole secular coupling constant of two coplanar wires of mass m1, m2
@@ -162,27 +157,20 @@ pub fn coupling_planets_p9(p: &GomesParams) -> f64 {
 ///
 /// (magnitude; the node regresses for prograde mutual tilt). The precession
 /// period is T_prec = 2π / g_p.
-pub fn precession_rate(p: &GomesParams) -> f64 {
+pub fn precession_rate_typed(p: &GomesParams) -> AngularVelocity {
     let c = coupling_planets_p9(p);
     let lp = l_planets();
     let l9 = l_p9(p);
     let ltot = l_total(p);
-    (3.0 * c * p.i9.cos() * ltot / (lp * l9)).abs()
+    let rate = (3.0 * c * p.i9.cos() * ltot / (lp * l9)).abs();
+    (radians(rate) / days(1.0)).into()
 }
 
-/// [`precession_rate`] as a typed [`AngularVelocity`].
-pub fn precession_rate_typed(p: &GomesParams) -> AngularVelocity {
-    (radians(precession_rate(p)) / days(1.0)).into()
-}
-
-/// Precession period of the planetary plane about L_tot (days).
-pub fn precession_period(p: &GomesParams) -> f64 {
-    2.0 * PI / precession_rate(p)
-}
-
-/// [`precession_period`] as a typed [`Time`].
+/// Precession period of the planetary plane about L_tot, as a typed [`Time`].
 pub fn precession_period_typed(p: &GomesParams) -> Time {
-    days(precession_period(p))
+    let w = precession_rate_typed(p);
+    let rate_per_day = (w / (radians(1.0) / days(1.0))).value;
+    days(2.0 * PI / rate_per_day)
 }
 
 /// Solar obliquity induced at time `t` (days), given a fixed primordial solar
@@ -196,15 +184,10 @@ pub fn precession_period_typed(p: &GomesParams) -> Time {
 ///
 /// Over one precession period the obliquity rises from 0 to a maximum of
 /// 2·i_p (when the plane has precessed half-way around) and returns to 0.
-pub fn obliquity_at_time(p: &GomesParams, t: f64) -> f64 {
-    let i_p = forced_inclination(p);
-    let t_prec = precession_period(p);
-    2.0 * i_p * (PI * t / t_prec).sin().abs()
-}
-
-/// [`obliquity_at_time`] as a typed [`Angle`].
 pub fn obliquity_at_time_typed(p: &GomesParams, t: f64) -> Angle {
-    radians(obliquity_at_time(p, t))
+    let i_p = forced_inclination_typed(p);
+    let t_prec = (precession_period_typed(p) / days(1.0)).value;
+    2.0 * i_p * (PI * t / t_prec).sin().abs()
 }
 
 /// Maximum solar obliquity achievable over a full precession cycle (radians).
@@ -215,34 +198,25 @@ pub fn obliquity_at_time_typed(p: &GomesParams, t: f64) -> Angle {
 /// Planet Nine configuration is capable of exciting; the value actually
 /// realised at 4.5 Gyr (see `obliquity_over_age`) is a phase-dependent
 /// fraction of it because the precession period exceeds the system age.
-pub fn max_obliquity(p: &GomesParams) -> f64 {
-    2.0 * forced_inclination(p)
-}
-
-/// [`max_obliquity`] as a typed [`Angle`].
 pub fn max_obliquity_typed(p: &GomesParams) -> Angle {
-    radians(max_obliquity(p))
+    2.0 * forced_inclination_typed(p)
 }
 
 /// Maximum achievable solar obliquity in degrees.
 pub fn max_obliquity_deg(p: &GomesParams) -> f64 {
-    max_obliquity(p) * RAD2DEG
+    (max_obliquity_typed(p) / radians(1.0)).value * RAD2DEG
 }
 
-/// Solar obliquity induced over the age of the Solar System (radians).
-pub fn obliquity_over_age(p: &GomesParams) -> f64 {
-    let t_age = crate::reference::SOLAR_SYSTEM_AGE_GYR * GYR_DAYS;
-    obliquity_at_time(p, t_age)
-}
-
-/// [`obliquity_over_age`] as a typed [`Angle`].
+/// Solar obliquity induced over the age of the Solar System, as a typed
+/// [`Angle`].
 pub fn obliquity_over_age_typed(p: &GomesParams) -> Angle {
-    radians(obliquity_over_age(p))
+    let t_age = crate::reference::SOLAR_SYSTEM_AGE_GYR * GYR_DAYS;
+    obliquity_at_time_typed(p, t_age)
 }
 
 /// Convenience: solar obliquity over the age of the Solar System in degrees.
 pub fn obliquity_over_age_deg(p: &GomesParams) -> f64 {
-    obliquity_over_age(p) * RAD2DEG
+    (obliquity_over_age_typed(p) / radians(1.0)).value * RAD2DEG
 }
 
 /// A single sample of the obliquity time series.
@@ -272,7 +246,7 @@ pub fn obliquity_series(p: &GomesParams, t_max: f64, n: usize) -> Vec<ObliquityS
             let t = t_max * (k as f64) / (n as f64);
             ObliquitySample {
                 t,
-                obliquity: obliquity_at_time(p, t),
+                obliquity: (obliquity_at_time_typed(p, t) / radians(1.0)).value,
             }
         })
         .collect()
@@ -282,7 +256,7 @@ pub fn obliquity_series(p: &GomesParams, t_max: f64, n: usize) -> Vec<ObliquityS
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
-    use uom::si::angle::radian;
+    use uom::si::angle::{degree, radian};
     use uom::si::angular_velocity::radian_per_second;
     use uom::si::length::astronomical_unit;
     use uom::si::time::day;
@@ -292,24 +266,35 @@ mod tests {
         let p = GomesParams::nominal();
         assert_relative_eq!(p.semi_major_axis().get::<astronomical_unit>(), p.a9);
         assert_relative_eq!(p.inclination().get::<radian>(), p.i9);
-        assert_relative_eq!(
-            forced_inclination_typed(&p).get::<radian>(),
-            forced_inclination(&p)
-        );
+
+        // forced inclination: typed vs the inline closed form.
+        let l9 = l_p9(&p);
+        let ltot = l_total(&p);
+        let i_p = ((l9 / ltot) * p.i9.sin()).clamp(-1.0, 1.0).asin();
+        assert_relative_eq!(forced_inclination_typed(&p).get::<radian>(), i_p);
+
+        // precession rate (rad/day) and its rad/s typed view.
+        let c = coupling_planets_p9(&p);
+        let lp = l_planets();
+        let rate = (3.0 * c * p.i9.cos() * ltot / (lp * l9)).abs();
         assert_relative_eq!(
             precession_rate_typed(&p).get::<radian_per_second>(),
-            precession_rate(&p) / 86_400.0,
+            rate / 86_400.0,
             epsilon = 1e-40
         );
-        assert_relative_eq!(
-            precession_period_typed(&p).get::<day>(),
-            precession_period(&p)
-        );
-        assert_relative_eq!(max_obliquity_typed(&p).get::<radian>(), max_obliquity(&p));
-        assert_relative_eq!(
-            obliquity_over_age_typed(&p).get::<radian>(),
-            obliquity_over_age(&p)
-        );
+
+        // precession period (days).
+        assert_relative_eq!(precession_period_typed(&p).get::<day>(), 2.0 * PI / rate);
+
+        // max obliquity (rad) = 2·i_p.
+        assert_relative_eq!(max_obliquity_typed(&p).get::<radian>(), 2.0 * i_p);
+
+        // obliquity over age (rad) vs inline formula.
+        let t_age = crate::reference::SOLAR_SYSTEM_AGE_GYR * GYR_DAYS;
+        let t_prec = 2.0 * PI / rate;
+        let eps_age = 2.0 * i_p * (PI * t_age / t_prec).sin().abs();
+        assert_relative_eq!(obliquity_over_age_typed(&p).get::<radian>(), eps_age);
+
         let s = ObliquitySample {
             t: 1.0e9,
             obliquity: 0.1,
@@ -318,7 +303,7 @@ mod tests {
         assert_relative_eq!(s.obliquity_typed().get::<radian>(), s.obliquity);
         assert_relative_eq!(
             crate::reference::observed_solar_obliquity().get::<radian>(),
-            crate::reference::observed_solar_obliquity_rad()
+            crate::reference::OBSERVED_SOLAR_OBLIQUITY_DEG * DEG2RAD
         );
     }
 
@@ -385,8 +370,16 @@ mod tests {
     fn test_no_obliquity_without_inclination() {
         let mut p = GomesParams::nominal();
         p.i9 = 0.0;
-        assert_relative_eq!(obliquity_over_age(&p), 0.0, epsilon = 1e-12);
-        assert_relative_eq!(forced_inclination(&p), 0.0, epsilon = 1e-12);
+        assert_relative_eq!(
+            obliquity_over_age_typed(&p).get::<radian>(),
+            0.0,
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            forced_inclination_typed(&p).get::<radian>(),
+            0.0,
+            epsilon = 1e-12
+        );
     }
 
     /// Obliquity increases monotonically with Planet Nine mass (more massive
@@ -423,7 +416,7 @@ mod tests {
             };
             // Compare the forced inclination, which scales with sin(i_9) and is
             // the monotone driver of the obliquity amplitude.
-            let i_p = forced_inclination(&p) * RAD2DEG;
+            let i_p = forced_inclination_typed(&p).get::<degree>();
             assert!(
                 i_p > prev,
                 "forced inclination not increasing with i_9: i9={i_deg} gave {i_p:.3}°"
@@ -457,7 +450,7 @@ mod tests {
     #[test]
     fn test_precession_period_order_of_magnitude() {
         let p = GomesParams::nominal();
-        let t_prec_gyr = precession_period(&p) / GYR_DAYS;
+        let t_prec_gyr = precession_period_typed(&p).get::<day>() / GYR_DAYS;
         assert!(
             (1.0..100.0).contains(&t_prec_gyr),
             "precession period {t_prec_gyr:.2} Gyr outside the expected 1-100 Gyr range"
@@ -469,7 +462,7 @@ mod tests {
     #[test]
     fn test_forced_inclination_brackets_observed() {
         let p = GomesParams::nominal();
-        let i_p_deg = forced_inclination(&p) * RAD2DEG;
+        let i_p_deg = forced_inclination_typed(&p).get::<degree>();
         // Forced inclination is positive and below the mutual inclination.
         assert!(i_p_deg > 0.0 && i_p_deg < crate::reference::P9_INCLINATION_DEG);
         // The cycle maximum 2·i_p must be able to reach the observed 6°.
@@ -490,7 +483,7 @@ mod tests {
 
         assert_relative_eq!(series[0].obliquity, 0.0, epsilon = 1e-12);
         // First half-period (t_max < T_prec/2 for the nominal case): monotone.
-        let half_period = precession_period(&p) / 2.0;
+        let half_period = precession_period_typed(&p).get::<day>() / 2.0;
         for w in series.windows(2) {
             assert!(w[1].obliquity.is_finite() && w[1].obliquity >= 0.0);
             if w[1].t <= half_period {

--- a/crates/p9-2016-obliquity-lai/Cargo.toml
+++ b/crates/p9-2016-obliquity-lai/Cargo.toml
@@ -9,7 +9,7 @@ p9-core = { path = "../p9-core" }
 nalgebra = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2016-obliquity-lai/src/planets.rs
+++ b/crates/p9-2016-obliquity-lai/src/planets.rs
@@ -35,14 +35,11 @@ pub fn canonical_planets() -> Vec<(f64, f64)> {
 /// in Lai (2016).
 pub const A_JUPITER_AU: f64 = 5.2026;
 
-/// Mean motion `n = √(GM_sun / a³)` in rad/day for a circular orbit at `a`.
-pub fn mean_motion(a_au: f64) -> f64 {
-    (G_AU3_MSUN_DAY2 * (a_au * a_au * a_au).recip()).sqrt()
-}
-
-/// [`mean_motion`] as a typed [`AngularVelocity`].
+/// Mean motion `n = √(GM_sun / a³)` for a circular orbit at `a`, as a typed
+/// [`AngularVelocity`].
 pub fn mean_motion_typed(a_au: f64) -> AngularVelocity {
-    (radians(mean_motion(a_au)) / days(1.0)).into()
+    let n = (G_AU3_MSUN_DAY2 * (a_au * a_au * a_au).recip()).sqrt();
+    (radians(n) / days(1.0)).into()
 }
 
 /// Orbital angular momentum of a circular planet, `L = m √(GM_sun a)`,
@@ -72,10 +69,11 @@ mod tests {
     use uom::si::angular_velocity::radian_per_second;
 
     #[test]
-    fn typed_mean_motion_matches_f64() {
+    fn typed_mean_motion_matches_formula() {
+        let n = (G_AU3_MSUN_DAY2 * (A_JUPITER_AU.powi(3)).recip()).sqrt();
         assert_relative_eq!(
             mean_motion_typed(A_JUPITER_AU).get::<radian_per_second>(),
-            mean_motion(A_JUPITER_AU) / 86_400.0,
+            n / 86_400.0,
             epsilon = 1e-30
         );
     }
@@ -104,7 +102,7 @@ mod tests {
 
     #[test]
     fn jupiter_mean_motion_period_about_11_86_yr() {
-        let n = mean_motion(A_JUPITER_AU);
+        let n = (mean_motion_typed(A_JUPITER_AU) / (radians(1.0) / days(1.0))).value;
         let period_yr = (2.0 * std::f64::consts::PI / n) / YEAR_DAYS;
         assert!(
             (period_yr - 11.86).abs() < 0.05,

--- a/crates/p9-2016-obliquity-lai/src/precession.rs
+++ b/crates/p9-2016-obliquity-lai/src/precession.rs
@@ -98,7 +98,7 @@ impl PlanetNine {
 ///
 ///   Ω_jp = (3 mp / 4 M★) (aⱼ / ãp)³ nⱼ
 fn omega_jp(p9: &PlanetNine, a_j: f64) -> f64 {
-    let n_j = planets::mean_motion(a_j);
+    let n_j = (planets::mean_motion_typed(a_j) / (radians(1.0) / days(1.0))).value;
     (3.0 * p9.mass_solar() / (4.0 * 1.0)) * (a_j / p9.a_tilde_au()).powi(3) * n_j
 }
 
@@ -108,7 +108,7 @@ fn omega_jp(p9: &PlanetNine, a_j: f64) -> f64 {
 ///   Ω_L = Σ_j Lⱼ Ω_jp / L
 ///
 /// Lai gives Ω_L = 2π / 87.5 Gyr × (mp/10m⊕)(ãp/400 AU)⁻³.
-pub fn omega_l(p9: &PlanetNine) -> f64 {
+pub fn omega_l_typed(p9: &PlanetNine) -> AngularVelocity {
     let mut num = 0.0;
     let mut l_total = 0.0;
     for &(m, a) in planets::canonical_planets().iter() {
@@ -116,12 +116,7 @@ pub fn omega_l(p9: &PlanetNine) -> f64 {
         num += l_j * omega_jp(p9, a);
         l_total += l_j;
     }
-    num / l_total
-}
-
-/// [`omega_l`] as a typed [`AngularVelocity`].
-pub fn omega_l_typed(p9: &PlanetNine) -> AngularVelocity {
-    (radians(omega_l(p9)) / days(1.0)).into()
+    (radians(num / l_total) / days(1.0)).into()
 }
 
 /// Solar spin-axis precession frequency Ω★ps driven by the planetary torques
@@ -130,18 +125,14 @@ pub fn omega_l_typed(p9: &PlanetNine) -> AngularVelocity {
 ///   Ω★ps = Σ_j (3 k_q★ / 2 k★) (mⱼ / M★) (R★ / aⱼ)³ Ω★
 ///
 /// with Ω★ = 2π / P★. Lai gives Ω★ps = 2π / 55.8 Gyr × (P★/10 d)⁻¹ for λ★ = 1.
-pub fn omega_spin_precession(spin_period_days: f64) -> f64 {
+pub fn omega_spin_precession_typed(spin_period_days: f64) -> AngularVelocity {
     let omega_star = 2.0 * PI / spin_period_days;
     let coeff = 3.0 * solar::KQ_STAR / (2.0 * solar::K_STAR);
-    planets::canonical_planets()
+    let rate: f64 = planets::canonical_planets()
         .iter()
         .map(|&(m, a)| coeff * (m / 1.0) * (RADIUS_SUN_AU / a).powi(3) * omega_star)
-        .sum()
-}
-
-/// [`omega_spin_precession`] as a typed [`AngularVelocity`].
-pub fn omega_spin_precession_typed(spin_period_days: f64) -> AngularVelocity {
-    (radians(omega_spin_precession(spin_period_days)) / days(1.0)).into()
+        .sum();
+    (radians(rate) / days(1.0)).into()
 }
 
 /// The two precession frequencies of the spin equation in the frame
@@ -153,24 +144,19 @@ pub fn omega_spin_precession_typed(spin_period_days: f64) -> AngularVelocity {
 ///   Ω_z ≃ Ω★ps − Ω_L cos θp (L/Lp + cos θp).
 ///
 /// The secular spin–orbit resonance is `Ω_z = 0`.
-pub fn corotating_frequencies(p9: &PlanetNine, spin_period_days: f64) -> (f64, f64) {
+pub fn corotating_frequencies_typed(
+    p9: &PlanetNine,
+    spin_period_days: f64,
+) -> (AngularVelocity, AngularVelocity) {
     let theta_p = p9.inclination_rad;
-    let om_l = omega_l(p9);
-    let om_spin = omega_spin_precession(spin_period_days);
+    let om_l = (omega_l_typed(p9) / (radians(1.0) / days(1.0))).value;
+    let om_spin =
+        (omega_spin_precession_typed(spin_period_days) / (radians(1.0) / days(1.0))).value;
     let l_total = planets::total_orbital_angular_momentum();
     let lp = p9.angular_momentum();
 
     let omega_y = om_l * theta_p.sin() * theta_p.cos();
     let omega_z = om_spin - om_l * theta_p.cos() * (l_total / lp + theta_p.cos());
-    (omega_y, omega_z)
-}
-
-/// [`corotating_frequencies`] as typed [`AngularVelocity`] pair `(Ω_y, Ω_z)`.
-pub fn corotating_frequencies_typed(
-    p9: &PlanetNine,
-    spin_period_days: f64,
-) -> (AngularVelocity, AngularVelocity) {
-    let (omega_y, omega_z) = corotating_frequencies(p9, spin_period_days);
     (
         (radians(omega_y) / days(1.0)).into(),
         (radians(omega_z) / days(1.0)).into(),
@@ -183,24 +169,23 @@ pub fn corotating_frequencies_typed(
 ///
 /// `t_gyr` is the elapsed time in Gyr (Lai evaluates at 4.5 Gyr). The solar
 /// rotation enters only through `spin_period_days = P★/λ★` (λ★ ≈ 1).
-pub fn solar_obliquity_rad(p9: &PlanetNine, spin_period_days: f64, t_gyr: f64) -> f64 {
-    let (omega_y, omega_z) = corotating_frequencies(p9, spin_period_days);
-    let t = t_gyr * GYR_DAYS;
-    if omega_z.abs() < 1e-30 {
-        // Exact resonance: sin(Ω_z t/2)/Ω_z → t/2, so θsl → Ω_y t.
-        return (omega_y * t).abs();
-    }
-    ((2.0 * omega_y / omega_z) * (omega_z * t / 2.0).sin()).abs()
-}
-
-/// [`solar_obliquity_rad`] as a typed [`Angle`].
 pub fn solar_obliquity_typed(p9: &PlanetNine, spin_period_days: f64, t_gyr: f64) -> Angle {
-    radians(solar_obliquity_rad(p9, spin_period_days, t_gyr))
+    let (omega_y_t, omega_z_t) = corotating_frequencies_typed(p9, spin_period_days);
+    let omega_y = (omega_y_t / (radians(1.0) / days(1.0))).value;
+    let omega_z = (omega_z_t / (radians(1.0) / days(1.0))).value;
+    let t = t_gyr * GYR_DAYS;
+    let theta = if omega_z.abs() < 1e-30 {
+        // Exact resonance: sin(Ω_z t/2)/Ω_z → t/2, so θsl → Ω_y t.
+        (omega_y * t).abs()
+    } else {
+        ((2.0 * omega_y / omega_z) * (omega_z * t / 2.0).sin()).abs()
+    };
+    radians(theta)
 }
 
 /// Convenience: obliquity in degrees at 4.5 Gyr.
 pub fn solar_obliquity_deg(p9: &PlanetNine, spin_period_days: f64) -> f64 {
-    solar_obliquity_rad(p9, spin_period_days, 4.5) * RAD2DEG
+    (solar_obliquity_typed(p9, spin_period_days, 4.5) / radians(1.0)).value * RAD2DEG
 }
 
 #[cfg(test)]
@@ -217,23 +202,61 @@ mod tests {
         assert_relative_eq!(p9.semi_major_axis().get::<astronomical_unit>(), p9.a_au);
         assert_relative_eq!(p9.inclination().get::<radian>(), p9.inclination_rad);
         assert_relative_eq!(p9.a_tilde().get::<astronomical_unit>(), p9.a_tilde_au());
+
+        // Ω_L: typed against the inline rad/day → rad/s sum.
+        let mut num = 0.0;
+        let mut l_total_lj = 0.0;
+        for &(m, a) in planets::canonical_planets().iter() {
+            let l_j = planets::orbital_angular_momentum(m, a);
+            num += l_j * omega_jp(&p9, a);
+            l_total_lj += l_j;
+        }
         assert_relative_eq!(
             omega_l_typed(&p9).get::<radian_per_second>(),
-            omega_l(&p9) / 86_400.0,
+            (num / l_total_lj) / 86_400.0,
             epsilon = 1e-40
         );
+
+        // Ω★ps: typed against the inline rad/day → rad/s sum.
+        let omega_star = 2.0 * PI / 10.0;
+        let coeff = 3.0 * solar::KQ_STAR / (2.0 * solar::K_STAR);
+        let spin_rate: f64 = planets::canonical_planets()
+            .iter()
+            .map(|&(m, a)| coeff * (m / 1.0) * (RADIUS_SUN_AU / a).powi(3) * omega_star)
+            .sum();
         assert_relative_eq!(
             omega_spin_precession_typed(10.0).get::<radian_per_second>(),
-            omega_spin_precession(10.0) / 86_400.0,
+            spin_rate / 86_400.0,
             epsilon = 1e-40
         );
-        let (y, z) = corotating_frequencies(&p9, 20.0);
+
+        // Corotating frequencies: typed against the inline formula (rad/day → rad/s).
+        let theta_p = p9.inclination_rad;
+        let om_l = omega_l_typed(&p9).get::<radian_per_second>() * 86_400.0;
+        let om_spin = omega_spin_precession_typed(20.0).get::<radian_per_second>() * 86_400.0;
+        let l_total = planets::total_orbital_angular_momentum();
+        let lp = p9.angular_momentum();
+        let y = om_l * theta_p.sin() * theta_p.cos();
+        let z = om_spin - om_l * theta_p.cos() * (l_total / lp + theta_p.cos());
         let (yt, zt) = corotating_frequencies_typed(&p9, 20.0);
-        assert_relative_eq!(yt.get::<radian_per_second>(), y / 86_400.0, epsilon = 1e-40);
-        assert_relative_eq!(zt.get::<radian_per_second>(), z / 86_400.0, epsilon = 1e-40);
+        assert_relative_eq!(
+            yt.get::<radian_per_second>(),
+            y / 86_400.0,
+            max_relative = 1e-12
+        );
+        assert_relative_eq!(
+            zt.get::<radian_per_second>(),
+            z / 86_400.0,
+            max_relative = 1e-12
+        );
+
+        // Obliquity: typed against the inline closed form.
+        let t = 4.5 * GYR_DAYS;
+        let theta = ((2.0 * y / z) * (z * t / 2.0).sin()).abs();
         assert_relative_eq!(
             solar_obliquity_typed(&p9, 20.0, 4.5).get::<radian>(),
-            solar_obliquity_rad(&p9, 20.0, 4.5)
+            theta,
+            max_relative = 1e-12
         );
     }
 
@@ -265,7 +288,7 @@ mod tests {
     fn omega_l_matches_published_period() {
         // Lai Eq. (5): Ω_L = 2π / 87.5 Gyr for the nominal P9.
         let p9 = nominal_p9();
-        let om_l = omega_l(&p9);
+        let om_l = omega_l_typed(&p9).get::<radian_per_second>() * 86_400.0;
         let period_gyr = (2.0 * PI / om_l) / GYR_DAYS;
         let rel =
             (period_gyr - published::OMEGA_L_PERIOD_GYR).abs() / published::OMEGA_L_PERIOD_GYR;
@@ -279,7 +302,8 @@ mod tests {
     fn omega_l_is_2p74_omega_jp() {
         // Lai Eq. (5): Ω_L = 2.74 Ω_Jp.
         let p9 = nominal_p9();
-        let ratio = omega_l(&p9) / omega_jp(&p9, planets::A_JUPITER_AU);
+        let om_l = omega_l_typed(&p9).get::<radian_per_second>() * 86_400.0;
+        let ratio = om_l / omega_jp(&p9, planets::A_JUPITER_AU);
         assert!(
             (ratio - published::OMEGA_L_OVER_OMEGA_JP).abs() < 0.03,
             "Ω_L/Ω_Jp = {ratio:.3} (Lai: 2.74)"
@@ -292,20 +316,20 @@ mod tests {
         let base = nominal_p9();
         let mut heavy = base;
         heavy.mass_earth = 20.0;
-        let r_mass = omega_l(&heavy) / omega_l(&base);
+        let r_mass = (omega_l_typed(&heavy) / omega_l_typed(&base)).value;
         assert!((r_mass - 2.0).abs() < 1e-6, "mass scaling {r_mass:.4}");
 
         // Double ãp by doubling a (e fixed): expect Ω_L → 1/8.
         let mut far = base;
         far.a_au = base.a_au * 2.0;
-        let r_a = omega_l(&far) / omega_l(&base);
+        let r_a = (omega_l_typed(&far) / omega_l_typed(&base)).value;
         assert!((r_a - 0.125).abs() < 1e-6, "ãp⁻³ scaling {r_a:.5}");
     }
 
     #[test]
     fn omega_spin_matches_published_period() {
         // Lai Eq. (8): Ω★ps = 2π / 55.8 Gyr for P★ = 10 d, λ★ = 1.
-        let om = omega_spin_precession(10.0);
+        let om = omega_spin_precession_typed(10.0).get::<radian_per_second>() * 86_400.0;
         let period_gyr = (2.0 * PI / om) / GYR_DAYS;
         let rel = (period_gyr - published::OMEGA_SPIN_PERIOD_GYR).abs()
             / published::OMEGA_SPIN_PERIOD_GYR;
@@ -326,7 +350,8 @@ mod tests {
             * MASS_JUPITER_SOLAR
             * (RADIUS_SUN_AU / planets::A_JUPITER_AU).powi(3)
             * omega_star;
-        let ratio = omega_spin_precession(10.0) / om_j;
+        let om_spin = omega_spin_precession_typed(10.0).get::<radian_per_second>() * 86_400.0;
+        let ratio = om_spin / om_j;
         assert!(
             (ratio - published::OMEGA_SPIN_OVER_J).abs() < 0.03,
             "Ω★ps/Ω★J = {ratio:.3} (Lai: 2.88)"
@@ -431,17 +456,21 @@ mod tests {
 
         // At P★/λ★ = 20 d the system is below resonance (Ω_z < 0).
         assert!(
-            corotating_frequencies(&p9, 20.0).1 < 0.0,
+            corotating_frequencies_typed(&p9, 20.0)
+                .1
+                .get::<radian_per_second>()
+                < 0.0,
             "Ω_z should be negative (below resonance) at P★ = 20 d"
         );
 
         // The plane-precession side of the balance (Ω_z = 0):
-        let om_l = omega_l(&p9);
+        let om_l = omega_l_typed(&p9).get::<radian_per_second>() * 86_400.0;
         let l_total = planets::total_orbital_angular_momentum();
         let lp = p9.angular_momentum();
         let rhs = om_l * theta_p.cos() * (l_total / lp + theta_p.cos());
         // Ω★ps(P) = Ω★ps(10 d)·(10/P); solve Ω★ps = rhs for P.
-        let p_resonant = omega_spin_precession(10.0) * 10.0 / rhs;
+        let om_spin10 = omega_spin_precession_typed(10.0).get::<radian_per_second>() * 86_400.0;
+        let p_resonant = om_spin10 * 10.0 / rhs;
         assert!(
             (1.0..6.0).contains(&p_resonant),
             "resonant spin period {p_resonant:.2} d (young, rapidly rotating Sun)"
@@ -449,8 +478,12 @@ mod tests {
 
         // Confirm Ω_z indeed crosses zero versus spin period (sign flip between
         // the fast-spin resonant value and the slow 20 d value).
-        let z_fast = corotating_frequencies(&p9, 0.5 * p_resonant).1;
-        let z_slow = corotating_frequencies(&p9, 20.0).1;
+        let z_fast = corotating_frequencies_typed(&p9, 0.5 * p_resonant)
+            .1
+            .get::<radian_per_second>();
+        let z_slow = corotating_frequencies_typed(&p9, 20.0)
+            .1
+            .get::<radian_per_second>();
         assert!(
             z_fast * z_slow < 0.0,
             "Ω_z must change sign across resonance"
@@ -471,11 +504,12 @@ mod tests {
             e,
             inclination_rad: theta_p,
         };
-        let om_l = omega_l(&p9);
+        let om_l = omega_l_typed(&p9).get::<radian_per_second>() * 86_400.0;
         let l_total = planets::total_orbital_angular_momentum();
         let lp = p9.angular_momentum();
         let rhs = om_l * theta_p.cos() * (l_total / lp + theta_p.cos());
-        let p_resonant = omega_spin_precession(10.0) * 10.0 / rhs;
+        let om_spin10 = omega_spin_precession_typed(10.0).get::<radian_per_second>() * 86_400.0;
+        let p_resonant = om_spin10 * 10.0 / rhs;
 
         // Slightly off resonance to keep θsl finite and small-angle valid.
         let obl_near = solar_obliquity_deg(&p9, 1.15 * p_resonant);

--- a/crates/p9-2016-obliquity-lai/src/survey.rs
+++ b/crates/p9-2016-obliquity-lai/src/survey.rs
@@ -37,14 +37,9 @@ impl NodeGeometry {
 /// target obliquity, as a function of P9 mass and inclination:
 ///
 ///   ãₚ ≃ 462 [ (mp/10m⊕) sin 2θp / (θ̂sl f) ]^(1/3) AU
-pub fn required_a_tilde(mass_earth: f64, theta_p_rad: f64, geom: &NodeGeometry) -> f64 {
-    let inner = (mass_earth / 10.0) * (2.0 * theta_p_rad).sin() / (geom.theta_sl_hat * geom.f);
-    published::A_TILDE_PREFACTOR_AU * inner.powf(1.0 / 3.0)
-}
-
-/// [`required_a_tilde`] as a typed [`Length`].
 pub fn required_a_tilde_typed(mass_earth: f64, theta_p_rad: f64, geom: &NodeGeometry) -> Length {
-    au(required_a_tilde(mass_earth, theta_p_rad, geom))
+    let inner = (mass_earth / 10.0) * (2.0 * theta_p_rad).sin() / (geom.theta_sl_hat * geom.f);
+    au(published::A_TILDE_PREFACTOR_AU * inner.powf(1.0 / 3.0))
 }
 
 /// Brute-force inversion of the full analytic theory: find the effective
@@ -120,11 +115,13 @@ mod tests {
     use uom::si::length::astronomical_unit;
 
     #[test]
-    fn typed_required_a_tilde_matches_f64() {
+    fn typed_required_a_tilde_matches_formula() {
         let geom = NodeGeometry::new(6.0, 45.0 * DEG2RAD);
+        let inner = (10.0 / 10.0) * (2.0 * 20.0 * DEG2RAD).sin() / (geom.theta_sl_hat * geom.f);
+        let expected = published::A_TILDE_PREFACTOR_AU * inner.powf(1.0 / 3.0);
         assert_relative_eq!(
             required_a_tilde_typed(10.0, 20.0 * DEG2RAD, &geom).get::<astronomical_unit>(),
-            required_a_tilde(10.0, 20.0 * DEG2RAD, &geom)
+            expected
         );
     }
 
@@ -133,7 +130,8 @@ mod tests {
         // Lai §3: across the parameter box, ãₚ ∈ [340, 480] AU. For ΔΩ = 45°,
         // mp = 10 m⊕, θp = 20°, Eq. (17) should land inside that band.
         let geom = NodeGeometry::new(6.0, 45.0 * DEG2RAD);
-        let a_tilde = required_a_tilde(10.0, 20.0 * DEG2RAD, &geom);
+        let a_tilde =
+            required_a_tilde_typed(10.0, 20.0 * DEG2RAD, &geom).get::<astronomical_unit>();
         let (lo, hi) = published::A_TILDE_RANGE_AU;
         assert!(
             (lo..=hi).contains(&a_tilde),
@@ -148,8 +146,8 @@ mod tests {
         // shrinks as mp grows. Equivalently at fixed θp, ãₚ ∝ mp^(1/3) — a
         // modest (cube-root) change.
         let geom = NodeGeometry::new(6.0, 45.0 * DEG2RAD);
-        let a10 = required_a_tilde(10.0, 20.0 * DEG2RAD, &geom);
-        let a20 = required_a_tilde(20.0, 20.0 * DEG2RAD, &geom);
+        let a10 = required_a_tilde_typed(10.0, 20.0 * DEG2RAD, &geom).get::<astronomical_unit>();
+        let a20 = required_a_tilde_typed(20.0, 20.0 * DEG2RAD, &geom).get::<astronomical_unit>();
         let ratio = a20 / a10;
         // Cube-root of 2 ≈ 1.26: a "modest change".
         assert!(

--- a/crates/p9-2016-obliquity/Cargo.toml
+++ b/crates/p9-2016-obliquity/Cargo.toml
@@ -9,7 +9,7 @@ p9-core = { path = "../p9-core" }
 nalgebra = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2016-obliquity/src/secular_hamiltonian.rs
+++ b/crates/p9-2016-obliquity/src/secular_hamiltonian.rs
@@ -66,29 +66,21 @@ impl SpinOrbitState {
         SpinOrbitState { l_gp, l_9, l_sun }
     }
 
-    /// Compute the angle between solar spin and giant planet angular momentum (solar obliquity).
-    pub fn obliquity(&self) -> f64 {
+    /// Angle between solar spin and giant planet angular momentum (solar
+    /// obliquity), as a typed [`Angle`].
+    pub fn obliquity_typed(&self) -> Angle {
         let dot = self.l_sun[0] * self.l_gp[0]
             + self.l_sun[1] * self.l_gp[1]
             + self.l_sun[2] * self.l_gp[2];
-        dot.clamp(-1.0, 1.0).acos()
+        radians(dot.clamp(-1.0, 1.0).acos())
     }
 
-    /// Compute the mutual inclination between giant planets and Planet Nine.
-    pub fn mutual_inclination(&self) -> f64 {
+    /// Mutual inclination between giant planets and Planet Nine, as a typed
+    /// [`Angle`].
+    pub fn mutual_inclination_typed(&self) -> Angle {
         let dot =
             self.l_gp[0] * self.l_9[0] + self.l_gp[1] * self.l_9[1] + self.l_gp[2] * self.l_9[2];
-        dot.clamp(-1.0, 1.0).acos()
-    }
-
-    /// Solar obliquity [`obliquity`](Self::obliquity) as a typed [`Angle`].
-    pub fn obliquity_typed(&self) -> Angle {
-        radians(self.obliquity())
-    }
-    /// Mutual inclination [`mutual_inclination`](Self::mutual_inclination) as a
-    /// typed [`Angle`].
-    pub fn mutual_inclination_typed(&self) -> Angle {
-        radians(self.mutual_inclination())
+        radians(dot.clamp(-1.0, 1.0).acos())
     }
 }
 
@@ -351,8 +343,11 @@ pub fn integrate_obliquity(
     for _ in 0..n_steps {
         // Time-dependent solar parameters
         let compute_solar_couplings = |t_now: f64| {
-            let omega_rot = solar_model::solar_omega_at_time(t_now, t_age);
-            let a_tilde = solar_model::solar_ring_semimajor_axis(omega_rot);
+            // ω in rad/day, extracted version-safely from the typed quantity.
+            let omega_rot = (solar_model::solar_omega_at_time_typed(t_now, t_age)
+                / (radians(1.0) / days(1.0)))
+            .value;
+            let a_tilde = (solar_model::solar_ring_semimajor_axis_typed(omega_rot) / au(1.0)).value;
             let l_sun_mag = solar_model::solar_spin_angular_momentum(omega_rot);
 
             // Effective mass of solar spin ring
@@ -409,8 +404,8 @@ pub fn integrate_obliquity(
 }
 
 fn make_snapshot(state: &SpinOrbitState, t: f64) -> ObliquitySnapshot {
-    let obliquity = state.obliquity();
-    let mutual_inclination = state.mutual_inclination();
+    let obliquity = (state.obliquity_typed() / radians(1.0)).value;
+    let mutual_inclination = (state.mutual_inclination_typed() / radians(1.0)).value;
 
     // Extract angles from unit vectors for diagnostics
     let i_9 = state.l_9[2].clamp(-1.0, 1.0).acos();
@@ -458,10 +453,21 @@ mod tests {
         assert_relative_eq!(params.timestep().get::<day>(), params.dt);
 
         let state = SpinOrbitState::from_inclinations(0.5, 1.0, 1.0, 0.3);
-        assert_relative_eq!(state.obliquity_typed().get::<radian>(), state.obliquity());
+        // obliquity = acos(L̂_sun · L̂_gp).
+        let dot_sun_gp = state.l_sun[0] * state.l_gp[0]
+            + state.l_sun[1] * state.l_gp[1]
+            + state.l_sun[2] * state.l_gp[2];
+        assert_relative_eq!(
+            state.obliquity_typed().get::<radian>(),
+            dot_sun_gp.clamp(-1.0, 1.0).acos()
+        );
+        // mutual inclination = acos(L̂_gp · L̂_9).
+        let dot_gp_9 = state.l_gp[0] * state.l_9[0]
+            + state.l_gp[1] * state.l_9[1]
+            + state.l_gp[2] * state.l_9[2];
         assert_relative_eq!(
             state.mutual_inclination_typed().get::<radian>(),
-            state.mutual_inclination()
+            dot_gp_9.clamp(-1.0, 1.0).acos()
         );
 
         let snap = ObliquitySnapshot {
@@ -532,7 +538,7 @@ mod tests {
         let l_9_mag = giant_planets::p9_angular_momentum(m9_solar, a9, e9);
 
         let initial = SpinOrbitState::from_inclinations(20.0 * DEG2RAD, PI, l_gp_mag, l_9_mag);
-        let theta = initial.mutual_inclination();
+        let theta = (initial.mutual_inclination_typed() / radians(1.0)).value;
         let epsilon_9 = (1.0_f64 - e9 * e9).sqrt();
         let c_gp_9 = coupling_gp_9(m9_solar, a9, epsilon_9);
 

--- a/crates/p9-2016-obliquity/src/solar_model.rs
+++ b/crates/p9-2016-obliquity/src/solar_model.rs
@@ -29,14 +29,10 @@ pub const P_SUN_PRESENT_DAYS: f64 = 25.4;
 /// Initial solar rotation period in days (~10 days for young Sun).
 pub const P_SUN_INITIAL_DAYS: f64 = 10.0;
 
-/// Angular velocity of the Sun from rotation period (rad/day).
-pub fn omega_sun(period_days: f64) -> f64 {
-    2.0 * PI / period_days
-}
-
-/// [`omega_sun`] as a typed [`AngularVelocity`].
+/// Angular velocity of the Sun from rotation period, as a typed
+/// [`AngularVelocity`].
 pub fn omega_sun_typed(period_days: f64) -> AngularVelocity {
-    (radians(omega_sun(period_days)) / days(1.0)).into()
+    (radians(2.0 * PI / period_days) / days(1.0)).into()
 }
 
 /// Skumanich spin-down: ω(t) = ω₀ * (t₀/t)^{1/2}, capped at the initial
@@ -53,18 +49,13 @@ pub fn omega_sun_typed(period_days: f64) -> AngularVelocity {
 ///
 /// `t` is time since formation in days.
 /// `t_age` is the total age (4.5 Gyr in days).
-pub fn solar_omega_at_time(t: f64, t_age: f64) -> f64 {
-    let omega_initial = omega_sun(P_SUN_INITIAL_DAYS);
+pub fn solar_omega_at_time_typed(t: f64, t_age: f64) -> AngularVelocity {
+    let omega_initial = omega_sun_typed(P_SUN_INITIAL_DAYS);
     if t <= 0.0 {
         return omega_initial;
     }
-    let omega_present = omega_sun(P_SUN_PRESENT_DAYS);
+    let omega_present = omega_sun_typed(P_SUN_PRESENT_DAYS);
     (omega_present * (t_age / t).sqrt()).min(omega_initial)
-}
-
-/// [`solar_omega_at_time`] as a typed [`AngularVelocity`].
-pub fn solar_omega_at_time_typed(t: f64, t_age: f64) -> AngularVelocity {
-    (radians(solar_omega_at_time(t, t_age)) / days(1.0)).into()
 }
 
 /// Spin angular momentum of the Sun: L = I_hat * M * R² * ω
@@ -79,17 +70,12 @@ pub fn solar_spin_angular_momentum(omega: f64) -> f64 {
 ///   a_tilde = [ 16 * ω² * k₂² * R⁶ / (9 * I_hat² * G * M_sun) ]^{1/3}
 ///
 /// This maps the rotational bulge's gravitational effect to an equivalent wire.
-/// Returns value in AU.
-pub fn solar_ring_semimajor_axis(omega: f64) -> f64 {
+/// Returns a typed [`Length`].
+pub fn solar_ring_semimajor_axis_typed(omega: f64) -> Length {
     let r6 = R_SUN_AU.powi(6);
     let numerator = 16.0 * omega * omega * K2_SUN * K2_SUN * r6;
     let denominator = 9.0 * I_HAT * I_HAT * G_AU3_MSUN_DAY2 * M_SUN_SOLAR;
-    (numerator / denominator).powf(1.0 / 3.0)
-}
-
-/// [`solar_ring_semimajor_axis`] as a typed [`Length`].
-pub fn solar_ring_semimajor_axis_typed(omega: f64) -> Length {
-    au(solar_ring_semimajor_axis(omega))
+    au((numerator / denominator).powf(1.0 / 3.0))
 }
 
 #[cfg(test)]
@@ -99,31 +85,42 @@ mod tests {
     use uom::si::angular_velocity::radian_per_second;
     use uom::si::length::astronomical_unit;
 
+    /// Angular velocity in rad/day, extracted version-safely from a typed value.
+    fn rad_per_day(w: AngularVelocity) -> f64 {
+        (w / (radians(1.0) / days(1.0))).value
+    }
+
     #[test]
-    fn typed_accessors_match_f64_sources() {
+    fn typed_accessors_match_formula() {
         let t_age = 4.5 * GYR_DAYS;
-        let omega = omega_sun(P_SUN_PRESENT_DAYS);
+        // ω(P) = 2π/P rad/day.
         assert_relative_eq!(
             omega_sun_typed(P_SUN_PRESENT_DAYS).get::<radian_per_second>(),
-            omega / 86_400.0,
+            (2.0 * PI / P_SUN_PRESENT_DAYS) / 86_400.0,
             epsilon = 1e-30
         );
+        // At the present age the spin-down normalizes to the present-day rate.
         assert_relative_eq!(
             solar_omega_at_time_typed(t_age, t_age).get::<radian_per_second>(),
-            solar_omega_at_time(t_age, t_age) / 86_400.0,
+            (2.0 * PI / P_SUN_PRESENT_DAYS) / 86_400.0,
             epsilon = 1e-30
         );
+        // a_tilde = [16 ω² k₂² R⁶ / (9 Î² G M)]^{1/3}.
+        let omega = 2.0 * PI / P_SUN_PRESENT_DAYS;
+        let r6 = R_SUN_AU.powi(6);
+        let numerator = 16.0 * omega * omega * K2_SUN * K2_SUN * r6;
+        let denominator = 9.0 * I_HAT * I_HAT * G_AU3_MSUN_DAY2 * M_SUN_SOLAR;
         assert_relative_eq!(
             solar_ring_semimajor_axis_typed(omega).get::<astronomical_unit>(),
-            solar_ring_semimajor_axis(omega)
+            (numerator / denominator).powf(1.0 / 3.0)
         );
     }
 
     #[test]
     fn test_skumanich_spindown() {
         let t_age = 4.5 * GYR_DAYS;
-        let omega_now = solar_omega_at_time(t_age, t_age);
-        let omega_present = omega_sun(P_SUN_PRESENT_DAYS);
+        let omega_now = rad_per_day(solar_omega_at_time_typed(t_age, t_age));
+        let omega_present = rad_per_day(omega_sun_typed(P_SUN_PRESENT_DAYS));
 
         // At present age, should match present-day omega
         assert!(
@@ -134,7 +131,7 @@ mod tests {
         );
 
         // At half the age, should be faster by sqrt(2)
-        let omega_half = solar_omega_at_time(t_age / 2.0, t_age);
+        let omega_half = rad_per_day(solar_omega_at_time_typed(t_age / 2.0, t_age));
         let ratio = omega_half / omega_now;
         assert!(
             (ratio - std::f64::consts::SQRT_2).abs() < 1e-10,
@@ -146,11 +143,11 @@ mod tests {
     #[test]
     fn test_spindown_capped_at_initial_rotation() {
         let t_age = 4.5 * GYR_DAYS;
-        let omega_initial = omega_sun(P_SUN_INITIAL_DAYS);
+        let omega_initial = rad_per_day(omega_sun_typed(P_SUN_INITIAL_DAYS));
 
         // Early times: the divergent √(t_age/t) is capped at ω(P = 10 d).
         for &t in &[0.0, 1.0, 1e3, 1e6, 0.01 * t_age] {
-            let w = solar_omega_at_time(t, t_age);
+            let w = rad_per_day(solar_omega_at_time_typed(t, t_age));
             assert!(
                 w <= omega_initial * (1.0 + 1e-12),
                 "ω(t={t:.1e}) = {w:.3e} exceeds the initial rotation"
@@ -159,13 +156,13 @@ mod tests {
 
         // The cap releases exactly at t_c = t_age (ω_present/ω_initial)².
         let t_c = t_age * (P_SUN_INITIAL_DAYS / P_SUN_PRESENT_DAYS).powi(2);
-        let w_after = solar_omega_at_time(1.01 * t_c, t_age);
+        let w_after = rad_per_day(solar_omega_at_time_typed(1.01 * t_c, t_age));
         assert!(w_after < omega_initial);
 
         // Monotonically non-increasing
         let mut prev = f64::INFINITY;
         for k in 0..100 {
-            let w = solar_omega_at_time(k as f64 * t_age / 100.0, t_age);
+            let w = rad_per_day(solar_omega_at_time_typed(k as f64 * t_age / 100.0, t_age));
             assert!(w <= prev + 1e-15);
             prev = w;
         }
@@ -173,8 +170,8 @@ mod tests {
 
     #[test]
     fn test_solar_ring_semimajor_axis() {
-        let omega = omega_sun(P_SUN_PRESENT_DAYS);
-        let a_tilde = solar_ring_semimajor_axis(omega);
+        let omega = 2.0 * PI / P_SUN_PRESENT_DAYS;
+        let a_tilde = solar_ring_semimajor_axis_typed(omega).get::<astronomical_unit>();
 
         // Should be very small (inside the Sun)
         assert!(a_tilde > 0.0 && a_tilde < R_SUN_AU);

--- a/crates/p9-2016-secular-resonance/Cargo.toml
+++ b/crates/p9-2016-secular-resonance/Cargo.toml
@@ -9,6 +9,7 @@ p9-core = { path = "../p9-core" }
 nalgebra = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/crates/p9-2016-secular-resonance/src/libration.rs
+++ b/crates/p9-2016-secular-resonance/src/libration.rs
@@ -43,26 +43,18 @@ pub struct Trajectory {
 }
 
 impl Trajectory {
-    /// Libration center: midpoint of the Δϖ swing (radians, folded to [0, 2π)).
-    pub fn center(&self) -> f64 {
-        let (lo, hi) = self.bounds();
-        (0.5 * (lo + hi)).rem_euclid(2.0 * PI)
-    }
-
-    /// Libration amplitude: half the peak-to-peak Δϖ swing (radians).
-    pub fn amplitude(&self) -> f64 {
-        let (lo, hi) = self.bounds();
-        0.5 * (hi - lo)
-    }
-
-    /// Libration center as a dimension-checked [`Angle`].
+    /// Libration center: midpoint of the Δϖ swing (radians, folded to [0, 2π)),
+    /// as a dimension-checked [`Angle`].
     pub fn center_typed(&self) -> Angle {
-        radians(self.center())
+        let (lo, hi) = self.bounds();
+        radians((0.5 * (lo + hi)).rem_euclid(2.0 * PI))
     }
 
-    /// Libration amplitude as a dimension-checked [`Angle`].
+    /// Libration amplitude: half the peak-to-peak Δϖ swing, as a
+    /// dimension-checked [`Angle`].
     pub fn amplitude_typed(&self) -> Angle {
-        radians(self.amplitude())
+        let (lo, hi) = self.bounds();
+        radians(0.5 * (hi - lo))
     }
 
     fn bounds(&self) -> (f64, f64) {
@@ -193,22 +185,21 @@ mod tests {
             dt,
             steps,
         );
-        // Typed angle accessors mirror the f64 center/amplitude.
+        // Typed angle accessors mirror the inline center/amplitude formulae.
+        let lo = lib.dvarpi.iter().cloned().fold(f64::INFINITY, f64::min);
+        let hi = lib.dvarpi.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
         assert_relative_eq!(
             (lib.center_typed() / radians(1.0)).value,
-            lib.center(),
+            (0.5 * (lo + hi)).rem_euclid(2.0 * PI),
             max_relative = 1e-12
         );
-        assert_relative_eq!(
-            (lib.amplitude_typed() / radians(1.0)).value,
-            lib.amplitude(),
-            max_relative = 1e-12
-        );
+        let amplitude_rad = (lib.amplitude_typed() / radians(1.0)).value;
+        assert_relative_eq!(amplitude_rad, 0.5 * (hi - lo), max_relative = 1e-12);
         assert_eq!(
             lib.kind,
             TrajectoryKind::Libration,
             "commensurate start should librate; amplitude {:.1}°, K-drift {:.1e}",
-            lib.amplitude().to_degrees(),
+            amplitude_rad.to_degrees(),
             lib.energy_drift()
         );
         // K is conserved to integrator precision (the pendulum is exact).
@@ -229,7 +220,7 @@ mod tests {
             circ.kind,
             TrajectoryKind::Circulation,
             "detuned (non-commensurate) start should circulate; net swing {:.0}°",
-            (2.0 * circ.amplitude()).to_degrees()
+            (2.0 * (circ.amplitude_typed() / radians(1.0)).value).to_degrees()
         );
     }
 
@@ -268,7 +259,7 @@ mod tests {
             large.kind,
             TrajectoryKind::Circulation,
             "large launch should cross the separatrix and circulate; swing {:.0}°",
-            (2.0 * large.amplitude()).to_degrees()
+            (2.0 * (large.amplitude_typed() / radians(1.0)).value).to_degrees()
         );
     }
 
@@ -289,11 +280,12 @@ mod tests {
         );
         assert_eq!(lib.kind, TrajectoryKind::Libration);
 
-        let center_err = (lib.center() - published::ANTI_ALIGNED_CENTER_RAD).abs();
+        let center_rad = (lib.center_typed() / radians(1.0)).value;
+        let center_err = (center_rad - published::ANTI_ALIGNED_CENTER_RAD).abs();
         assert!(
             center_err < 0.15,
             "libration center {:.1}° not near 180° (err {:.1}°)",
-            lib.center().to_degrees(),
+            center_rad.to_degrees(),
             center_err.to_degrees()
         );
     }
@@ -323,11 +315,13 @@ mod tests {
         );
         assert_eq!(small.kind, TrajectoryKind::Libration);
         assert_eq!(large.kind, TrajectoryKind::Libration);
+        let small_amp = (small.amplitude_typed() / radians(1.0)).value;
+        let large_amp = (large.amplitude_typed() / radians(1.0)).value;
         assert!(
-            large.amplitude() > small.amplitude(),
+            large_amp > small_amp,
             "amplitude should grow with displacement: {:.1}° vs {:.1}°",
-            large.amplitude().to_degrees(),
-            small.amplitude().to_degrees()
+            large_amp.to_degrees(),
+            small_amp.to_degrees()
         );
     }
 }

--- a/crates/p9-2017-bias/Cargo.toml
+++ b/crates/p9-2017-bias/Cargo.toml
@@ -10,6 +10,7 @@ rand = { workspace = true }
 rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/crates/p9-2017-dynamics/Cargo.toml
+++ b/crates/p9-2017-dynamics/Cargo.toml
@@ -10,6 +10,7 @@ rand = { workspace = true }
 rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/crates/p9-2017-dynamics/src/hamiltonian.rs
+++ b/crates/p9-2017-dynamics/src/hamiltonian.rs
@@ -70,11 +70,6 @@ impl SecularHamiltonianParams {
         }
     }
 
-    /// Planet Nine GM in AU³/day².
-    pub fn gm9(&self) -> f64 {
-        self.m9_solar * GM_SUN
-    }
-
     /// Planet Nine semi-major axis as a dimension-checked [`Length`].
     pub fn semi_major_axis(&self) -> Length {
         au(self.a9)
@@ -88,7 +83,7 @@ impl SecularHamiltonianParams {
     /// Planet Nine gravitational parameter as a dimension-checked
     /// [`GravitationalParameter`] (AU³/day² source).
     pub fn gm9_typed(&self) -> GravitationalParameter {
-        gm_from_au3_day2(self.gm9())
+        gm_from_au3_day2(self.m9_solar * GM_SUN)
     }
 
     /// Planet Nine apsidal precession rate as a dimension-checked
@@ -143,7 +138,7 @@ pub fn octupole_term(a: f64, e: f64, delta_varpi: f64, params: &SecularHamiltoni
     let alpha = a / params.a9;
     let eta9_sq = 1.0 - params.e9 * params.e9;
     -(15.0 / 16.0)
-        * (params.gm9() * alpha.powi(3) / params.a9)
+        * ((params.gm9_typed() / gm_from_au3_day2(1.0)).value * alpha.powi(3) / params.a9)
         * e
         * params.e9
         * (1.0 + 0.75 * e * e)
@@ -176,7 +171,15 @@ pub fn secular_hamiltonian(
     let h_frame = -params.precession_rate_9 * (GM_SUN * a).sqrt() * eta;
 
     // Term 3: standard doubly-averaged quadrupole (axisymmetric in Δϖ).
-    let h_quad = quadrupole_hamiltonian(a, e, i, omega, params.a9, params.e9, params.gm9());
+    let h_quad = quadrupole_hamiltonian(
+        a,
+        e,
+        i,
+        omega,
+        params.a9,
+        params.e9,
+        (params.gm9_typed() / gm_from_au3_day2(1.0)).value,
+    );
 
     // Term 4: octupole — the leading Δϖ-dependent coupling, ∝ e e₉.
     let h_oct = octupole_term(a, e, delta_varpi, params);
@@ -219,7 +222,7 @@ mod tests {
         );
         assert_relative_eq!(
             (p.gm9_typed() / gm_from_au3_day2(1.0)).value,
-            p.gm9(),
+            p.m9_solar * GM_SUN,
             max_relative = 1e-9
         );
     }

--- a/crates/p9-2017-dynamics/src/simulation.rs
+++ b/crates/p9-2017-dynamics/src/simulation.rs
@@ -232,10 +232,6 @@ pub struct TestParticle {
 }
 
 impl TestParticle {
-    pub fn perihelion(&self) -> f64 {
-        self.a * (1.0 - self.e)
-    }
-
     pub fn inclination_deg(&self) -> f64 {
         self.i / DEG2RAD
     }
@@ -252,7 +248,7 @@ impl TestParticle {
 
     /// Perihelion distance `q = a(1 − e)` as a dimension-checked [`Length`].
     pub fn perihelion_typed(&self) -> Length {
-        au(self.perihelion())
+        au(self.a * (1.0 - self.e))
     }
 
     fn elements(&self) -> OrbitalElements {
@@ -418,7 +414,7 @@ mod tests {
         };
         assert_relative_eq!(
             (tp.perihelion_typed() / au(1.0)).value,
-            tp.perihelion(),
+            tp.a * (1.0 - tp.e),
             max_relative = 1e-12
         );
         assert_relative_eq!(
@@ -449,7 +445,7 @@ mod tests {
         for p in &particles {
             assert!(p.a >= config.a_min && p.a <= config.a_max);
             assert!(p.e >= 0.0 && p.e < 1.0);
-            let q = p.perihelion();
+            let q = (p.perihelion_typed() / au(1.0)).value;
             assert!(q >= config.q_min - 1.0 && q <= config.q_max + 1.0);
         }
     }

--- a/crates/p9-2017-ossos-bias/Cargo.toml
+++ b/crates/p9-2017-ossos-bias/Cargo.toml
@@ -10,6 +10,7 @@ rand = { workspace = true }
 rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/crates/p9-2017-ossos-bias/src/population.rs
+++ b/crates/p9-2017-ossos-bias/src/population.rs
@@ -152,6 +152,7 @@ mod tests {
     use p9_core::analysis::circular::{mean_resultant_length, rayleigh_p_value};
     use rand::rngs::StdRng;
     use rand::SeedableRng;
+    use uom::si::length::astronomical_unit;
 
     #[test]
     fn typed_population_accessors_match_f64() {
@@ -182,7 +183,7 @@ mod tests {
         let pop = generate_population(5000, &p, &mut rng);
         for o in &pop {
             assert!(o.elements.a >= p.a_range.0 && o.elements.a <= p.a_range.1);
-            let q = o.elements.perihelion();
+            let q = o.elements.perihelion_typed().get::<astronomical_unit>();
             assert!(
                 q >= p.q_range.0 - 1e-9 && q <= p.q_range.1 + 1e-9,
                 "q = {q}"

--- a/crates/p9-2017-ossos-bias/src/population.rs
+++ b/crates/p9-2017-ossos-bias/src/population.rs
@@ -41,14 +41,10 @@ pub struct SyntheticEtno {
 }
 
 impl SyntheticEtno {
-    /// Longitude of perihelion ϖ = Ω + ω, wrapped to [0, 2π).
-    pub fn longitude_of_perihelion(&self) -> f64 {
-        (self.elements.omega_big + self.elements.omega).rem_euclid(TWO_PI)
-    }
-
-    /// Longitude of perihelion as a dimension-checked [`Angle`].
+    /// Longitude of perihelion ϖ = Ω + ω, wrapped to [0, 2π), as a
+    /// dimension-checked [`Angle`].
     pub fn longitude_of_perihelion_typed(&self) -> Angle {
-        radians(self.longitude_of_perihelion())
+        radians((self.elements.omega_big + self.elements.omega).rem_euclid(TWO_PI))
     }
 }
 
@@ -142,7 +138,9 @@ pub fn generate_population<R: Rng>(
 
 /// Longitudes of perihelion of a population (radians).
 pub fn longitudes_of_perihelion(pop: &[SyntheticEtno]) -> Vec<f64> {
-    pop.iter().map(|o| o.longitude_of_perihelion()).collect()
+    pop.iter()
+        .map(|o| (o.longitude_of_perihelion_typed() / radians(1.0)).value)
+        .collect()
 }
 
 #[cfg(test)]
@@ -171,7 +169,7 @@ mod tests {
         let o = generate_population(1, &p, &mut rng)[0];
         assert_relative_eq!(
             (o.longitude_of_perihelion_typed() / radians(1.0)).value,
-            o.longitude_of_perihelion(),
+            (o.elements.omega_big + o.elements.omega).rem_euclid(TWO_PI),
             max_relative = 1e-12
         );
     }

--- a/crates/p9-2017-resonance-hopping/Cargo.toml
+++ b/crates/p9-2017-resonance-hopping/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 p9-core = { path = "../p9-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2017-resonance-hopping/src/chain.rs
+++ b/crates/p9-2017-resonance-hopping/src/chain.rs
@@ -88,17 +88,11 @@ impl P9Resonance {
         self.p.abs_diff(self.q)
     }
 
-    /// Interior resonance semimajor axis (AU) for a perturber at `a9`:
-    /// `a_res = a9 (q/p)^{2/3}`. Delegates to the single workspace Kepler
-    /// relation (with arguments swapped to select the interior branch).
-    pub fn semi_major_axis(&self, a9_au: f64) -> f64 {
-        resonance_semi_major_axis(self.q, self.p, a9_au)
-    }
-
-    /// Interior resonance semimajor axis as a typed [`Length`] (see
-    /// [`Self::semi_major_axis`]).
+    /// Interior resonance semimajor axis as a typed [`Length`] for a perturber
+    /// at `a9`: `a_res = a9 (q/p)^{2/3}`. Delegates to the single workspace
+    /// Kepler relation (with arguments swapped to select the interior branch).
     pub fn semi_major_axis_typed(&self, a9_au: f64) -> Length {
-        au(self.semi_major_axis(a9_au))
+        au(resonance_semi_major_axis(self.q, self.p, a9_au))
     }
 
     /// Dimensionless ratio α = a_res / a9 (< 1 for interior resonances).
@@ -110,7 +104,7 @@ impl P9Resonance {
     /// eccentricity `e` perturbed by a planet of mass ratio `mu` at `a9`:
     /// `δa = a_res · sqrt( (16/3) · mu · S )`, S from `resonance_strength`.
     pub fn libration_half_width_au(&self, a9_au: f64, mu: f64, e: f64) -> f64 {
-        let a_res = self.semi_major_axis(a9_au);
+        let a_res = (self.semi_major_axis_typed(a9_au) / au(1.0)).value;
         let strength = resonance_strength(self.alpha(), e);
         a_res * ((16.0 / 3.0) * mu * strength).sqrt()
     }
@@ -166,8 +160,8 @@ fn sorted_by_a(iter: impl Iterator<Item = P9Resonance>) -> Vec<P9Resonance> {
 /// Chirikov overlap parameter between two neighbouring resonances:
 /// `K = (δa_lo + δa_hi) / |a_hi − a_lo|`. K ≥ 1 ⇒ overlap (hopping).
 pub fn neighbour_overlap(lo: P9Resonance, hi: P9Resonance, a9_au: f64, mu: f64, e: f64) -> f64 {
-    let a_lo = lo.semi_major_axis(a9_au);
-    let a_hi = hi.semi_major_axis(a9_au);
+    let a_lo = (lo.semi_major_axis_typed(a9_au) / au(1.0)).value;
+    let a_hi = (hi.semi_major_axis_typed(a9_au) / au(1.0)).value;
     let sep = (a_hi - a_lo).abs();
     let w = lo.libration_half_width_au(a9_au, mu, e) + hi.libration_half_width_au(a9_au, mu, e);
     w / sep
@@ -215,8 +209,8 @@ pub fn overlap_profile(chain: &[P9Resonance], a9_au: f64, mu: f64, e: f64) -> Ve
         .windows(2)
         .map(|w| {
             let (lo, hi) = (w[0], w[1]);
-            let a_lo = lo.semi_major_axis(a9_au);
-            let a_hi = hi.semi_major_axis(a9_au);
+            let a_lo = (lo.semi_major_axis_typed(a9_au) / au(1.0)).value;
+            let a_hi = (hi.semi_major_axis_typed(a9_au) / au(1.0)).value;
             OverlapLink {
                 lo,
                 hi,
@@ -255,7 +249,7 @@ mod tests {
         let mu = mass_ratio(published::M9_EARTH);
         assert_relative_eq!(
             res.semi_major_axis_typed(A9).get::<astronomical_unit>(),
-            res.semi_major_axis(A9),
+            resonance_semi_major_axis(res.q, res.p, A9),
             epsilon = 1e-9
         );
         assert_relative_eq!(
@@ -290,9 +284,13 @@ mod tests {
         for &(p, q) in &[(2u32, 1u32), (3, 1), (5, 1), (3, 2), (5, 2), (4, 3)] {
             let res = P9Resonance::new(p, q);
             let expected = A9 * (q as f64 / p as f64).powf(2.0 / 3.0);
-            assert_relative_eq!(res.semi_major_axis(A9), expected, epsilon = 1e-9);
+            assert_relative_eq!(
+                res.semi_major_axis_typed(A9).get::<astronomical_unit>(),
+                expected,
+                epsilon = 1e-9
+            );
             // All interior resonances sit inside P9.
-            assert!(res.semi_major_axis(A9) < A9);
+            assert!(res.semi_major_axis_typed(A9) < au(A9));
         }
     }
 
@@ -300,13 +298,13 @@ mod tests {
     fn n_over_1_chain_is_ordered_and_crowds_toward_p9() {
         let chain = n_over_1_chain(2, 30);
         for w in chain.windows(2) {
-            assert!(w[1].semi_major_axis(A9) > w[0].semi_major_axis(A9));
+            assert!(w[1].semi_major_axis_typed(A9) > w[0].semi_major_axis_typed(A9));
         }
         // Spacing shrinks toward smaller a (higher p crowds together): the
         // first (small-a) gap is smaller than the last (large-a, near 2:1).
-        let seps: Vec<f64> = chain
+        let seps: Vec<Length> = chain
             .windows(2)
-            .map(|w| w[1].semi_major_axis(A9) - w[0].semi_major_axis(A9))
+            .map(|w| w[1].semi_major_axis_typed(A9) - w[0].semi_major_axis_typed(A9))
             .collect();
         assert!(seps.first().unwrap() < seps.last().unwrap());
     }
@@ -315,15 +313,18 @@ mod tests {
     fn n_over_2_interleaves_n_over_1() {
         // A (2p+1):2 resonance sits between the (p+1):1 and p:1 resonances.
         let p = 5u32;
-        let inner = P9Resonance::new(p + 1, 1).semi_major_axis(A9); // smaller a
-        let outer = P9Resonance::new(p, 1).semi_major_axis(A9); // larger a
-        let half = P9Resonance::new(2 * p + 1, 2).semi_major_axis(A9);
-        assert!(inner < half && half < outer, "{inner} < {half} < {outer}");
+        let inner = P9Resonance::new(p + 1, 1).semi_major_axis_typed(A9); // smaller a
+        let outer = P9Resonance::new(p, 1).semi_major_axis_typed(A9); // larger a
+        let half = P9Resonance::new(2 * p + 1, 2).semi_major_axis_typed(A9);
+        assert!(
+            inner < half && half < outer,
+            "{inner:?} < {half:?} < {outer:?}"
+        );
         // n:2 chain is odd-p and ordered.
         let chain = n_over_2_chain(3, 21);
         assert!(chain.iter().all(|r| r.p % 2 == 1));
         for w in chain.windows(2) {
-            assert!(w[1].semi_major_axis(A9) > w[0].semi_major_axis(A9));
+            assert!(w[1].semi_major_axis_typed(A9) > w[0].semi_major_axis_typed(A9));
         }
     }
 

--- a/crates/p9-2017-resonance-hopping/src/tno.rs
+++ b/crates/p9-2017-resonance-hopping/src/tno.rs
@@ -17,6 +17,7 @@ use crate::chain::{
     first_order_chain, hopping_threshold_au, mass_ratio, n_over_1_chain, published, P9Resonance,
 };
 use p9_core::data::etno::{Etno, BROWN_2017_SAMPLE};
+use p9_core::units::au;
 
 /// Classification of a TNO's dynamical state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -57,9 +58,9 @@ pub fn nearest_n1_resonance(a_au: f64) -> P9Resonance {
     *chain
         .iter()
         .min_by(|x, y| {
-            (x.semi_major_axis(published::A9_AU) - a_au)
+            (x.semi_major_axis_typed(published::A9_AU) - au(a_au))
                 .abs()
-                .partial_cmp(&(y.semi_major_axis(published::A9_AU) - a_au).abs())
+                .partial_cmp(&(y.semi_major_axis_typed(published::A9_AU) - au(a_au)).abs())
                 .unwrap()
         })
         .unwrap()
@@ -122,11 +123,12 @@ mod tests {
         // within the local 2:1→1:1 gap.
         let o = obj("2007 TG422"); // a = 501 AU
         let res = nearest_n1_resonance(o.a);
-        let local_gap = published::A9_AU - P9Resonance::new(2, 1).semi_major_axis(published::A9_AU);
-        let da = (res.semi_major_axis(published::A9_AU) - o.a).abs();
+        let local_gap =
+            au(published::A9_AU) - P9Resonance::new(2, 1).semi_major_axis_typed(published::A9_AU);
+        let da = (res.semi_major_axis_typed(published::A9_AU) - au(o.a)).abs();
         assert!(
             da < local_gap,
-            "nearest n:1 resonance {da} AU away (gap {local_gap})"
+            "nearest n:1 resonance {da:?} away (gap {local_gap:?})"
         );
         // And the nearest n:1 to 2007 TG422 is the 2:1.
         assert_eq!(res, P9Resonance::new(2, 1));

--- a/crates/p9-2018-bp519/Cargo.toml
+++ b/crates/p9-2018-bp519/Cargo.toml
@@ -9,7 +9,7 @@ p9-core = { path = "../p9-core" }
 nalgebra = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2018-bp519/src/bp519.rs
+++ b/crates/p9-2018-bp519/src/bp519.rs
@@ -55,21 +55,6 @@ impl Bp519 {
         }
     }
 
-    /// Perihelion distance q = a(1 − e) in AU.
-    pub fn perihelion(&self) -> f64 {
-        self.a * (1.0 - self.e)
-    }
-
-    /// Aphelion distance Q = a(1 + e) in AU.
-    pub fn aphelion(&self) -> f64 {
-        self.a * (1.0 + self.e)
-    }
-
-    /// Longitude of perihelion ϖ = ω + Ω in radians, wrapped to [0, 2π).
-    pub fn longitude_of_perihelion(&self) -> f64 {
-        ((self.omega_deg + self.omega_big_deg) * DEG2RAD).rem_euclid(TWO_PI)
-    }
-
     /// Semi-major axis as a typed [`Length`] (via the core
     /// [`OrbitalElements`] accessor).
     pub fn semi_major_axis(&self) -> Length {
@@ -82,20 +67,20 @@ impl Bp519 {
         self.elements().inclination()
     }
 
-    /// Perihelion distance as a typed [`Length`] (see [`Self::perihelion`]).
+    /// Perihelion distance q = a(1 − e) as a typed [`Length`].
     pub fn perihelion_typed(&self) -> Length {
         self.elements().perihelion_typed()
     }
 
-    /// Aphelion distance as a typed [`Length`] (see [`Self::aphelion`]).
+    /// Aphelion distance Q = a(1 + e) as a typed [`Length`].
     pub fn aphelion_typed(&self) -> Length {
         self.elements().aphelion_typed()
     }
 
-    /// Longitude of perihelion as a typed [`Angle`] (see
-    /// [`Self::longitude_of_perihelion`]).
+    /// Longitude of perihelion ϖ = ω + Ω as a typed [`Angle`], wrapped to
+    /// [0, 2π).
     pub fn longitude_of_perihelion_typed(&self) -> Angle {
-        radians(self.longitude_of_perihelion())
+        radians(((self.omega_deg + self.omega_big_deg) * DEG2RAD).rem_euclid(TWO_PI))
     }
 }
 
@@ -133,28 +118,32 @@ mod tests {
 
     #[test]
     fn discovery_elements_pinned() {
+        use uom::si::length::astronomical_unit;
         let bp = discovery_2018();
         // Headline: highly inclined, eccentric, large-a detached ETNO.
         assert_relative_eq!(bp.a, 449.0, epsilon = 1.0);
         assert_relative_eq!(bp.e, 0.92, epsilon = 0.01);
         assert_relative_eq!(bp.i_deg, 54.0, epsilon = 1.0);
         // Detached: q well outside Neptune's reach (~35 AU).
-        assert!(
-            (33.0..40.0).contains(&bp.perihelion()),
-            "q = {:.1} AU",
-            bp.perihelion()
-        );
+        let q = bp.perihelion_typed().get::<astronomical_unit>();
+        assert!((33.0..40.0).contains(&q), "q = {q:.1} AU");
         // Aphelion deep in the P9-clustered distance range.
-        assert!(bp.aphelion() > 800.0, "Q = {:.0} AU", bp.aphelion());
+        let aph = bp.aphelion_typed().get::<astronomical_unit>();
+        assert!(aph > 800.0, "Q = {aph:.0} AU");
     }
 
     #[test]
     fn jpl_solution_drift_is_documented() {
+        use uom::si::length::astronomical_unit;
         let disc = discovery_2018();
         let jpl = jpl_current();
         // i, q stable across solutions; a, e drift up the fit degeneracy.
         assert_relative_eq!(disc.i_deg, jpl.i_deg, epsilon = 0.5);
-        assert_relative_eq!(disc.perihelion(), jpl.perihelion(), epsilon = 1.5);
+        assert_relative_eq!(
+            disc.perihelion_typed().get::<astronomical_unit>(),
+            jpl.perihelion_typed().get::<astronomical_unit>(),
+            epsilon = 1.5
+        );
         assert!(jpl.a > disc.a, "JPL a should drift upward");
     }
 
@@ -183,17 +172,17 @@ mod tests {
         );
         assert_relative_eq!(
             bp.perihelion_typed().get::<astronomical_unit>(),
-            bp.perihelion(),
+            bp.a * (1.0 - bp.e),
             epsilon = 1e-9
         );
         assert_relative_eq!(
             bp.aphelion_typed().get::<astronomical_unit>(),
-            bp.aphelion(),
+            bp.a * (1.0 + bp.e),
             epsilon = 1e-9
         );
         assert_relative_eq!(
             bp.longitude_of_perihelion_typed().get::<radian>(),
-            bp.longitude_of_perihelion(),
+            ((bp.omega_deg + bp.omega_big_deg) * DEG2RAD).rem_euclid(TWO_PI),
             epsilon = 1e-9
         );
     }

--- a/crates/p9-2018-bp519/src/clustering.rs
+++ b/crates/p9-2018-bp519/src/clustering.rs
@@ -11,6 +11,7 @@ use crate::bp519::Bp519;
 use p9_core::analysis::circular::{circular_mean, mean_resultant_length, wrap_to_pi};
 use p9_core::constants::RAD2DEG;
 use p9_core::data::etno::longitudes_of_perihelion;
+use uom::si::angle::radian;
 
 /// Circular mean ϖ of the Brown (2017) sample, in radians [0, 2π).
 pub fn sample_mean_varpi() -> f64 {
@@ -26,7 +27,8 @@ pub fn sample_varpi_concentration() -> f64 {
 /// (−180°, 180°] and returned in degrees. Near 0° means apsidally aligned
 /// with the cluster.
 pub fn varpi_offset_from_cluster_deg(bp: &Bp519) -> f64 {
-    let delta = wrap_to_pi(bp.longitude_of_perihelion() - sample_mean_varpi());
+    let delta =
+        wrap_to_pi(bp.longitude_of_perihelion_typed().get::<radian>() - sample_mean_varpi());
     delta * RAD2DEG
 }
 
@@ -35,7 +37,7 @@ pub fn varpi_offset_from_cluster_deg(bp: &Bp519) -> f64 {
 /// comparable if BP519 is consistent with the population).
 pub fn concentration_with_bp519(bp: &Bp519) -> f64 {
     let mut varpis = longitudes_of_perihelion();
-    varpis.push(bp.longitude_of_perihelion());
+    varpis.push(bp.longitude_of_perihelion_typed().get::<radian>());
     mean_resultant_length(&varpis)
 }
 

--- a/crates/p9-2018-bp519/src/pumping.rs
+++ b/crates/p9-2018-bp519/src/pumping.rs
@@ -264,29 +264,19 @@ pub struct PumpingHistory {
 }
 
 impl PumpingHistory {
-    /// Maximum inclination reached over the history (degrees).
-    pub fn max_inclination_deg(&self) -> f64 {
-        self.inclination_deg
-            .iter()
-            .cloned()
-            .fold(f64::NEG_INFINITY, f64::max)
-    }
-
-    /// Inclination at the end of the history (degrees).
-    pub fn final_inclination_deg(&self) -> f64 {
-        *self.inclination_deg.last().unwrap()
-    }
-
-    /// Maximum inclination over the history as a typed [`Angle`] (see
-    /// [`Self::max_inclination_deg`]).
+    /// Maximum inclination over the history as a typed [`Angle`].
     pub fn max_inclination(&self) -> Angle {
-        degrees(self.max_inclination_deg())
+        degrees(
+            self.inclination_deg
+                .iter()
+                .cloned()
+                .fold(f64::NEG_INFINITY, f64::max),
+        )
     }
 
-    /// Inclination at the end of the history as a typed [`Angle`] (see
-    /// [`Self::final_inclination_deg`]).
+    /// Inclination at the end of the history as a typed [`Angle`].
     pub fn final_inclination(&self) -> Angle {
-        degrees(self.final_inclination_deg())
+        degrees(*self.inclination_deg.last().unwrap())
     }
 
     /// Maximum eccentricity reached.
@@ -391,6 +381,7 @@ pub fn scattered_particle(a: f64, e: f64, i_mutual_deg: f64) -> TestParticle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uom::si::angle::degree;
 
     /// The nominal inclined Planet Nine (Batygin & Brown 2016): 10 M⊕,
     /// a = 700 AU, e = 0.6, i₉ = 30°.
@@ -401,17 +392,21 @@ mod tests {
     #[test]
     fn typed_inclination_accessors_match_degrees() {
         use approx::assert_relative_eq;
-        use uom::si::angle::degree;
         let p = scattered_particle(250.0, 0.85, 40.0);
         let hist = integrate(p, &inclined_p9(), PumpConfig::fast());
+        let max_deg = hist
+            .inclination_deg
+            .iter()
+            .cloned()
+            .fold(f64::NEG_INFINITY, f64::max);
         assert_relative_eq!(
             hist.max_inclination().get::<degree>(),
-            hist.max_inclination_deg(),
+            max_deg,
             epsilon = 1e-9
         );
         assert_relative_eq!(
             hist.final_inclination().get::<degree>(),
-            hist.final_inclination_deg(),
+            *hist.inclination_deg.last().unwrap(),
             epsilon = 1e-9
         );
     }
@@ -424,16 +419,16 @@ mod tests {
         let p = scattered_particle(250.0, 0.85, 40.0);
         let hist = integrate(p, &inclined_p9(), PumpConfig::fast());
         assert!(
-            hist.max_inclination_deg() >= 50.0,
+            hist.max_inclination().get::<degree>() >= 50.0,
             "inclined P9 should pump i ≥ 50° (BP519-like), got {:.1}°",
-            hist.max_inclination_deg()
+            hist.max_inclination().get::<degree>()
         );
         // And the achieved inclination is in the high-i band, consistent with
         // BP519's observed i ≈ 54°.
         assert!(
-            (50.0..70.0).contains(&hist.max_inclination_deg()),
+            (50.0..70.0).contains(&hist.max_inclination().get::<degree>()),
             "max i = {:.1}° outside the BP519-consistent band",
-            hist.max_inclination_deg()
+            hist.max_inclination().get::<degree>()
         );
     }
 
@@ -452,16 +447,16 @@ mod tests {
             .iter()
             .cloned()
             .fold(f64::INFINITY, f64::min);
-        let range = hist.max_inclination_deg() - min_i;
+        let range = hist.max_inclination().get::<degree>() - min_i;
         assert!(
             range < 2.0,
             "no-P9 control inclination should stay flat, range = {range:.2}°"
         );
         // It stays near its initial 40°, never reaching the BP519-like band.
         assert!(
-            hist.max_inclination_deg() < 45.0,
+            hist.max_inclination().get::<degree>() < 45.0,
             "no-P9 control should not pump, got {:.1}°",
-            hist.max_inclination_deg()
+            hist.max_inclination().get::<degree>()
         );
     }
 
@@ -482,10 +477,10 @@ mod tests {
             PumpConfig::fast(),
         );
         assert!(
-            hi.max_inclination_deg() > lo.max_inclination_deg() + 3.0,
+            hi.max_inclination().get::<degree>() > lo.max_inclination().get::<degree>() + 3.0,
             "higher i₉ (mutual inclination) should pump more: {:.1}° vs {:.1}°",
-            hi.max_inclination_deg(),
-            lo.max_inclination_deg()
+            hi.max_inclination().get::<degree>(),
+            lo.max_inclination().get::<degree>()
         );
     }
 
@@ -504,10 +499,10 @@ mod tests {
         let light = integrate(p, &p9_light, cfg);
         let heavy = integrate(p, &p9_heavy, cfg);
         assert!(
-            heavy.max_inclination_deg() > light.max_inclination_deg(),
+            heavy.max_inclination().get::<degree>() > light.max_inclination().get::<degree>(),
             "heavier P9 should pump faster: {:.1}° vs {:.1}°",
-            heavy.max_inclination_deg(),
-            light.max_inclination_deg()
+            heavy.max_inclination().get::<degree>(),
+            light.max_inclination().get::<degree>()
         );
     }
 
@@ -521,9 +516,10 @@ mod tests {
         let p = scattered_particle(250.0, 0.85, 40.0);
         let hist = integrate(p, &inclined_p9(), PumpConfig::fast());
         assert!(
-            hist.max_inclination_deg() > 50.0 && hist.max_inclination_deg() < 90.0,
+            hist.max_inclination().get::<degree>() > 50.0
+                && hist.max_inclination().get::<degree>() < 90.0,
             "pumped i should be high but prograde, max i = {:.1}°",
-            hist.max_inclination_deg()
+            hist.max_inclination().get::<degree>()
         );
         for (&i, &e) in hist.inclination_deg.iter().zip(&hist.eccentricity) {
             assert!(i.is_finite() && (0.0..90.0).contains(&i), "i = {i}");

--- a/crates/p9-2018-chaotic-dynamics/Cargo.toml
+++ b/crates/p9-2018-chaotic-dynamics/Cargo.toml
@@ -8,7 +8,7 @@ description = "Reproduction of Hadden, Li, Payne & Holman (2018) 'Chaotic dynami
 p9-core = { path = "../p9-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2018-chaotic-dynamics/src/chaos.rs
+++ b/crates/p9-2018-chaotic-dynamics/src/chaos.rs
@@ -66,14 +66,8 @@ pub fn nearest_j_one_index(a_au: f64, a9_au: f64) -> i64 {
 /// Delegated to `p9_core::analysis::resonance::resonance_semi_major_axis(1, j,
 /// a₉)` = a₉ (1/j)^{2/3} — a particle completing `j` orbits per Planet Nine
 /// orbit sits here.
-pub fn j_one_location(j: i64, a9_au: f64) -> f64 {
-    resonance_semi_major_axis(1, j as u32, a9_au)
-}
-
-/// Interior j:1 resonance location as a typed [`Length`] (see
-/// [`j_one_location`]).
 pub fn j_one_location_typed(j: i64, a9_au: f64) -> Length {
-    au(j_one_location(j, a9_au))
+    au(resonance_semi_major_axis(1, j as u32, a9_au))
 }
 
 /// Inward extent (AU) of the overlapped resonance zone from Planet Nine, for a
@@ -84,15 +78,9 @@ pub fn j_one_location_typed(j: i64, a9_au: f64) -> Length {
 /// `m9_earth` is Planet Nine's mass in Earth masses. The eccentricity factor
 /// e^{1/5} is the Mustill & Wyatt (2012) enhancement of the Wisdom (1980)
 /// circular overlap zone.
-pub fn overlap_zone_width(e: f64, a9_au: f64, m9_earth: f64) -> f64 {
-    let mu = m9_earth * EARTH_MASS_SOLAR;
-    OVERLAP_PREFACTOR * mu.powf(2.0 / 7.0) * e.powf(0.2) * a9_au
-}
-
-/// Inward extent of the overlapped resonance zone as a typed [`Length`] (see
-/// [`overlap_zone_width`]).
 pub fn overlap_zone_width_typed(e: f64, a9_au: f64, m9_earth: f64) -> Length {
-    au(overlap_zone_width(e, a9_au, m9_earth))
+    let mu = m9_earth * EARTH_MASS_SOLAR;
+    au(OVERLAP_PREFACTOR * mu.powf(2.0 / 7.0) * e.powf(0.2) * a9_au)
 }
 
 /// Resonance-overlap parameter K at (a, e) for a Planet Nine of semi-major
@@ -109,7 +97,7 @@ pub fn overlap_parameter(a_au: f64, e: f64, a9_au: f64, m9_earth: f64, _e9: f64)
     if gap <= 0.0 {
         return f64::INFINITY;
     }
-    overlap_zone_width(e, a9_au, m9_earth) / gap
+    (overlap_zone_width_typed(e, a9_au, m9_earth) / au(gap)).value
 }
 
 /// Whether the point (a, e) lies in the chaotic resonance-overlap regime
@@ -227,16 +215,19 @@ mod tests {
     }
 
     #[test]
-    fn typed_accessors_match_f64_sources() {
-        use uom::si::length::astronomical_unit;
+    fn typed_accessors_match_inline_formulas() {
+        // j:1 location: a_j = a9 j^{-2/3}.
         assert_relative_eq!(
-            j_one_location_typed(5, A9).get::<astronomical_unit>(),
-            j_one_location(5, A9),
+            (j_one_location_typed(5, A9) / au(1.0)).value,
+            A9 * 5.0f64.powf(-2.0 / 3.0),
             max_relative = 1e-12
         );
+        // Overlap zone width: C μ^{2/7} e^{1/5} a9.
+        let mu = M9 * EARTH_MASS_SOLAR;
+        let expected = OVERLAP_PREFACTOR * mu.powf(2.0 / 7.0) * 0.7f64.powf(0.2) * A9;
         assert_relative_eq!(
-            overlap_zone_width_typed(0.7, A9, M9).get::<astronomical_unit>(),
-            overlap_zone_width(0.7, A9, M9),
+            (overlap_zone_width_typed(0.7, A9, M9) / au(1.0)).value,
+            expected,
             max_relative = 1e-12
         );
     }
@@ -246,7 +237,7 @@ mod tests {
         // Cross-check the j:1 resonance locations against a_j = a9 j^{-2/3}
         // to 1e-9 (the analytic relation underpinning the chain).
         for j in 1..=30i64 {
-            let computed = j_one_location(j, A9);
+            let computed = (j_one_location_typed(j, A9) / au(1.0)).value;
             let analytic = A9 * (j as f64).powf(-2.0 / 3.0);
             assert_relative_eq!(computed, analytic, max_relative = 1e-9);
         }
@@ -255,7 +246,7 @@ mod tests {
     #[test]
     fn nearest_index_is_self_consistent() {
         for j in 1..=20i64 {
-            let a = j_one_location(j, A9);
+            let a = (j_one_location_typed(j, A9) / au(1.0)).value;
             assert_eq!(nearest_j_one_index(a, A9), j, "j = {j}");
         }
     }

--- a/crates/p9-2018-chaotic-dynamics/src/width.rs
+++ b/crates/p9-2018-chaotic-dynamics/src/width.rs
@@ -28,37 +28,33 @@ use p9_core::units::{au, Length};
 /// it vanishes for a circular orbit and grows strongly toward e → 1, which is
 /// what drives the resonance overlap. `e9` is accepted for API symmetry with
 /// the chaos map but does not enter the leading multipole width.
-pub fn libration_half_width(j: i64, e: f64, m9_earth: f64, a9_au: f64, _e9: f64) -> f64 {
+pub fn libration_half_width_typed(j: i64, e: f64, m9_earth: f64, a9_au: f64, _e9: f64) -> Length {
     let m9_solar = m9_earth * EARTH_MASS_SOLAR;
     let a_j = resonance_semi_major_axis(1, j as u32, a9_au);
     let alpha = a_j / a9_au;
     let x = hansen_coefficient(1, j as i32, j as i32, e, 1e-8).abs();
-    a_j * ((16.0 / 3.0) * m9_solar * alpha.powi(j as i32 + 1) * x).sqrt()
+    au(a_j * ((16.0 / 3.0) * m9_solar * alpha.powi(j as i32 + 1) * x).sqrt())
 }
 
-/// Quadrupole-limit pendulum half-width as a typed [`Length`] (see
-/// [`libration_half_width`]).
-pub fn libration_half_width_typed(j: i64, e: f64, m9_earth: f64, a9_au: f64, e9: f64) -> Length {
-    au(libration_half_width(j, e, m9_earth, a9_au, e9))
-}
-
-/// Full libration width (AU) — twice the half-width — of the j:1 resonance.
-pub fn libration_width(j: i64, e: f64, m9_earth: f64, a9_au: f64, e9: f64) -> f64 {
-    2.0 * libration_half_width(j, e, m9_earth, a9_au, e9)
-}
-
-/// Full libration width as a typed [`Length`] (see [`libration_width`]).
+/// Full libration width as a typed [`Length`] — twice the half-width — of the
+/// j:1 resonance (see [`libration_half_width_typed`]).
 pub fn libration_width_typed(j: i64, e: f64, m9_earth: f64, a9_au: f64, e9: f64) -> Length {
-    au(libration_width(j, e, m9_earth, a9_au, e9))
+    2.0 * libration_half_width_typed(j, e, m9_earth, a9_au, e9)
 }
 
 /// Libration half-width as a function of mass over a list of Planet Nine
 /// masses (Earth masses), all other parameters fixed. Returns parallel
 /// (mass, half-width) pairs for trend analysis.
-pub fn width_vs_mass(masses_earth: &[f64], j: i64, e: f64, a9_au: f64, e9: f64) -> Vec<(f64, f64)> {
+pub fn width_vs_mass(
+    masses_earth: &[f64],
+    j: i64,
+    e: f64,
+    a9_au: f64,
+    e9: f64,
+) -> Vec<(f64, Length)> {
     masses_earth
         .iter()
-        .map(|&m| (m, libration_half_width(j, e, m, a9_au, e9)))
+        .map(|&m| (m, libration_half_width_typed(j, e, m, a9_au, e9)))
         .collect()
 }
 
@@ -76,13 +72,15 @@ mod tests {
         let masses = [1.0, 5.0, 10.0, 20.0, 50.0];
         let widths = width_vs_mass(&masses, 3, 0.7, A9, E9);
         for w in widths.windows(2) {
+            let lo = (w[0].1 / au(1.0)).value;
+            let hi = (w[1].1 / au(1.0)).value;
             assert!(
-                w[1].1 > w[0].1,
+                hi > lo,
                 "width must grow with mass: {} M⊕ -> {} AU, {} M⊕ -> {} AU",
                 w[0].0,
-                w[0].1,
+                lo,
                 w[1].0,
-                w[1].1
+                hi
             );
         }
     }
@@ -90,39 +88,48 @@ mod tests {
     #[test]
     fn libration_half_width_follows_sqrt_mass_scaling() {
         // δa ∝ √m₉: doubling the mass multiplies the half-width by √2.
-        let w1 = libration_half_width(3, 0.7, 10.0, A9, E9);
-        let w2 = libration_half_width(3, 0.7, 40.0, A9, E9);
+        let w1 = libration_half_width_typed(3, 0.7, 10.0, A9, E9);
+        let w2 = libration_half_width_typed(3, 0.7, 40.0, A9, E9);
         // 4x mass -> 2x width.
-        assert_relative_eq!(w2 / w1, 2.0, max_relative = 1e-6);
+        assert_relative_eq!((w2 / w1).value, 2.0, max_relative = 1e-6);
     }
 
     #[test]
-    fn typed_width_accessors_match_f64_sources() {
-        use uom::si::length::astronomical_unit;
-        assert_relative_eq!(
-            libration_half_width_typed(3, 0.7, 10.0, A9, E9).get::<astronomical_unit>(),
-            libration_half_width(3, 0.7, 10.0, A9, E9),
-            max_relative = 1e-12
-        );
-        assert_relative_eq!(
-            libration_width_typed(3, 0.7, 10.0, A9, E9).get::<astronomical_unit>(),
-            libration_width(3, 0.7, 10.0, A9, E9),
-            max_relative = 1e-12
-        );
+    fn typed_width_matches_inline_formula() {
+        use p9_core::analysis::hansen::hansen_coefficient;
+        use p9_core::analysis::resonance::resonance_semi_major_axis;
+        use p9_core::constants::EARTH_MASS_SOLAR;
+        // Reproduce the closed-form half-width inline and compare to the typed
+        // accessor (in AU).
+        let (j, e, m9_earth) = (3i64, 0.7, 10.0);
+        let m9_solar = m9_earth * EARTH_MASS_SOLAR;
+        let a_j = resonance_semi_major_axis(1, j as u32, A9);
+        let alpha = a_j / A9;
+        let x = hansen_coefficient(1, j as i32, j as i32, e, 1e-8).abs();
+        let expected = a_j * ((16.0 / 3.0) * m9_solar * alpha.powi(j as i32 + 1) * x).sqrt();
+        let half = libration_half_width_typed(j, e, m9_earth, A9, E9);
+        assert_relative_eq!((half / au(1.0)).value, expected, max_relative = 1e-12);
+        // Full width is exactly twice the half-width.
+        let full = libration_width_typed(j, e, m9_earth, A9, E9);
+        assert_relative_eq!((full / au(1.0)).value, 2.0 * expected, max_relative = 1e-12);
     }
 
     #[test]
     fn full_width_is_twice_half_width() {
-        let h = libration_half_width(4, 0.6, 10.0, A9, E9);
-        let f = libration_width(4, 0.6, 10.0, A9, E9);
-        assert_relative_eq!(f, 2.0 * h, max_relative = 1e-12);
+        let h = libration_half_width_typed(4, 0.6, 10.0, A9, E9);
+        let f = libration_width_typed(4, 0.6, 10.0, A9, E9);
+        assert_relative_eq!(
+            (f / au(1.0)).value,
+            2.0 * (h / au(1.0)).value,
+            max_relative = 1e-12
+        );
     }
 
     #[test]
     fn width_is_finite_and_positive() {
         for &j in &[2i64, 3, 5, 8] {
             for &e in &[0.1, 0.5, 0.85] {
-                let w = libration_half_width(j, e, 10.0, A9, E9);
+                let w = (libration_half_width_typed(j, e, 10.0, A9, E9) / au(1.0)).value;
                 assert!(w.is_finite() && w > 0.0, "j={j} e={e} w={w}");
             }
         }

--- a/crates/p9-2018-resonance/Cargo.toml
+++ b/crates/p9-2018-resonance/Cargo.toml
@@ -10,6 +10,4 @@ rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 approx = { workspace = true }
-
-[dev-dependencies]
 uom = "0.38.0"

--- a/crates/p9-2018-resonance/src/probability_analysis.rs
+++ b/crates/p9-2018-resonance/src/probability_analysis.rs
@@ -67,13 +67,8 @@ pub fn p_all_simple(p_simple: f64, n_kbos: usize) -> f64 {
 /// If the KBO is in a p:q resonance with P9:
 ///   a_kbo = a₉ * (q/p)^(2/3)
 ///   a₉ = a_kbo / (q/p)^(2/3) = a_kbo * (p/q)^(2/3)
-pub fn implied_a9(a_kbo: f64, res: &Resonance) -> f64 {
-    a_kbo * (res.p as f64 / res.q as f64).powf(2.0 / 3.0)
-}
-
-/// Implied a₉ as a typed [`Length`] (see [`implied_a9`]).
 pub fn implied_a9_typed(a_kbo: f64, res: &Resonance) -> Length {
-    au(implied_a9(a_kbo, res))
+    au(a_kbo * (res.p as f64 / res.q as f64).powf(2.0 / 3.0))
 }
 
 /// Explicit, honest prior on a₉ and the kernel model for the
@@ -158,7 +153,7 @@ pub fn compute_a9_distribution(
                 if res.period_ratio() >= 1.0 {
                     continue; // exterior: P9 inside the KBO orbit
                 }
-                let a_res = res.semimajor_axis(a9);
+                let a_res = (res.semimajor_axis_typed(a9) / au(1.0)).value;
                 let z = (a_kbo - a_res) / sigma;
                 let weight = if prior.order_weighting {
                     1.0 / res.order().max(1) as f64
@@ -281,22 +276,18 @@ mod tests {
     fn test_implied_a9() {
         // If KBO at a=378 is in 2:1 with P9:
         // a₉ = 378 * (2/1)^(2/3) = 378 * 1.587 ≈ 600
-        let a9 = implied_a9(378.0, &Resonance::new(2, 1));
+        let a9 = (implied_a9_typed(378.0, &Resonance::new(2, 1)) / au(1.0)).value;
         assert!((a9 - 600.0).abs() < 5.0, "Implied a₉ = {:.1}", a9);
     }
 
     #[test]
-    fn typed_length_accessors_match_f64_sources() {
-        use uom::si::length::astronomical_unit;
+    fn typed_length_accessors_match_sources() {
         let res = Resonance::new(2, 1);
-        assert!(
-            (implied_a9_typed(378.0, &res).get::<astronomical_unit>() - implied_a9(378.0, &res))
-                .abs()
-                < 1e-9
-        );
+        let expected = 378.0 * (res.p as f64 / res.q as f64).powf(2.0 / 3.0);
+        assert!(((implied_a9_typed(378.0, &res) / au(1.0)).value - expected).abs() < 1e-9);
         let cmp = compare_distributions(&observed_kbo_axes());
-        assert!((cmp.f5_peak().get::<astronomical_unit>() - cmp.f5_peak_a9).abs() < 1e-9);
-        assert!((cmp.ext_peak().get::<astronomical_unit>() - cmp.ext_peak_a9).abs() < 1e-9);
+        assert!(((cmp.f5_peak() / au(1.0)).value - cmp.f5_peak_a9).abs() < 1e-9);
+        assert!(((cmp.ext_peak() / au(1.0)).value - cmp.ext_peak_a9).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/p9-2018-resonance/src/resonance_catalog.rs
+++ b/crates/p9-2018-resonance/src/resonance_catalog.rs
@@ -42,14 +42,8 @@ impl Resonance {
 
     /// Semi-major axis of the resonance given perturber semi-major axis.
     /// a_res = a_p9 * (q/p)^(2/3)
-    pub fn semimajor_axis(&self, a_p9: f64) -> f64 {
-        a_p9 * self.period_ratio().powf(2.0 / 3.0)
-    }
-
-    /// Resonance semi-major axis as a typed [`Length`] (see
-    /// [`Self::semimajor_axis`]).
     pub fn semimajor_axis_typed(&self, a_p9: f64) -> Length {
-        au(self.semimajor_axis(a_p9))
+        au(a_p9 * self.period_ratio().powf(2.0 / 3.0))
     }
 
     /// Whether this is an N/1 period ratio (integer period ratio, p=1).
@@ -161,7 +155,7 @@ pub fn identify_resonance(
     let mut best: Option<(Resonance, f64)> = None;
 
     for &res in catalog {
-        let a_res = res.semimajor_axis(a_p9);
+        let a_res = (res.semimajor_axis_typed(a_p9) / au(1.0)).value;
         let delta = (a - a_res).abs() / a_res;
 
         if delta < tolerance_frac {
@@ -226,7 +220,7 @@ pub fn resonance_census(
     catalog
         .iter()
         .filter_map(|&res| {
-            let a_res = res.semimajor_axis(a_p9);
+            let a_res = (res.semimajor_axis_typed(a_p9) / au(1.0)).value;
             let count = elements
                 .iter()
                 .filter(|e| ((e.a - a_res) / a_res).abs() < tolerance)
@@ -248,21 +242,17 @@ mod tests {
     #[test]
     fn test_resonance_semimajor_axis() {
         let res = Resonance::new(2, 1);
-        let a = res.semimajor_axis(700.0);
+        let a = (res.semimajor_axis_typed(700.0) / au(1.0)).value;
         // 2:1 → a = 700 * (1/2)^(2/3) ≈ 441
         assert!((a - 441.0).abs() < 1.0, "2:1 at {:.1} AU", a);
     }
 
     #[test]
-    fn typed_semimajor_axis_matches_f64_source() {
-        use uom::si::length::astronomical_unit;
+    fn typed_semimajor_axis_matches_formula() {
         let res = Resonance::new(2, 1);
-        assert!(
-            (res.semimajor_axis_typed(700.0).get::<astronomical_unit>()
-                - res.semimajor_axis(700.0))
-            .abs()
-                < 1e-9
-        );
+        let expected = 700.0 * res.period_ratio().powf(2.0 / 3.0);
+        assert!((res.semimajor_axis_typed(700.0) / au(1.0)).value - expected < 1e-9);
+        assert!(expected - (res.semimajor_axis_typed(700.0) / au(1.0)).value < 1e-9);
     }
 
     #[test]
@@ -345,7 +335,7 @@ mod tests {
         let a_p9 = 600.0;
 
         // Near 2:1 resonance: a = 600 * (1/2)^(2/3) ≈ 378
-        let a_21 = Resonance::new(2, 1).semimajor_axis(a_p9);
+        let a_21 = (Resonance::new(2, 1).semimajor_axis_typed(a_p9) / au(1.0)).value;
         let result = identify_resonance(a_21 + 1.0, a_p9, &catalog, 0.02);
         assert!(result.is_some());
         assert_eq!(result.unwrap().0, Resonance::new(2, 1));
@@ -373,7 +363,7 @@ mod tests {
     fn test_resonance_census() {
         let catalog = vec![Resonance::new(2, 1), Resonance::new(3, 1)];
         let a_p9 = 600.0;
-        let a_21 = Resonance::new(2, 1).semimajor_axis(a_p9);
+        let a_21 = (Resonance::new(2, 1).semimajor_axis_typed(a_p9) / au(1.0)).value;
 
         let elements = vec![
             OrbitalElements {

--- a/crates/p9-2018-resonance/src/simulation.rs
+++ b/crates/p9-2018-resonance/src/simulation.rs
@@ -275,7 +275,7 @@ pub fn classify_particle(
 
     let mut best: Option<(Resonance, f64)> = None;
     for &res in catalog {
-        let a_res = res.semimajor_axis(a_p9);
+        let a_res = (res.semimajor_axis_typed(a_p9) / au(1.0)).value;
         if ((a_mean - a_res) / a_res).abs() > CANDIDATE_A_TOLERANCE {
             continue;
         }
@@ -457,7 +457,7 @@ mod tests {
         // φ = qλ − pλ9 + (p−q)ϖ oscillates about π with amplitude 0.6.
         let res = Resonance::new(2, 1);
         let a_p9 = 600.0;
-        let a_res = res.semimajor_axis(a_p9);
+        let a_res = (res.semimajor_axis_typed(a_p9) / au(1.0)).value;
         let n = 200;
         let mut series = Vec::with_capacity(n);
         let mut p9_samples = Vec::with_capacity(n);
@@ -491,7 +491,7 @@ mod tests {
         // a-proximity preselect alone would have called this resonant.
         let res = Resonance::new(2, 1);
         let a_p9 = 600.0;
-        let a_res = res.semimajor_axis(a_p9);
+        let a_res = (res.semimajor_axis_typed(a_p9) / au(1.0)).value;
         let n = 200;
         let mut series = Vec::with_capacity(n);
         let mut p9_samples = Vec::with_capacity(n);

--- a/crates/p9-2018-secular-dynamics/Cargo.toml
+++ b/crates/p9-2018-secular-dynamics/Cargo.toml
@@ -9,7 +9,7 @@ nalgebra = { workspace = true }
 p9-core = { path = "../p9-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2018-secular-dynamics/src/secular_model.rs
+++ b/crates/p9-2018-secular-dynamics/src/secular_model.rs
@@ -112,8 +112,9 @@ pub fn hamiltonian(a: f64, e: f64, dvarpi: f64, p9: &P9Params) -> f64 {
     giants_j2_energy(a, e) + p9_ring_energy(a, e, dvarpi, p9)
 }
 
-/// Free (giants-only) apsidal precession rate dϖ/dt (rad/day) of a low-e test
-/// particle, from the secular J2 quadrupole:
+/// Free (giants-only) apsidal precession rate dϖ/dt as a typed
+/// [`AngularVelocity`] (rad/day) of a low-e test particle, from the secular J2
+/// quadrupole:
 ///
 ///   dϖ/dt = (√(1−e²) / (n a² e)) · ∂H_J2/∂e   →   prograde (> 0).
 ///
@@ -121,19 +122,14 @@ pub fn hamiltonian(a: f64, e: f64, dvarpi: f64, p9: &P9Params) -> f64 {
 /// classical (3/2) n J2_eff (R/a)² regression-free precession. This is the
 /// rate that competes with P9's torque and sets the circulation regime at
 /// small `a`.
-pub fn free_precession_rate(a: f64, e: f64) -> f64 {
+pub fn free_precession_rate_typed(a: f64, e: f64) -> AngularVelocity {
     let n = mean_motion(a);
     let de = 1e-4;
     let dh = (giants_j2_energy(a, e + de) - giants_j2_energy(a, e - de)) / (2.0 * de);
     // dϖ/dt = +(√(1−e²)/(n a² e)) · ∂R/∂e with the disturbing function R = −H,
     // so the giants' apsidal precession comes out prograde (> 0).
-    -(1.0 - e * e).sqrt() / (n * a * a * e) * dh
-}
-
-/// Free (giants-only) apsidal precession rate as a typed [`AngularVelocity`]
-/// (see [`free_precession_rate`], in rad/day).
-pub fn free_precession_rate_typed(a: f64, e: f64) -> AngularVelocity {
-    (radians(free_precession_rate(a, e)) / days(1.0)).into()
+    let rate = -(1.0 - e * e).sqrt() / (n * a * a * e) * dh;
+    (radians(rate) / days(1.0)).into()
 }
 
 /// The linear secular coefficients `(B, A)` of the eccentricity-vector
@@ -235,11 +231,11 @@ pub fn classify_apsidal_motion(
     }
 }
 
-/// Locate the critical semi-major axis a_crit separating circulation (below)
-/// from libration (above), by bisection on the `librates` predicate over
-/// [a_lo, a_hi]. Returns None if the predicate does not change between the
-/// endpoints (no transition inside the bracket).
-pub fn critical_semimajor_axis(p9: &P9Params, a_lo: f64, a_hi: f64) -> Option<f64> {
+/// Locate the critical semi-major axis a_crit as a typed [`Length`], separating
+/// circulation (below) from libration (above), by bisection on the `librates`
+/// predicate over [a_lo, a_hi]. Returns None if the predicate does not change
+/// between the endpoints (no transition inside the bracket).
+pub fn critical_semimajor_axis_typed(p9: &P9Params, a_lo: f64, a_hi: f64) -> Option<Length> {
     let lib_lo = librates(a_lo, p9);
     let lib_hi = librates(a_hi, p9);
     if lib_lo == lib_hi {
@@ -260,18 +256,12 @@ pub fn critical_semimajor_axis(p9: &P9Params, a_lo: f64, a_hi: f64) -> Option<f6
             break;
         }
     }
-    Some(0.5 * (lo + hi))
-}
-
-/// Critical semi-major axis as a typed [`Length`] (see
-/// [`critical_semimajor_axis`]).
-pub fn critical_semimajor_axis_typed(p9: &P9Params, a_lo: f64, a_hi: f64) -> Option<Length> {
-    critical_semimajor_axis(p9, a_lo, a_hi).map(au)
+    Some(au(0.5 * (lo + hi)))
 }
 
 /// Analytic-vs-numerical cross-check helper: the secular apsidal precession
 /// rate from the giants' J2 term computed by finite difference of the p9-core
-/// J2 energy (`free_precession_rate`) against the closed-form
+/// J2 energy (`free_precession_rate_typed`) against the closed-form
 ///
 ///   dϖ/dt = (3/2) n J2_eff (R_ref/a)² (1 − e²)^{−2}.
 ///
@@ -281,7 +271,10 @@ pub fn precession_cross_check(a: f64, e: f64) -> (f64, f64) {
     let (j2_eff, _j4, _gm) = combined_j2_jsu();
     let r_ref = 1.0_f64;
     let analytic = 1.5 * n * j2_eff * (r_ref / a).powi(2) * (1.0 - e * e).powi(-2);
-    let numerical = free_precession_rate(a, e);
+    // Recover the rad/day numeric value from the typed AngularVelocity by
+    // dividing out one radian-per-day; the resulting dimensionless ratio's
+    // value is exactly the original rad/day number.
+    let numerical = (free_precession_rate_typed(a, e) / (radians(1.0) / days(1.0))).value;
     (numerical, analytic)
 }
 
@@ -291,30 +284,36 @@ mod tests {
     use p9_core::analysis::secular::coplanar_quadrupole;
 
     #[test]
-    fn typed_accessors_match_f64_sources() {
+    fn typed_accessors_match_inline_formulas() {
         use approx::assert_relative_eq;
         use uom::si::angular_velocity::radian_per_second;
         use uom::si::length::astronomical_unit;
         use uom::si::time::second;
 
-        // The typed rate stores rad/s; convert back to rad/day to compare with
-        // the f64 source (which is in rad/day).
+        // Reproduce the inline f64 precession formula (rad/day) and compare
+        // against the typed accessor (which stores rad/s).
+        let a = 250.0;
+        let e = 0.2;
+        let n = mean_motion(a);
+        let de = 1e-4;
+        let dh = (giants_j2_energy(a, e + de) - giants_j2_energy(a, e - de)) / (2.0 * de);
+        let rate = -(1.0 - e * e).sqrt() / (n * a * a * e) * dh;
+
         let seconds_per_day = days(1.0).get::<second>();
-        let rate = free_precession_rate(250.0, 0.2);
-        let typed = free_precession_rate_typed(250.0, 0.2);
+        let typed = free_precession_rate_typed(a, e);
         assert_relative_eq!(
             typed.get::<radian_per_second>() * seconds_per_day,
             rate,
             max_relative = 1e-9
         );
 
+        // The typed critical semi-major axis reads back in AU within the bracket.
         let p9 = nominal_p9();
-        if let Some(a_crit) = critical_semimajor_axis(&p9, 50.0, 400.0) {
-            let typed_a = critical_semimajor_axis_typed(&p9, 50.0, 400.0).unwrap();
-            assert_relative_eq!(
-                typed_a.get::<astronomical_unit>(),
-                a_crit,
-                max_relative = 1e-9
+        if let Some(typed_a) = critical_semimajor_axis_typed(&p9, 50.0, 400.0) {
+            let a_crit = typed_a.get::<astronomical_unit>();
+            assert!(
+                (50.0..400.0).contains(&a_crit),
+                "a_crit {a_crit} must be inside the bracket"
             );
         }
     }
@@ -360,9 +359,11 @@ mod tests {
     /// threshold.
     #[test]
     fn test_critical_semimajor_axis_separates_regimes() {
+        use uom::si::length::astronomical_unit;
         let p9 = nominal_p9();
-        let a_crit = critical_semimajor_axis(&p9, 50.0, 480.0)
-            .expect("a transition must exist in [50, 480] AU");
+        let a_crit = critical_semimajor_axis_typed(&p9, 50.0, 480.0)
+            .expect("a transition must exist in [50, 480] AU")
+            .get::<astronomical_unit>();
 
         // Circulation well below, libration well above the transition.
         assert!(

--- a/crates/p9-2019-clustering/src/kbo_sample.rs
+++ b/crates/p9-2019-clustering/src/kbo_sample.rs
@@ -182,6 +182,7 @@ pub fn paper_sample_a230() -> Vec<DistantKbo> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uom::si::length::astronomical_unit;
 
     #[test]
     fn test_sample_size() {
@@ -207,7 +208,7 @@ mod tests {
     #[test]
     fn test_sample_cut_q_above_30() {
         for kbo in paper_sample_a230() {
-            let q = kbo.elements.perihelion();
+            let q = kbo.elements.perihelion_typed().get::<astronomical_unit>();
             assert!(q > 30.0, "{} has q = {:.1} AU, expected > 30", kbo.name, q);
         }
     }
@@ -218,9 +219,9 @@ mod tests {
         let fe72 = kbos.iter().find(|k| k.name == "2014 FE72").unwrap();
         assert!((fe72.elements.e - 0.983).abs() < 1e-12);
         assert!(
-            (fe72.elements.perihelion() - 36.0).abs() < 1.0,
+            (fe72.elements.perihelion_typed().get::<astronomical_unit>() - 36.0).abs() < 1.0,
             "q = {:.1}",
-            fe72.elements.perihelion()
+            fe72.elements.perihelion_typed().get::<astronomical_unit>()
         );
     }
 }

--- a/crates/p9-2019-ossos-scattering/Cargo.toml
+++ b/crates/p9-2019-ossos-scattering/Cargo.toml
@@ -9,7 +9,7 @@ rand = { workspace = true }
 rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2019-ossos-scattering/src/planet_nine.rs
+++ b/crates/p9-2019-ossos-scattering/src/planet_nine.rs
@@ -60,11 +60,6 @@ impl Default for PlanetNine {
 }
 
 impl PlanetNine {
-    /// Heliocentric gravitational parameter GM₉ (AU³/day²).
-    pub fn gm(&self) -> f64 {
-        self.mass_earth * EARTH_MASS_SOLAR * GM_SUN
-    }
-
     /// Mass as a typed [`Mass`].
     pub fn mass(&self) -> Mass {
         earth_masses(self.mass_earth)
@@ -75,9 +70,10 @@ impl PlanetNine {
         au(self.a_au)
     }
 
-    /// Gravitational parameter GM₉ as a typed [`GravitationalParameter`].
+    /// Heliocentric gravitational parameter GM₉ as a typed
+    /// [`GravitationalParameter`].
     pub fn gm_typed(&self) -> GravitationalParameter {
-        gm_from_au3_day2(self.gm())
+        gm_from_au3_day2(self.mass_earth * EARTH_MASS_SOLAR * GM_SUN)
     }
 }
 
@@ -126,7 +122,7 @@ const E_BRANCH_MIN: f64 = 0.7;
 /// roots past the peak.
 pub fn max_perihelion(p9: &PlanetNine, a_au: f64, q0_au: f64, dvarpi0: f64) -> f64 {
     let e0 = 1.0 - q0_au / a_au;
-    let gm = p9.gm();
+    let gm = (p9.gm_typed() / gm_from_au3_day2(1.0)).value;
     let soft = 0.01 * p9.a_au;
     if e0 <= E_BRANCH_MIN {
         return q0_au;
@@ -175,7 +171,7 @@ pub fn forcing_rate(p9: &PlanetNine, a_au: f64, q0_au: f64) -> f64 {
     if e0 <= E_BRANCH_MIN || e0 <= 0.0 {
         return 0.0;
     }
-    let gm = p9.gm();
+    let gm = (p9.gm_typed() / gm_from_au3_day2(1.0)).value;
     let soft = 0.01 * p9.a_au;
     let n = (GM_SUN / a_au.powi(3)).sqrt(); // mean motion (rad/day)
     let dphi = 1e-3;
@@ -254,6 +250,7 @@ mod tests {
 
     #[test]
     fn gm_scales_with_mass() {
+        let gm_au3_day2 = |p9: &PlanetNine| (p9.gm_typed() / gm_from_au3_day2(1.0)).value;
         let small = PlanetNine {
             mass_earth: 5.0,
             ..Default::default()
@@ -262,11 +259,15 @@ mod tests {
             mass_earth: 10.0,
             ..Default::default()
         };
-        assert_relative_eq!(big.gm() / small.gm(), 2.0, epsilon = 1e-12);
+        assert_relative_eq!(
+            gm_au3_day2(&big) / gm_au3_day2(&small),
+            2.0,
+            epsilon = 1e-12
+        );
         // Sanity: 6.2 M⊕ in solar masses times GM_SUN.
         let nominal = PlanetNine::default();
         assert_relative_eq!(
-            nominal.gm(),
+            gm_au3_day2(&nominal),
             6.2 * EARTH_MASS_SOLAR * GM_SUN,
             epsilon = 1e-18
         );
@@ -287,10 +288,10 @@ mod tests {
             p9.mass_earth * p9_core::units::EARTH_MASS_KG,
             epsilon = 1e12
         );
-        // GM round-trips from AU³/day² to SI base via the core converter.
+        // GM matches the inline AU³/day² formula, converted to SI base.
         assert_relative_eq!(
             p9.gm_typed().value,
-            gm_from_au3_day2(p9.gm()).value,
+            gm_from_au3_day2(p9.mass_earth * EARTH_MASS_SOLAR * GM_SUN).value,
             epsilon = 1e-30
         );
     }

--- a/crates/p9-2020-des-isotropy/Cargo.toml
+++ b/crates/p9-2020-des-isotropy/Cargo.toml
@@ -9,7 +9,7 @@ rand = { workspace = true }
 rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2020-des-isotropy/src/des_sample.rs
+++ b/crates/p9-2020-des-isotropy/src/des_sample.rs
@@ -42,26 +42,6 @@ pub struct DesEtno {
 }
 
 impl DesEtno {
-    /// Perihelion distance q = a(1 − e) in AU.
-    pub fn perihelion(&self) -> f64 {
-        self.a * (1.0 - self.e)
-    }
-
-    /// Longitude of ascending node Ω in radians, wrapped to [0, 2π).
-    pub fn node(&self) -> f64 {
-        (self.node_deg * DEG2RAD).rem_euclid(TWO_PI)
-    }
-
-    /// Argument of perihelion ω in radians, wrapped to [0, 2π).
-    pub fn argp(&self) -> f64 {
-        (self.argp_deg * DEG2RAD).rem_euclid(TWO_PI)
-    }
-
-    /// Longitude of perihelion ϖ = ω + Ω in radians, wrapped to [0, 2π).
-    pub fn varpi(&self) -> f64 {
-        ((self.argp_deg + self.node_deg) * DEG2RAD).rem_euclid(TWO_PI)
-    }
-
     // ---- typed boundary accessors (dimension-checked views of the f64 fields) ----
 
     /// Semi-major axis as a typed [`Length`].
@@ -71,7 +51,7 @@ impl DesEtno {
 
     /// Perihelion distance q = a(1 − e) as a typed [`Length`].
     pub fn perihelion_typed(&self) -> Length {
-        au(self.perihelion())
+        au(self.a * (1.0 - self.e))
     }
 
     /// Inclination as a typed [`units::Angle`].
@@ -79,19 +59,22 @@ impl DesEtno {
         degrees(self.i_deg)
     }
 
-    /// Longitude of ascending node Ω as a typed [`units::Angle`].
+    /// Longitude of ascending node Ω as a typed [`units::Angle`], wrapped to
+    /// [0, 2π).
     pub fn node_typed(&self) -> units::Angle {
-        radians(self.node())
+        radians((self.node_deg * DEG2RAD).rem_euclid(TWO_PI))
     }
 
-    /// Argument of perihelion ω as a typed [`units::Angle`].
+    /// Argument of perihelion ω as a typed [`units::Angle`], wrapped to
+    /// [0, 2π).
     pub fn argp_typed(&self) -> units::Angle {
-        radians(self.argp())
+        radians((self.argp_deg * DEG2RAD).rem_euclid(TWO_PI))
     }
 
-    /// Longitude of perihelion ϖ as a typed [`units::Angle`].
+    /// Longitude of perihelion ϖ = ω + Ω as a typed [`units::Angle`], wrapped
+    /// to [0, 2π).
     pub fn varpi_typed(&self) -> units::Angle {
-        radians(self.varpi())
+        radians(((self.argp_deg + self.node_deg) * DEG2RAD).rem_euclid(TWO_PI))
     }
 }
 
@@ -211,7 +194,11 @@ pub fn case_sample(case: SampleCase) -> Vec<DesEtno> {
     let (a_min, q_min) = case.cuts();
     DES_ETNOS
         .iter()
-        .filter(|o| o.y4_discovery && o.a > a_min && o.perihelion() > q_min)
+        .filter(|o| {
+            o.y4_discovery
+                && o.a > a_min
+                && (o.perihelion_typed() / p9_core::units::au(1.0)).value > q_min
+        })
         .copied()
         .collect()
 }
@@ -242,11 +229,12 @@ impl Angle {
 
     /// Extract this angle (radians) from an object.
     pub fn of(&self, o: &DesEtno) -> f64 {
-        match self {
-            Angle::Node => o.node(),
-            Angle::ArgPeri => o.argp(),
-            Angle::Varpi => o.varpi(),
-        }
+        let a = match self {
+            Angle::Node => o.node_typed(),
+            Angle::ArgPeri => o.argp_typed(),
+            Angle::Varpi => o.varpi_typed(),
+        };
+        (a / p9_core::units::radians(1.0)).value
     }
 }
 
@@ -271,7 +259,8 @@ mod tests {
     fn test_varpi_consistent_with_paper() {
         // Paper lists ϖ = Ω + ω; spot-check 2013 RA109 (104.79 + 262.91 = 367.70 → 7.70°).
         let ra109 = DES_ETNOS.iter().find(|o| o.name == "2013 RA109").unwrap();
-        let varpi_deg = ra109.varpi() * p9_core::constants::RAD2DEG;
+        let varpi_deg = (ra109.varpi_typed() / p9_core::units::radians(1.0)).value
+            * p9_core::constants::RAD2DEG;
         assert!((varpi_deg - 7.70).abs() < 0.05, "varpi = {varpi_deg:.2}");
     }
 
@@ -289,25 +278,33 @@ mod tests {
         );
         assert_relative_eq!(
             o.perihelion_typed().get::<astronomical_unit>(),
-            o.perihelion(),
+            o.a * (1.0 - o.e),
             epsilon = 1e-12
         );
         assert_relative_eq!(o.inclination().get::<degree>(), o.i_deg, epsilon = 1e-12);
-        assert_relative_eq!(o.node_typed().get::<radian>(), o.node(), epsilon = 1e-12);
-        assert_relative_eq!(o.argp_typed().get::<radian>(), o.argp(), epsilon = 1e-12);
-        assert_relative_eq!(o.varpi_typed().get::<radian>(), o.varpi(), epsilon = 1e-12);
+        assert_relative_eq!(
+            o.node_typed().get::<radian>(),
+            (o.node_deg * DEG2RAD).rem_euclid(TWO_PI),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            o.argp_typed().get::<radian>(),
+            (o.argp_deg * DEG2RAD).rem_euclid(TWO_PI),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            o.varpi_typed().get::<radian>(),
+            ((o.argp_deg + o.node_deg) * DEG2RAD).rem_euclid(TWO_PI),
+            epsilon = 1e-12
+        );
     }
 
     #[test]
     fn test_all_objects_are_etnos() {
         for o in &DES_ETNOS {
             assert!(o.a > 150.0, "{}: a = {}", o.name, o.a);
-            assert!(
-                o.perihelion() > 30.0,
-                "{}: q = {:.1}",
-                o.name,
-                o.perihelion()
-            );
+            let q = (o.perihelion_typed() / p9_core::units::au(1.0)).value;
+            assert!(q > 30.0, "{}: q = {q:.1}", o.name);
         }
     }
 }

--- a/crates/p9-2020-des-isotropy/tests/isotropy_pins.rs
+++ b/crates/p9-2020-des-isotropy/tests/isotropy_pins.rs
@@ -189,8 +189,14 @@ fn mc_null_calibrated_on_uniform() {
 #[test]
 fn des_two_angle_correlation_not_significant() {
     let sample = case_sample(SampleCase::Case1);
-    let omega: Vec<f64> = sample.iter().map(|o| o.argp()).collect();
-    let node: Vec<f64> = sample.iter().map(|o| o.node()).collect();
+    let omega: Vec<f64> = sample
+        .iter()
+        .map(|o| (o.argp_typed() / p9_core::units::radians(1.0)).value)
+        .collect();
+    let node: Vec<f64> = sample
+        .iter()
+        .map(|o| (o.node_typed() / p9_core::units::radians(1.0)).value)
+        .collect();
     let r = circular_correlation(&omega, &node);
     assert!(r.abs() < 0.95, "|r_T| = {:.3}", r.abs());
     let p = mc_correlation_p_value(&omega, &node, SEED, MC);

--- a/crates/p9-2020-resonance-hopping/Cargo.toml
+++ b/crates/p9-2020-resonance-hopping/Cargo.toml
@@ -9,7 +9,7 @@ rand = { workspace = true }
 rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2020-resonance-hopping/src/classification.rs
+++ b/crates/p9-2020-resonance-hopping/src/classification.rs
@@ -54,20 +54,15 @@ pub struct Mmr {
 }
 
 impl Mmr {
-    /// Semimajor axis of this interior resonance for a P9 at `a_p9` (AU).
+    /// Semimajor axis of this interior resonance as a typed [`Length`], for a
+    /// Planet Nine at `a_p9` (AU).
     ///
     /// Particle does `p` orbits per `q` P9 orbits ⇒ period ratio
     /// T_particle/T_p9 = q/p, so a = a₉ (q/p)^{2/3}. We express this through
     /// the p9-core exterior helper a_planet (P/Q)^{2/3} with (P, Q) = (q, p),
     /// the single workspace resonance-location convention.
-    pub fn semimajor_axis(&self, a_p9: f64) -> f64 {
-        resonance_semi_major_axis(self.q, self.p, a_p9)
-    }
-
-    /// Semimajor axis of this interior resonance as a typed [`Length`], for a
-    /// Planet Nine at `a_p9` (AU).
     pub fn semi_major_axis_typed(&self, a_p9: f64) -> Length {
-        au(self.semimajor_axis(a_p9))
+        au(resonance_semi_major_axis(self.q, self.p, a_p9))
     }
 
     /// Order of the resonance, |p − q|.
@@ -120,7 +115,7 @@ impl ResonanceLandscape {
                     continue;
                 }
                 let mmr = Mmr { p, q };
-                let a_res = mmr.semimajor_axis(a_p9);
+                let a_res = (mmr.semi_major_axis_typed(a_p9) / au(1.0)).value;
                 if a_res < a_min {
                     break; // larger p only goes lower in a
                 }
@@ -319,7 +314,7 @@ mod tests {
         let mmr = Mmr { p: 3, q: 1 };
         assert_relative_eq!(
             mmr.semi_major_axis_typed(a_p9).get::<astronomical_unit>(),
-            mmr.semimajor_axis(a_p9),
+            resonance_semi_major_axis(mmr.q, mmr.p, a_p9),
             epsilon = 1e-12
         );
         let land = ResonanceLandscape::new(a_p9, 100.0, 600.0, 5);
@@ -336,7 +331,7 @@ mod tests {
         let a_p9 = 500.0;
         for (p, q) in [(2u32, 1u32), (3, 1), (5, 1), (3, 2), (5, 2), (7, 2)] {
             let mmr = Mmr { p, q };
-            let computed = mmr.semimajor_axis(a_p9);
+            let computed = mmr.semi_major_axis_typed(a_p9).get::<astronomical_unit>();
             let analytic = a_p9 * (q as f64 / p as f64).powf(2.0 / 3.0);
             assert_relative_eq!(computed, analytic, epsilon = 1e-9);
             // And it agrees with the p9-core helper directly.
@@ -361,7 +356,9 @@ mod tests {
             assert!(mmr.is_simple(), "{mmr:?} should be n:1 or n:2");
         }
         // 2:1 is the widest-spaced low-order resonance, near 315 AU.
-        let two_one = Mmr { p: 2, q: 1 }.semimajor_axis(500.0);
+        let two_one = Mmr { p: 2, q: 1 }
+            .semi_major_axis_typed(500.0)
+            .get::<astronomical_unit>();
         assert!((two_one - 315.0).abs() < 2.0, "2:1 at {two_one:.1} AU");
     }
 

--- a/crates/p9-2020-resonance-hopping/src/population.rs
+++ b/crates/p9-2020-resonance-hopping/src/population.rs
@@ -26,19 +26,14 @@ pub struct Tno {
 }
 
 impl Tno {
-    /// Perihelion distance q = a(1 − e) (AU).
-    pub fn perihelion(&self) -> f64 {
-        self.a * (1.0 - self.e)
-    }
-
     /// Semimajor axis as a typed [`Length`].
     pub fn semi_major_axis(&self) -> Length {
         au(self.a)
     }
 
-    /// Perihelion distance as a typed [`Length`].
+    /// Perihelion distance q = a(1 − e) as a typed [`Length`].
     pub fn perihelion_typed(&self) -> Length {
-        au(self.perihelion())
+        au(self.a * (1.0 - self.e))
     }
 }
 
@@ -200,7 +195,7 @@ mod tests {
         );
         assert_relative_eq!(
             t.perihelion_typed().get::<astronomical_unit>(),
-            t.perihelion(),
+            t.a * (1.0 - t.e),
             epsilon = 1e-12
         );
     }

--- a/crates/p9-2020-secular-octupole/Cargo.toml
+++ b/crates/p9-2020-secular-octupole/Cargo.toml
@@ -9,7 +9,7 @@ p9-core = { path = "../p9-core" }
 nalgebra = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2020-secular-octupole/src/precession.rs
+++ b/crates/p9-2020-secular-octupole/src/precession.rs
@@ -35,19 +35,10 @@ fn de_dgamma(a: f64, e: f64) -> f64 {
     (1.0 - e * e).sqrt() / ((GM_SUN * a).sqrt() * e)
 }
 
-/// QUADRUPOLE apsidal precession rate d(dvarpi)/dt (radians/day). A function of
-/// e only (dvarpi-independent): uniform circulation, no libration. Computed
-/// from the e-derivative of the reused `p9_core` coplanar quadrupole.
-pub fn precession_rate_quadrupole(a: f64, e: f64, a_p: f64, e_p: f64, gm_p: f64) -> f64 {
-    let de = 1e-5;
-    let dh_de = (hamiltonian_quadrupole(a, e + de, a_p, e_p, gm_p)
-        - hamiltonian_quadrupole(a, e - de, a_p, e_p, gm_p))
-        / (2.0 * de);
-    dh_de * de_dgamma(a, e)
-}
-
-/// QUADRUPOLE apsidal precession rate as a typed [`AngularVelocity`] (the
-/// dimension-checked view of [`precession_rate_quadrupole`], rad/day).
+/// QUADRUPOLE apsidal precession rate d(dvarpi)/dt as a typed
+/// [`AngularVelocity`] (rad/day). A function of e only (dvarpi-independent):
+/// uniform circulation, no libration. Computed from the e-derivative of the
+/// reused `p9_core` coplanar quadrupole.
 pub fn precession_rate_quadrupole_typed(
     a: f64,
     e: f64,
@@ -55,22 +46,17 @@ pub fn precession_rate_quadrupole_typed(
     e_p: f64,
     gm_p: f64,
 ) -> AngularVelocity {
-    (radians(precession_rate_quadrupole(a, e, a_p, e_p, gm_p)) / days(1.0)).into()
-}
-
-/// OCTUPOLE apsidal precession rate d(dvarpi)/dt (radians/day) at apsidal angle
-/// `dvarpi`. Carries the dvarpi-dependence from the octupole term; equals the
-/// quadrupole rate plus an octupole modulation proportional to cos(dvarpi).
-pub fn precession_rate_octupole(a: f64, e: f64, dvarpi: f64, a_p: f64, e_p: f64, gm_p: f64) -> f64 {
     let de = 1e-5;
-    let dh_de = (hamiltonian_octupole(a, e + de, dvarpi, a_p, e_p, gm_p)
-        - hamiltonian_octupole(a, e - de, dvarpi, a_p, e_p, gm_p))
+    let dh_de = (hamiltonian_quadrupole(a, e + de, a_p, e_p, gm_p)
+        - hamiltonian_quadrupole(a, e - de, a_p, e_p, gm_p))
         / (2.0 * de);
-    dh_de * de_dgamma(a, e)
+    (radians(dh_de * de_dgamma(a, e)) / days(1.0)).into()
 }
 
-/// OCTUPOLE apsidal precession rate as a typed [`AngularVelocity`] (the
-/// dimension-checked view of [`precession_rate_octupole`], rad/day).
+/// OCTUPOLE apsidal precession rate d(dvarpi)/dt as a typed [`AngularVelocity`]
+/// (rad/day) at apsidal angle `dvarpi`. Carries the dvarpi-dependence from the
+/// octupole term; equals the quadrupole rate plus an octupole modulation
+/// proportional to cos(dvarpi).
 pub fn precession_rate_octupole_typed(
     a: f64,
     e: f64,
@@ -79,23 +65,17 @@ pub fn precession_rate_octupole_typed(
     e_p: f64,
     gm_p: f64,
 ) -> AngularVelocity {
-    (radians(precession_rate_octupole(a, e, dvarpi, a_p, e_p, gm_p)) / days(1.0)).into()
-}
-
-/// Peak octupole modulation of the precession rate (radians/day): the
-/// amplitude of the dvarpi-dependent part. Equals
-/// C_oct e_p * de/dGamma (the e-derivative of +C_oct e e_p cos at the cos
-/// extremum has magnitude C_oct e_p), a clean closed form we can pin.
-pub fn octupole_modulation_amplitude(a: f64, e: f64, a_p: f64, e_p: f64, gm_p: f64) -> f64 {
-    let c_oct = octupole_coupling(a, a_p, e_p, gm_p);
-    // d/de [ +C_oct e e_p cos(dvarpi) ] = C_oct e_p cos(dvarpi); peak |.| at
-    // cos = +/-1 is C_oct e_p.
-    c_oct * e_p * de_dgamma(a, e)
+    let de = 1e-5;
+    let dh_de = (hamiltonian_octupole(a, e + de, dvarpi, a_p, e_p, gm_p)
+        - hamiltonian_octupole(a, e - de, dvarpi, a_p, e_p, gm_p))
+        / (2.0 * de);
+    (radians(dh_de * de_dgamma(a, e)) / days(1.0)).into()
 }
 
 /// Peak octupole modulation of the precession rate as a typed
-/// [`AngularVelocity`] (the dimension-checked view of
-/// [`octupole_modulation_amplitude`], rad/day).
+/// [`AngularVelocity`] (rad/day): the amplitude of the dvarpi-dependent part.
+/// Equals C_oct e_p * de/dGamma (the e-derivative of +C_oct e e_p cos at the cos
+/// extremum has magnitude C_oct e_p), a clean closed form we can pin.
 pub fn octupole_modulation_amplitude_typed(
     a: f64,
     e: f64,
@@ -103,7 +83,10 @@ pub fn octupole_modulation_amplitude_typed(
     e_p: f64,
     gm_p: f64,
 ) -> AngularVelocity {
-    (radians(octupole_modulation_amplitude(a, e, a_p, e_p, gm_p)) / days(1.0)).into()
+    let c_oct = octupole_coupling(a, a_p, e_p, gm_p);
+    // d/de [ +C_oct e e_p cos(dvarpi) ] = C_oct e_p cos(dvarpi); peak |.| at
+    // cos = +/-1 is C_oct e_p.
+    (radians(c_oct * e_p * de_dgamma(a, e)) / days(1.0)).into()
 }
 
 #[cfg(test)]
@@ -111,34 +94,48 @@ mod tests {
     use super::*;
     use p9_core::constants::{EARTH_MASS_SOLAR, GM_SUN};
     use std::f64::consts::PI;
-    use uom::si::angular_velocity::radian_per_second;
 
     fn gm_p9(mass_earth: f64) -> f64 {
         mass_earth * EARTH_MASS_SOLAR * GM_SUN
     }
 
+    /// Extract a precession rate in radians/day from a typed [`AngularVelocity`]
+    /// without depending on `uom`'s unit-constant module paths.
+    fn rad_per_day(w: AngularVelocity) -> f64 {
+        (w / (radians(1.0) / days(1.0))).value
+    }
+
     #[test]
-    fn typed_precession_rates_match_f64() {
+    fn typed_precession_rates_match_inline_formula() {
         use approx::assert_relative_eq;
-        // 1 day = 86400 s, so a rate in rad/day reads back as rate/86400 in
-        // rad/s through the typed AngularVelocity.
-        const SEC_PER_DAY: f64 = 86_400.0;
         let gm = gm_p9(10.0);
         let (a, e, a_p, e_p, dv) = (250.0, 0.3, 700.0, 0.6, 0.4);
+        let de = 1e-5;
 
+        let quad_inline = (hamiltonian_quadrupole(a, e + de, a_p, e_p, gm)
+            - hamiltonian_quadrupole(a, e - de, a_p, e_p, gm))
+            / (2.0 * de)
+            * de_dgamma(a, e);
         assert_relative_eq!(
-            precession_rate_quadrupole_typed(a, e, a_p, e_p, gm).get::<radian_per_second>(),
-            precession_rate_quadrupole(a, e, a_p, e_p, gm) / SEC_PER_DAY,
+            rad_per_day(precession_rate_quadrupole_typed(a, e, a_p, e_p, gm)),
+            quad_inline,
             max_relative = 1e-12
         );
+
+        let oct_inline = (hamiltonian_octupole(a, e + de, dv, a_p, e_p, gm)
+            - hamiltonian_octupole(a, e - de, dv, a_p, e_p, gm))
+            / (2.0 * de)
+            * de_dgamma(a, e);
         assert_relative_eq!(
-            precession_rate_octupole_typed(a, e, dv, a_p, e_p, gm).get::<radian_per_second>(),
-            precession_rate_octupole(a, e, dv, a_p, e_p, gm) / SEC_PER_DAY,
+            rad_per_day(precession_rate_octupole_typed(a, e, dv, a_p, e_p, gm)),
+            oct_inline,
             max_relative = 1e-12
         );
+
+        let amp_inline = octupole_coupling(a, a_p, e_p, gm) * e_p * de_dgamma(a, e);
         assert_relative_eq!(
-            octupole_modulation_amplitude_typed(a, e, a_p, e_p, gm).get::<radian_per_second>(),
-            octupole_modulation_amplitude(a, e, a_p, e_p, gm) / SEC_PER_DAY,
+            rad_per_day(octupole_modulation_amplitude_typed(a, e, a_p, e_p, gm)),
+            amp_inline,
             max_relative = 1e-12
         );
     }
@@ -149,9 +146,13 @@ mod tests {
         // the octupole rate reduces to it when e_p = 0 (octupole off) at any
         // dvarpi.
         let gm = gm_p9(10.0);
-        let q = precession_rate_quadrupole(250.0, 0.4, 700.0, 0.0, gm);
-        let o0 = precession_rate_octupole(250.0, 0.4, 0.0, 700.0, 0.0, gm);
-        let o1 = precession_rate_octupole(250.0, 0.4, PI, 700.0, 0.0, gm);
+        let q = rad_per_day(precession_rate_quadrupole_typed(250.0, 0.4, 700.0, 0.0, gm));
+        let o0 = rad_per_day(precession_rate_octupole_typed(
+            250.0, 0.4, 0.0, 700.0, 0.0, gm,
+        ));
+        let o1 = rad_per_day(precession_rate_octupole_typed(
+            250.0, 0.4, PI, 700.0, 0.0, gm,
+        ));
         assert!((q - o0).abs() < 1e-18);
         assert!((o0 - o1).abs() < 1e-18);
     }
@@ -162,8 +163,8 @@ mod tests {
         // depend on dvarpi: aligned (0) and anti-aligned (pi) rates differ.
         let gm = gm_p9(10.0);
         let (a, a_p, e_p, e) = (250.0, 700.0, 0.6, 0.3);
-        let r_aligned = precession_rate_octupole(a, e, 0.0, a_p, e_p, gm);
-        let r_anti = precession_rate_octupole(a, e, PI, a_p, e_p, gm);
+        let r_aligned = rad_per_day(precession_rate_octupole_typed(a, e, 0.0, a_p, e_p, gm));
+        let r_anti = rad_per_day(precession_rate_octupole_typed(a, e, PI, a_p, e_p, gm));
         assert!(
             (r_aligned - r_anti).abs() > 1e-12,
             "expected apsidal modulation, aligned {r_aligned:e} anti {r_anti:e}"
@@ -176,9 +177,9 @@ mod tests {
         // precession-rate spread (the cos goes +1 -> -1).
         let gm = gm_p9(10.0);
         let (a, a_p, e_p, e) = (250.0, 700.0, 0.6, 0.3);
-        let amp = octupole_modulation_amplitude(a, e, a_p, e_p, gm);
-        let r_aligned = precession_rate_octupole(a, e, 0.0, a_p, e_p, gm);
-        let r_anti = precession_rate_octupole(a, e, PI, a_p, e_p, gm);
+        let amp = rad_per_day(octupole_modulation_amplitude_typed(a, e, a_p, e_p, gm));
+        let r_aligned = rad_per_day(precession_rate_octupole_typed(a, e, 0.0, a_p, e_p, gm));
+        let r_anti = rad_per_day(precession_rate_octupole_typed(a, e, PI, a_p, e_p, gm));
         let half_spread = 0.5 * (r_aligned - r_anti).abs();
         let rel = ((amp - half_spread) / amp).abs();
         assert!(
@@ -192,8 +193,8 @@ mod tests {
         // Modulation amplitude scales with e_p (octupole strength).
         let gm = gm_p9(10.0);
         let (a, a_p, e) = (250.0, 700.0, 0.3);
-        let lo = octupole_modulation_amplitude(a, e, a_p, 0.3, gm);
-        let hi = octupole_modulation_amplitude(a, e, a_p, 0.6, gm);
+        let lo = rad_per_day(octupole_modulation_amplitude_typed(a, e, a_p, 0.3, gm));
+        let hi = rad_per_day(octupole_modulation_amplitude_typed(a, e, a_p, 0.6, gm));
         assert!(hi > lo, "modulation hi {hi:e} not > lo {lo:e}");
     }
 }

--- a/crates/p9-2021-des-catalog/Cargo.toml
+++ b/crates/p9-2021-des-catalog/Cargo.toml
@@ -9,7 +9,7 @@ rand = { workspace = true }
 rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2021-des-catalog/src/catalog.rs
+++ b/crates/p9-2021-des-catalog/src/catalog.rs
@@ -41,31 +41,6 @@ pub struct DesTno {
 }
 
 impl DesTno {
-    /// Perihelion distance q = a(1 − e) in AU.
-    pub fn perihelion(&self) -> f64 {
-        self.a * (1.0 - self.e)
-    }
-
-    /// Aphelion distance Q = a(1 + e) in AU.
-    pub fn aphelion(&self) -> f64 {
-        self.a * (1.0 + self.e)
-    }
-
-    /// Longitude of ascending node Ω (radians, wrapped to [0, 2π)).
-    pub fn node(&self) -> f64 {
-        (self.node_deg * DEG2RAD).rem_euclid(TWO_PI)
-    }
-
-    /// Argument of perihelion ω (radians, wrapped to [0, 2π)).
-    pub fn argp(&self) -> f64 {
-        (self.argp_deg * DEG2RAD).rem_euclid(TWO_PI)
-    }
-
-    /// Longitude of perihelion ϖ = ω + Ω (radians, wrapped to [0, 2π)).
-    pub fn varpi(&self) -> f64 {
-        ((self.argp_deg + self.node_deg) * DEG2RAD).rem_euclid(TWO_PI)
-    }
-
     // ---- typed boundary accessors (dimension-checked views of the f64 fields) ----
 
     /// Semi-major axis as a typed [`Length`].
@@ -75,12 +50,12 @@ impl DesTno {
 
     /// Perihelion distance q = a(1 − e) as a typed [`Length`].
     pub fn perihelion_typed(&self) -> Length {
-        au(self.perihelion())
+        au(self.a * (1.0 - self.e))
     }
 
     /// Aphelion distance Q = a(1 + e) as a typed [`Length`].
     pub fn aphelion_typed(&self) -> Length {
-        au(self.aphelion())
+        au(self.a * (1.0 + self.e))
     }
 
     /// Inclination as a typed [`units::Angle`].
@@ -88,19 +63,22 @@ impl DesTno {
         degrees(self.i_deg)
     }
 
-    /// Longitude of ascending node Ω as a typed [`units::Angle`].
+    /// Longitude of ascending node Ω as a typed [`units::Angle`]
+    /// (wrapped to [0, 2π)).
     pub fn node_typed(&self) -> units::Angle {
-        radians(self.node())
+        radians((self.node_deg * DEG2RAD).rem_euclid(TWO_PI))
     }
 
-    /// Argument of perihelion ω as a typed [`units::Angle`].
+    /// Argument of perihelion ω as a typed [`units::Angle`]
+    /// (wrapped to [0, 2π)).
     pub fn argp_typed(&self) -> units::Angle {
-        radians(self.argp())
+        radians((self.argp_deg * DEG2RAD).rem_euclid(TWO_PI))
     }
 
-    /// Longitude of perihelion ϖ as a typed [`units::Angle`].
+    /// Longitude of perihelion ϖ = ω + Ω as a typed [`units::Angle`]
+    /// (wrapped to [0, 2π)).
     pub fn varpi_typed(&self) -> units::Angle {
-        radians(self.varpi())
+        radians(((self.argp_deg + self.node_deg) * DEG2RAD).rem_euclid(TWO_PI))
     }
 }
 
@@ -207,11 +185,12 @@ impl Angle {
 
     /// Extract this angle (radians) from an object.
     pub fn of(&self, o: &DesTno) -> f64 {
-        match self {
-            Angle::Node => o.node(),
-            Angle::ArgPeri => o.argp(),
-            Angle::Varpi => o.varpi(),
-        }
+        let a = match self {
+            Angle::Node => o.node_typed(),
+            Angle::ArgPeri => o.argp_typed(),
+            Angle::Varpi => o.varpi_typed(),
+        };
+        (a / p9_core::units::radians(1.0)).value
     }
 }
 
@@ -228,12 +207,8 @@ mod tests {
     fn all_objects_are_extreme_tnos() {
         for o in &DES_EXTREME_TNOS {
             assert!(o.a > 150.0, "{}: a = {}", o.name, o.a);
-            assert!(
-                o.perihelion() > 30.0,
-                "{}: q = {:.1}",
-                o.name,
-                o.perihelion()
-            );
+            let q = (o.perihelion_typed() / au(1.0)).value;
+            assert!(q > 30.0, "{}: q = {:.1}", o.name, q);
         }
     }
 
@@ -245,7 +220,7 @@ mod tests {
     }
 
     #[test]
-    fn typed_accessors_match_f64() {
+    fn typed_accessors_match_formulas() {
         use approx::assert_relative_eq;
         use uom::si::angle::{degree, radian};
         use uom::si::length::astronomical_unit;
@@ -258,18 +233,30 @@ mod tests {
         );
         assert_relative_eq!(
             o.perihelion_typed().get::<astronomical_unit>(),
-            o.perihelion(),
+            o.a * (1.0 - o.e),
             epsilon = 1e-12
         );
         assert_relative_eq!(
             o.aphelion_typed().get::<astronomical_unit>(),
-            o.aphelion(),
+            o.a * (1.0 + o.e),
             epsilon = 1e-12
         );
         assert_relative_eq!(o.inclination().get::<degree>(), o.i_deg, epsilon = 1e-12);
-        assert_relative_eq!(o.node_typed().get::<radian>(), o.node(), epsilon = 1e-12);
-        assert_relative_eq!(o.argp_typed().get::<radian>(), o.argp(), epsilon = 1e-12);
-        assert_relative_eq!(o.varpi_typed().get::<radian>(), o.varpi(), epsilon = 1e-12);
+        assert_relative_eq!(
+            o.node_typed().get::<radian>(),
+            (o.node_deg * DEG2RAD).rem_euclid(TWO_PI),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            o.argp_typed().get::<radian>(),
+            (o.argp_deg * DEG2RAD).rem_euclid(TWO_PI),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            o.varpi_typed().get::<radian>(),
+            ((o.argp_deg + o.node_deg) * DEG2RAD).rem_euclid(TWO_PI),
+            epsilon = 1e-12
+        );
     }
 
     #[test]
@@ -279,7 +266,8 @@ mod tests {
             .iter()
             .find(|o| o.name == "2013 RA109")
             .unwrap();
-        let varpi_deg = o.varpi() * p9_core::constants::RAD2DEG;
+        let varpi_rad = (o.varpi_typed() / radians(1.0)).value;
+        let varpi_deg = varpi_rad * p9_core::constants::RAD2DEG;
         assert!((varpi_deg - 7.70).abs() < 0.05, "varpi = {varpi_deg:.2}");
     }
 }

--- a/crates/p9-2021-detached-inclinations/Cargo.toml
+++ b/crates/p9-2021-detached-inclinations/Cargo.toml
@@ -11,7 +11,7 @@ rand = { workspace = true }
 rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2021-detached-inclinations/src/forcing.rs
+++ b/crates/p9-2021-detached-inclinations/src/forcing.rs
@@ -50,7 +50,7 @@ use p9_core::units::{julian_year, radians, Angle, AngularVelocity};
 ///
 /// Returned as a positive magnitude (a precession *rate*); the forced-
 /// inclination ratio only depends on the relative strengths.
-pub fn giant_planet_frequency(a: f64, e: f64, i: f64) -> f64 {
+pub fn giant_planet_frequency_typed(a: f64, e: f64, i: f64) -> AngularVelocity {
     let n = (GM_SUN / (a * a * a)).sqrt(); // rad/day
     let eta_sq = (1.0 - e * e) * (1.0 - e * e);
     let sum: f64 = giant_planets_j2000()
@@ -61,13 +61,8 @@ pub fn giant_planet_frequency(a: f64, e: f64, i: f64) -> f64 {
         })
         .sum();
     let rate_day = 0.75 * n * i.cos() / eta_sq * sum;
-    (rate_day * 365.25).abs() // rad/yr
-}
-
-/// Giant-planet nodal precession frequency as a typed [`AngularVelocity`]
-/// (dimension-checked view of [`giant_planet_frequency`], rad/yr).
-pub fn giant_planet_frequency_typed(a: f64, e: f64, i: f64) -> AngularVelocity {
-    (radians(giant_planet_frequency(a, e, i)) / julian_year()).into()
+    let rate_yr = (rate_day * 365.25).abs(); // rad/yr
+    (radians(rate_yr) / julian_year()).into()
 }
 
 /// Planet Nine secular inclination-coupling frequency `B_p9` for a test
@@ -92,20 +87,14 @@ pub fn giant_planet_frequency_typed(a: f64, e: f64, i: f64) -> AngularVelocity {
 /// the coupling *strengthen with semi-major axis*, the central prediction. We
 /// cross-check this closed form against the p9-core quadrupole Hamiltonian's
 /// curvature in the unit tests.
-pub fn planet_nine_frequency(a: f64, p9: &P9Params) -> f64 {
+pub fn planet_nine_frequency_typed(a: f64, p9: &P9Params) -> AngularVelocity {
     let n = (GM_SUN / (a * a * a)).sqrt(); // rad/day
     let m9 = p9.mass_solar();
     let alpha = a / p9.a;
     let ecc_factor = (1.0 - p9.e * p9.e).powf(-1.5);
     let rate_day = 0.75 * n * m9 * alpha * alpha * ecc_factor;
-    rate_day * 365.25 // rad/yr
-}
-
-/// Planet Nine secular inclination-coupling frequency as a typed
-/// [`AngularVelocity`] (dimension-checked view of [`planet_nine_frequency`],
-/// rad/yr).
-pub fn planet_nine_frequency_typed(a: f64, p9: &P9Params) -> AngularVelocity {
-    (radians(planet_nine_frequency(a, p9)) / julian_year()).into()
+    let rate_yr = rate_day * 365.25; // rad/yr
+    (radians(rate_yr) / julian_year()).into()
 }
 
 /// Curvature of the p9-core quadrupole Hamiltonian in inclination at I = 0,
@@ -131,19 +120,17 @@ pub fn quadrupole_inclination_curvature(a: f64, e: f64, p9: &P9Params) -> f64 {
 /// the invariable plane. As Planet Nine's mass or inclination grows, or as the
 /// particle's semi-major axis grows (stronger α² coupling), the forced plane
 /// tilts further toward Planet Nine's plane.
-pub fn forced_inclination(a: f64, e: f64, i: f64, p9: &P9Params) -> f64 {
-    let b_gp = giant_planet_frequency(a, e, i);
-    let b_p9 = planet_nine_frequency(a, p9);
-    if b_gp + b_p9 <= 0.0 {
-        return 0.0;
-    }
-    b_p9 / (b_gp + b_p9) * p9.i
-}
-
-/// Forced inclination as a typed [`Angle`] (dimension-checked view of
-/// [`forced_inclination`]).
 pub fn forced_inclination_typed(a: f64, e: f64, i: f64, p9: &P9Params) -> Angle {
-    radians(forced_inclination(a, e, i, p9))
+    let b_gp = giant_planet_frequency_typed(a, e, i);
+    let b_p9 = planet_nine_frequency_typed(a, p9);
+    // Extract rad/yr magnitudes via the version-safe units pattern.
+    let per_yr = radians(1.0) / julian_year();
+    let b_gp_yr = (b_gp / per_yr).value;
+    let b_p9_yr = (b_p9 / per_yr).value;
+    if b_gp_yr + b_p9_yr <= 0.0 {
+        return radians(0.0);
+    }
+    radians(b_p9_yr / (b_gp_yr + b_p9_yr)) * p9.i
 }
 
 /// Forced inclination in the Planet-Nine-free Solar System: identically zero
@@ -161,8 +148,19 @@ mod tests {
         P9Params::nominal_2016() // 10 M⊕, a = 700, e = 0.6, i = 30°
     }
 
+    /// Planet Nine coupling frequency in rad/yr (version-safe extraction).
+    fn p9_freq_yr(a: f64, p9: &P9Params) -> f64 {
+        let per_yr = radians(1.0) / julian_year();
+        (planet_nine_frequency_typed(a, p9) / per_yr).value
+    }
+
+    /// Forced inclination in radians (version-safe extraction).
+    fn forced_rad(a: f64, e: f64, i: f64, p9: &P9Params) -> f64 {
+        (forced_inclination_typed(a, e, i, p9) / radians(1.0)).value
+    }
+
     #[test]
-    fn typed_forcing_accessors_match_f64() {
+    fn typed_forcing_accessors_match_inline() {
         use approx::assert_relative_eq;
         use uom::si::angle::radian;
         use uom::si::angular_velocity::radian_per_second;
@@ -172,19 +170,40 @@ mod tests {
         let p9 = nominal();
         let (a, e, i) = (300.0, 0.5, 10.0 * DEG2RAD);
 
+        // Inline the forced-inclination formula from the typed components.
+        let b_gp_yr = giant_planet_frequency_typed(a, e, i).get::<radian_per_second>() * yr_s;
+        let b_p9_yr = planet_nine_frequency_typed(a, &p9).get::<radian_per_second>() * yr_s;
+        let forced = b_p9_yr / (b_gp_yr + b_p9_yr) * p9.i;
         assert_relative_eq!(
             forced_inclination_typed(a, e, i, &p9).get::<radian>(),
-            forced_inclination(a, e, i, &p9),
+            forced,
             epsilon = 1e-12
         );
+
+        // Inline B_gp closed form: (3/4) n cos i /(1−e²)² Σ_j (m_j/M_⊙)(a_j/a)².
+        let n = (GM_SUN / (a * a * a)).sqrt();
+        let eta_sq = (1.0 - e * e) * (1.0 - e * e);
+        let sum: f64 = giant_planets_j2000()
+            .iter()
+            .map(|body| {
+                let a_j = cartesian_to_elements(&body.state, GM_SUN).a;
+                body.mass * (a_j / a).powi(2)
+            })
+            .sum();
+        let b_gp_inline = (0.75 * n * i.cos() / eta_sq * sum * 365.25).abs();
         assert_relative_eq!(
             giant_planet_frequency_typed(a, e, i).get::<radian_per_second>(),
-            giant_planet_frequency(a, e, i) / yr_s,
+            b_gp_inline / yr_s,
             max_relative = 1e-12
         );
+
+        // Inline B_p9 closed form: (3/4) n (m₉/M_⊙) (a/a₉)² /(1−e₉²)^{3/2}.
+        let alpha = a / p9.a;
+        let b_p9_inline =
+            0.75 * n * p9.mass_solar() * alpha * alpha * (1.0 - p9.e * p9.e).powf(-1.5) * 365.25;
         assert_relative_eq!(
             planet_nine_frequency_typed(a, &p9).get::<radian_per_second>(),
-            planet_nine_frequency(a, &p9) / yr_s,
+            b_p9_inline / yr_s,
             max_relative = 1e-12
         );
     }
@@ -193,8 +212,8 @@ mod tests {
     fn test_p9_frequency_scales_as_alpha_squared() {
         // Coupling ∝ (a/a₉)²: doubling a quadruples B_p9 (× the n ∝ a^{-3/2}).
         let p9 = nominal();
-        let b1 = planet_nine_frequency(250.0, &p9);
-        let b2 = planet_nine_frequency(500.0, &p9);
+        let b1 = p9_freq_yr(250.0, &p9);
+        let b2 = p9_freq_yr(500.0, &p9);
         // B_p9 ∝ a^{-3/2} · a² = a^{1/2}; ratio = sqrt(2) ≈ 1.414.
         let ratio = b2 / b1;
         assert!(
@@ -214,7 +233,7 @@ mod tests {
             mass_earth: 10.0,
             ..nominal()
         };
-        let ratio = planet_nine_frequency(300.0, &heavy) / planet_nine_frequency(300.0, &light);
+        let ratio = p9_freq_yr(300.0, &heavy) / p9_freq_yr(300.0, &light);
         assert!((ratio - 2.0).abs() < 1e-9, "mass scaling = {ratio:.4}");
     }
 
@@ -239,7 +258,7 @@ mod tests {
         // 1/(1−e₉²)^{3/2} perturber-eccentricity scaling, shared with B_p9.
         let eobs = quadrupole_inclination_curvature(300.0, 0.4, &base)
             / quadrupole_inclination_curvature(300.0, 0.4, &ecc);
-        let bobs = planet_nine_frequency(300.0, &base) / planet_nine_frequency(300.0, &ecc);
+        let bobs = p9_freq_yr(300.0, &base) / p9_freq_yr(300.0, &ecc);
         let expected = (1.0 - ecc.e * ecc.e).powf(1.5) / (1.0 - base.e * base.e).powf(1.5);
         assert!(
             (eobs - expected).abs() < 0.02 && (bobs - expected).abs() < 0.02,
@@ -262,8 +281,8 @@ mod tests {
             mass_earth: 15.0,
             ..nominal()
         };
-        let fl = forced_inclination(400.0, 0.7, 10.0 * DEG2RAD, &light);
-        let fh = forced_inclination(400.0, 0.7, 10.0 * DEG2RAD, &heavy);
+        let fl = forced_rad(400.0, 0.7, 10.0 * DEG2RAD, &light);
+        let fh = forced_rad(400.0, 0.7, 10.0 * DEG2RAD, &heavy);
         assert!(fh > fl, "forced i should grow with mass: {fl} vs {fh}");
     }
 
@@ -277,8 +296,8 @@ mod tests {
             i: 30.0 * DEG2RAD,
             ..nominal()
         };
-        let fl = forced_inclination(400.0, 0.7, 10.0 * DEG2RAD, &low);
-        let fh = forced_inclination(400.0, 0.7, 10.0 * DEG2RAD, &high);
+        let fl = forced_rad(400.0, 0.7, 10.0 * DEG2RAD, &low);
+        let fh = forced_rad(400.0, 0.7, 10.0 * DEG2RAD, &high);
         assert!(fh > fl, "forced i should grow with i9: {fl} vs {fh}");
         // Approximately linear in i9 at fixed coupling fraction.
         let ratio = fh / fl;
@@ -291,8 +310,8 @@ mod tests {
     #[test]
     fn test_forced_inclination_strengthens_with_semimajor_axis() {
         let p9 = nominal();
-        let inner = forced_inclination(250.0, 0.7, 10.0 * DEG2RAD, &p9);
-        let outer = forced_inclination(450.0, 0.7, 10.0 * DEG2RAD, &p9);
+        let inner = forced_rad(250.0, 0.7, 10.0 * DEG2RAD, &p9);
+        let outer = forced_rad(450.0, 0.7, 10.0 * DEG2RAD, &p9);
         assert!(
             outer > inner,
             "forced i should strengthen with a: {inner} (250) vs {outer} (450)"
@@ -303,7 +322,7 @@ mod tests {
     fn test_forced_inclination_bounded_by_i9() {
         // The forced plane never over-tilts past Planet Nine's own plane.
         let p9 = nominal();
-        let f = forced_inclination(500.0, 0.8, 5.0 * DEG2RAD, &p9);
+        let f = forced_rad(500.0, 0.8, 5.0 * DEG2RAD, &p9);
         assert!(f >= 0.0 && f <= p9.i, "forced i = {f} out of [0, i9]");
     }
 }

--- a/crates/p9-2021-detached-inclinations/src/lib.rs
+++ b/crates/p9-2021-detached-inclinations/src/lib.rs
@@ -125,15 +125,19 @@ mod tests {
         let p9 = nominal_inclined_p9();
         let a_mid = 0.5 * (cfg.a_min + cfg.a_max);
 
+        use p9_core::units::radians;
+        let forced_rad = |p: &DetachedParticle| {
+            (forcing::forced_inclination_typed(p.a, p.e, p.i_free, &p9) / radians(1.0)).value
+        };
         let inner: Vec<f64> = pop
             .iter()
             .filter(|p| p.a < a_mid)
-            .map(|p| forcing::forced_inclination(p.a, p.e, p.i_free, &p9))
+            .map(|p| forced_rad(p))
             .collect();
         let outer: Vec<f64> = pop
             .iter()
             .filter(|p| p.a >= a_mid)
-            .map(|p| forcing::forced_inclination(p.a, p.e, p.i_free, &p9))
+            .map(|p| forced_rad(p))
             .collect();
 
         let mean_inner = mean(&inner) * RAD2DEG;

--- a/crates/p9-2021-detached-inclinations/src/population.rs
+++ b/crates/p9-2021-detached-inclinations/src/population.rs
@@ -35,7 +35,7 @@ use rand::Rng;
 use rand::SeedableRng;
 use rand_distr::{Distribution, Uniform};
 
-use crate::forcing::forced_inclination;
+use crate::forcing::forced_inclination_typed;
 
 /// A single detached test particle.
 #[derive(Debug, Clone, Copy)]
@@ -51,34 +51,23 @@ pub struct DetachedParticle {
 }
 
 impl DetachedParticle {
-    /// Perihelion distance q = a(1 − e) (AU).
-    pub fn perihelion(&self) -> f64 {
-        self.a * (1.0 - self.e)
-    }
-
-    /// Observed inclination to the invariable plane (rad) given a forced
-    /// inclination `i_forced`: the spherical combination of the free
-    /// inclination on a cone about the forced pole at this precession phase.
-    pub fn observed_inclination(&self, i_forced: f64) -> f64 {
-        let cos_i = i_forced.cos() * self.i_free.cos()
-            + i_forced.sin() * self.i_free.sin() * self.phase.cos();
-        cos_i.clamp(-1.0, 1.0).acos()
-    }
-
     /// Semi-major axis as a typed [`Length`].
     pub fn semi_major_axis(&self) -> Length {
         au(self.a)
     }
 
-    /// Perihelion distance as a typed [`Length`].
+    /// Perihelion distance q = a(1 − e) as a typed [`Length`].
     pub fn perihelion_typed(&self) -> Length {
-        au(self.perihelion())
+        au(self.a * (1.0 - self.e))
     }
 
-    /// Observed inclination as a typed [`Angle`] (dimension-checked view of
-    /// [`observed_inclination`](Self::observed_inclination)).
+    /// Observed inclination to the invariable plane as a typed [`Angle`] given a
+    /// forced inclination `i_forced`: the spherical combination of the free
+    /// inclination on a cone about the forced pole at this precession phase.
     pub fn observed_inclination_typed(&self, i_forced: f64) -> Angle {
-        radians(self.observed_inclination(i_forced))
+        let cos_i = i_forced.cos() * self.i_free.cos()
+            + i_forced.sin() * self.i_free.sin() * self.phase.cos();
+        radians(cos_i.clamp(-1.0, 1.0).acos())
     }
 }
 
@@ -154,8 +143,8 @@ pub fn build_population(cfg: &PopulationConfig) -> Vec<DetachedParticle> {
 pub fn observed_inclinations(pop: &[DetachedParticle], p9: &P9Params) -> Vec<f64> {
     pop.iter()
         .map(|p| {
-            let i_forced = forced_inclination(p.a, p.e, p.i_free, p9);
-            p.observed_inclination(i_forced)
+            let i_forced = (forced_inclination_typed(p.a, p.e, p.i_free, p9) / radians(1.0)).value;
+            (p.observed_inclination_typed(i_forced) / radians(1.0)).value
         })
         .collect()
 }
@@ -198,7 +187,7 @@ pub fn fraction_above(values: &[f64], threshold: f64) -> f64 {
 pub fn mean_forced_inclination(pop: &[DetachedParticle], p9: &P9Params) -> f64 {
     let forced: Vec<f64> = pop
         .iter()
-        .map(|p| forced_inclination(p.a, p.e, p.i_free, p9))
+        .map(|p| (forced_inclination_typed(p.a, p.e, p.i_free, p9) / radians(1.0)).value)
         .collect();
     mean(&forced)
 }
@@ -213,7 +202,7 @@ mod tests {
     }
 
     #[test]
-    fn typed_particle_accessors_match_f64() {
+    fn typed_particle_accessors_match_inline() {
         use approx::assert_relative_eq;
         use uom::si::angle::radian;
         use uom::si::length::astronomical_unit;
@@ -230,12 +219,15 @@ mod tests {
         );
         assert_relative_eq!(
             p.perihelion_typed().get::<astronomical_unit>(),
-            p.perihelion(),
+            p.a * (1.0 - p.e),
             epsilon = 1e-12
         );
+        let i_forced = 0.3_f64;
+        let cos_i =
+            i_forced.cos() * p.i_free.cos() + i_forced.sin() * p.i_free.sin() * p.phase.cos();
         assert_relative_eq!(
-            p.observed_inclination_typed(0.3).get::<radian>(),
-            p.observed_inclination(0.3),
+            p.observed_inclination_typed(i_forced).get::<radian>(),
+            cos_i.clamp(-1.0, 1.0).acos(),
             epsilon = 1e-12
         );
     }
@@ -246,7 +238,9 @@ mod tests {
         let pop = build_population(&cfg);
         assert_eq!(pop.len(), cfg.n);
         for p in &pop {
-            assert!(p.perihelion() >= cfg.q_min - 1e-9, "q = {}", p.perihelion());
+            use uom::si::length::astronomical_unit;
+            let q = p.perihelion_typed().get::<astronomical_unit>();
+            assert!(q >= cfg.q_min - 1e-9, "q = {q}");
             assert!(p.a >= cfg.a_min && p.a <= cfg.a_max);
             assert!((0.0..1.0).contains(&p.e));
         }

--- a/crates/p9-2021-oort-cloud/Cargo.toml
+++ b/crates/p9-2021-oort-cloud/Cargo.toml
@@ -11,6 +11,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 approx = { workspace = true }
 nalgebra.workspace = true
-
-[dev-dependencies]
 uom = "0.38.0"

--- a/crates/p9-2021-oort-cloud/src/injection_simulation.rs
+++ b/crates/p9-2021-oort-cloud/src/injection_simulation.rs
@@ -34,6 +34,7 @@ use p9_core::constants::*;
 use p9_core::forces::ExtraForce;
 use p9_core::types::{cartesian_to_elements, OrbitalElements, P9Params};
 use p9_core::units::{au, days, julian_year, Length, Time};
+use uom::si::length::astronomical_unit;
 
 use crate::oort_cloud::{generate_ioc_population, generate_scattered_disk, OortCloudConfig};
 
@@ -190,7 +191,10 @@ pub fn evolve_population(
 
     let mut elements: Vec<OrbitalElements> = initial.to_vec();
     let mut active = vec![true; initial.len()];
-    let mut min_q: Vec<f64> = initial.iter().map(|e| e.perihelion()).collect();
+    let mut min_q: Vec<f64> = initial
+        .iter()
+        .map(|e| e.perihelion_typed().get::<astronomical_unit>())
+        .collect();
 
     if let Some(ring) = &ring {
         // Second-order leapfrog: drift(dt/2) – kick(dt) – drift(dt/2);
@@ -211,8 +215,8 @@ pub fn evolve_population(
                     active[k] = false;
                     continue;
                 }
-                min_q[k] = min_q[k].min(new_elem.perihelion());
-                if new_elem.perihelion() < Q_REMOVAL_AU {
+                min_q[k] = min_q[k].min(new_elem.perihelion_typed().get::<astronomical_unit>());
+                if new_elem.perihelion_typed().get::<astronomical_unit>() < Q_REMOVAL_AU {
                     active[k] = false;
                     continue;
                 }
@@ -319,7 +323,11 @@ pub fn simulate_injection<R: Rng>(config: &InjectionConfig, rng: &mut R) -> Inje
     let mut injected_sma = Vec::new();
     let mut injected_dvarpi = Vec::new();
     for outcome in &ioc_run {
-        let started_above = outcome.initial.perihelion() > config.q_injection_threshold;
+        let started_above = outcome
+            .initial
+            .perihelion_typed()
+            .get::<astronomical_unit>()
+            > config.q_injection_threshold;
         let crossed = outcome.min_q < config.q_injection_threshold;
         let distant = outcome.initial.a > config.a_dkb_min;
         if started_above && crossed && distant {
@@ -332,7 +340,10 @@ pub fn simulate_injection<R: Rng>(config: &InjectionConfig, rng: &mut R) -> Inje
 
     let n_injectable = ioc_pop
         .iter()
-        .filter(|e| e.perihelion() > config.q_injection_threshold && e.a > config.a_dkb_min)
+        .filter(|e| {
+            e.perihelion_typed().get::<astronomical_unit>() > config.q_injection_threshold
+                && e.a > config.a_dkb_min
+        })
         .count()
         .max(1);
 

--- a/crates/p9-2021-oort-cloud/src/oort_cloud.rs
+++ b/crates/p9-2021-oort-cloud/src/oort_cloud.rs
@@ -314,7 +314,7 @@ mod tests {
                 "a = {} out of range",
                 elem.a
             );
-            let q = elem.perihelion();
+            let q = elem.perihelion_typed().get::<astronomical_unit>();
             assert!(
                 q >= config.q_min * 0.99 && q <= config.q_max * 1.01,
                 "q = {} out of range [{}, {}]",
@@ -334,7 +334,7 @@ mod tests {
         assert_eq!(pop.len(), 200);
         for e in &pop {
             assert!(e.a >= 250.0 && e.a <= 550.0);
-            let q = e.perihelion();
+            let q = e.perihelion_typed().get::<astronomical_unit>();
             assert!(q >= 29.9 && q <= 50.1, "q = {q}");
             assert!(e.e > 0.0 && e.e < 1.0);
         }

--- a/crates/p9-2021-perihelion-gap/Cargo.toml
+++ b/crates/p9-2021-perihelion-gap/Cargo.toml
@@ -9,7 +9,7 @@ rand = { workspace = true }
 rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2021-perihelion-gap/src/sample.rs
+++ b/crates/p9-2021-perihelion-gap/src/sample.rs
@@ -39,11 +39,6 @@ pub struct DistantTno {
 }
 
 impl DistantTno {
-    /// Perihelion distance q = a(1 − e) in AU.
-    pub fn perihelion(&self) -> f64 {
-        self.a * (1.0 - self.e)
-    }
-
     /// Semi-major axis as a dimension-checked [`Length`].
     pub fn semi_major_axis(&self) -> Length {
         au(self.a)
@@ -51,7 +46,7 @@ impl DistantTno {
 
     /// Perihelion distance q = a(1 − e) as a dimension-checked [`Length`].
     pub fn perihelion_typed(&self) -> Length {
-        au(self.perihelion())
+        au(self.a * (1.0 - self.e))
     }
 }
 
@@ -137,7 +132,11 @@ pub fn observed_perihelia() -> Vec<f64> {
     BROWN_2017_SAMPLE
         .iter()
         .map(|k| k.perihelion())
-        .chain(EXTENDED_DISTANT_TNOS.iter().map(|t| t.perihelion()))
+        .chain(
+            EXTENDED_DISTANT_TNOS
+                .iter()
+                .map(|t| (t.perihelion_typed() / au(1.0)).value),
+        )
         .collect()
 }
 
@@ -147,7 +146,11 @@ pub fn observed_perihelia_with_e() -> Vec<(f64, f64)> {
     BROWN_2017_SAMPLE
         .iter()
         .map(|k| (k.perihelion(), k.e))
-        .chain(EXTENDED_DISTANT_TNOS.iter().map(|t| (t.perihelion(), t.e)))
+        .chain(
+            EXTENDED_DISTANT_TNOS
+                .iter()
+                .map(|t| ((t.perihelion_typed() / au(1.0)).value, t.e)),
+        )
         .collect()
 }
 
@@ -182,7 +185,7 @@ mod tests {
         );
         assert_relative_eq!(
             t.perihelion_typed().get::<astronomical_unit>(),
-            t.perihelion(),
+            t.a * (1.0 - t.e),
             epsilon = 1e-9
         );
     }
@@ -204,12 +207,8 @@ mod tests {
             assert!(t.a >= 150.0, "{}: a = {}", t.name, t.a);
             assert!(t.e > 0.5 && t.e < 1.0, "{}: e = {}", t.name, t.e);
             // All in the distant trans-Neptunian q range.
-            assert!(
-                t.perihelion() > 30.0 && t.perihelion() < 120.0,
-                "{}: q = {:.1}",
-                t.name,
-                t.perihelion()
-            );
+            let q = t.perihelion_typed().get::<astronomical_unit>();
+            assert!(q > 30.0 && q < 120.0, "{}: q = {:.1}", t.name, q);
         }
     }
 

--- a/crates/p9-2022-uranus-tilt/Cargo.toml
+++ b/crates/p9-2022-uranus-tilt/Cargo.toml
@@ -9,7 +9,7 @@ p9-core = { path = "../p9-core" }
 nalgebra = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2022-uranus-tilt/src/lib.rs
+++ b/crates/p9-2022-uranus-tilt/src/lib.rs
@@ -26,16 +26,10 @@ pub mod cassini;
 pub mod resonance_capture;
 pub mod spin_axis;
 
-use p9_core::constants::DEG2RAD;
 use p9_core::units::{degrees, Angle};
 
 /// Uranus' observed obliquity (deg). IAU value; the paper's target is 98°.
 pub const URANUS_OBLIQUITY_DEG: f64 = 97.77;
-
-/// Uranus' observed obliquity (rad).
-pub fn uranus_obliquity_rad() -> f64 {
-    URANUS_OBLIQUITY_DEG * DEG2RAD
-}
 
 /// Uranus' observed obliquity as a typed [`Angle`].
 pub fn uranus_obliquity() -> Angle {
@@ -46,19 +40,20 @@ pub fn uranus_obliquity() -> Angle {
 mod typed_tests {
     use super::*;
     use approx::assert_relative_eq;
+    use p9_core::constants::DEG2RAD;
     use uom::si::angle::radian;
 
     #[test]
     fn obliquity_typed_matches_rad() {
         assert_relative_eq!(
             uranus_obliquity().get::<radian>(),
-            uranus_obliquity_rad(),
+            URANUS_OBLIQUITY_DEG * DEG2RAD,
             epsilon = 1e-12
         );
     }
 }
 
 /// Lu & Laughlin (2022) headline spin-axis precession constant for Uranus
-/// today (arcsec/yr). Reference label only; [`spin_axis::alpha_arcsec_per_yr`]
+/// today (arcsec/yr). Reference label only; [`spin_axis::alpha_typed`]
 /// computes it.
 pub const ALPHA_PRESENT_ARCSEC_PER_YR: f64 = 0.045;

--- a/crates/p9-2022-uranus-tilt/src/resonance_capture.rs
+++ b/crates/p9-2022-uranus-tilt/src/resonance_capture.rs
@@ -282,8 +282,9 @@ pub fn fixed_band_sweep(alpha_arcsec: f64) -> SweepConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::spin_axis::alpha_arcsec_per_yr;
+    use crate::spin_axis::alpha_typed;
     use p9_core::constants::RAD2DEG;
+    use p9_core::units::{arcseconds, julian_year};
 
     fn deg(theta: f64) -> f64 {
         theta * RAD2DEG
@@ -424,7 +425,7 @@ mod tests {
         // is ~100× too slow. Across the same P9-set |g| band it reaches the
         // resonance only weakly and falls well short of 90°, whereas a ~100×
         // enhanced α drives the spin near 90°.
-        let alpha_now = alpha_arcsec_per_yr(); // ≈0.045
+        let alpha_now = (alpha_typed() / (arcseconds(1.0) / julian_year())).value; // ≈0.045
         let weak = fixed_band_sweep(alpha_now);
         let strong = fixed_band_sweep(5.0);
         let theta_weak = deg(final_obliquity(&run_sweep(&weak, weak.t_total / 50.0)));

--- a/crates/p9-2022-uranus-tilt/src/spin_axis.rs
+++ b/crates/p9-2022-uranus-tilt/src/spin_axis.rs
@@ -124,30 +124,23 @@ pub fn satellite_l(
         / denom
 }
 
-/// The full spin-axis precession constant α (rad/yr) for Uranus today
-/// (Eq. 2). `cos θ` is folded in: α as defined is the precession-constant
-/// prefactor; the precession rate is α cos θ. Here we return the bare α.
-pub fn alpha_rad_per_yr() -> f64 {
+/// The full spin-axis precession constant α for Uranus today as a typed
+/// [`AngularVelocity`] (arcsec per Julian year). `cos θ` is folded in: α as
+/// defined is the precession-constant prefactor; the precession rate is
+/// α cos θ. Here we return the bare α (Eq. 2).
+pub fn alpha_typed() -> AngularVelocity {
     let n = mean_motion_rad_per_yr(URANUS_A_AU);
     let omega = spin_frequency_rad_per_yr(URANUS_SPIN_PERIOD_HR);
     let q = satellite_q(&URANUS_MOONS, URANUS_MASS_KG, URANUS_RADIUS_KM);
     let l = satellite_l(&URANUS_MOONS, URANUS_MASS_KG, URANUS_RADIUS_KM, omega);
-    (3.0 * n * n / (2.0 * omega)) * (J2_URANUS + q) / (URANUS_LAMBDA + l)
-}
-
-/// α in arcsec/yr (the paper's units).
-pub fn alpha_arcsec_per_yr() -> f64 {
-    alpha_rad_per_yr() * RAD2DEG * 3600.0
-}
-
-/// α as a typed [`AngularVelocity`] (arcsec per Julian year).
-pub fn alpha_typed() -> AngularVelocity {
-    (arcseconds(alpha_arcsec_per_yr()) / julian_year()).into()
+    let alpha_rad_per_yr = (3.0 * n * n / (2.0 * omega)) * (J2_URANUS + q) / (URANUS_LAMBDA + l);
+    (arcseconds(alpha_rad_per_yr * RAD2DEG * 3600.0) / julian_year()).into()
 }
 
 /// Spin-axis precession period Tα = 2π / (α cos θ) in Myr at obliquity θ.
 pub fn precession_period_myr(theta_rad: f64) -> f64 {
-    let rate = alpha_rad_per_yr() * theta_rad.cos().abs();
+    let alpha_rad_per_yr = (alpha_typed() / (p9_core::units::radians(1.0) / julian_year())).value;
+    let rate = alpha_rad_per_yr * theta_rad.cos().abs();
     (2.0 * PI / rate) / 1.0e6
 }
 
@@ -172,9 +165,15 @@ mod tests {
             moon.a_km,
             epsilon = 1e-9
         );
-        // α typed (arcsec/yr) read back in rad/s matches the f64 source.
+        // α typed (arcsec/yr) read back in rad/s matches the inline formula.
         let alpha_rad_s = alpha_typed().get::<radian_per_second>();
-        let expect = alpha_rad_per_yr() / (365.25 * 86_400.0);
+        let n = mean_motion_rad_per_yr(URANUS_A_AU);
+        let omega = spin_frequency_rad_per_yr(URANUS_SPIN_PERIOD_HR);
+        let q = satellite_q(&URANUS_MOONS, URANUS_MASS_KG, URANUS_RADIUS_KM);
+        let l = satellite_l(&URANUS_MOONS, URANUS_MASS_KG, URANUS_RADIUS_KM, omega);
+        let alpha_rad_per_yr =
+            (3.0 * n * n / (2.0 * omega)) * (J2_URANUS + q) / (URANUS_LAMBDA + l);
+        let expect = alpha_rad_per_yr / (365.25 * 86_400.0);
         assert_relative_eq!(alpha_rad_s, expect, max_relative = 1e-9);
     }
 
@@ -213,7 +212,7 @@ mod tests {
     #[test]
     fn alpha_matches_paper_present_value() {
         // HEADLINE PIN: Lu & Laughlin (2022) quote α ≈ 0.045 arcsec/yr today.
-        let alpha = alpha_arcsec_per_yr();
+        let alpha = (alpha_typed() / (arcseconds(1.0) / julian_year())).value;
         assert!(
             (0.030..0.070).contains(&alpha),
             "α = {alpha:.4} arcsec/yr; paper quotes ≈0.045"
@@ -227,7 +226,8 @@ mod tests {
         // Paper: Tα ≈ 169 Myr at the present 98° obliquity. cos(98°) is small,
         // so the precession about the orbit normal is slow; we land within a
         // factor of a few — see crate-level note on residuals.
-        let t = precession_period_myr(crate::uranus_obliquity_rad());
+        use uom::si::angle::radian;
+        let t = precession_period_myr(crate::uranus_obliquity().get::<radian>());
         assert!(t > 50.0 && t < 2000.0, "Tα = {t:.1} Myr (paper ~169)");
     }
 }

--- a/crates/p9-2023-mond-efe/Cargo.toml
+++ b/crates/p9-2023-mond-efe/Cargo.toml
@@ -9,7 +9,7 @@ p9-core = { path = "../p9-core" }
 nalgebra = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2023-mond-efe/src/efe.rs
+++ b/crates/p9-2023-mond-efe/src/efe.rs
@@ -59,28 +59,21 @@ pub fn galactic_center_ecliptic() -> Vector3<f64> {
     sky::ecliptic_to_galactic_matrix().row(0).transpose()
 }
 
-/// Ecliptic longitude (degrees, in [0, 360)) of the galactic-center direction.
-pub fn galactic_center_ecliptic_lon_deg() -> f64 {
-    let n = galactic_center_ecliptic();
-    n.y.atan2(n.x)
-        .rem_euclid(std::f64::consts::TAU)
-        .to_degrees()
-}
-
-/// Ecliptic latitude (degrees) of the galactic-center direction.
-pub fn galactic_center_ecliptic_lat_deg() -> f64 {
-    let n = galactic_center_ecliptic();
-    (n.z / n.norm()).asin().to_degrees()
-}
-
-/// Ecliptic longitude of the galactic-center direction as a typed [`Angle`].
+/// Ecliptic longitude (in [0, 360)) of the galactic-center direction as a typed
+/// [`Angle`].
 pub fn galactic_center_ecliptic_lon() -> Angle {
-    degrees(galactic_center_ecliptic_lon_deg())
+    let n = galactic_center_ecliptic();
+    degrees(
+        n.y.atan2(n.x)
+            .rem_euclid(std::f64::consts::TAU)
+            .to_degrees(),
+    )
 }
 
 /// Ecliptic latitude of the galactic-center direction as a typed [`Angle`].
 pub fn galactic_center_ecliptic_lat() -> Angle {
-    degrees(galactic_center_ecliptic_lat_deg())
+    let n = galactic_center_ecliptic();
+    degrees((n.z / n.norm()).asin().to_degrees())
 }
 
 /// EFE quadrupole perturbing potential per unit mass (AU²/day²) at a
@@ -112,16 +105,22 @@ mod tests {
     use p9_core::coords::sky;
 
     #[test]
-    fn typed_galactic_center_angles_match_f64() {
+    fn typed_galactic_center_angles_match_formula() {
         use uom::si::angle::degree;
+        let n = galactic_center_ecliptic();
+        let lon_deg =
+            n.y.atan2(n.x)
+                .rem_euclid(std::f64::consts::TAU)
+                .to_degrees();
+        let lat_deg = (n.z / n.norm()).asin().to_degrees();
         assert_relative_eq!(
             galactic_center_ecliptic_lon().get::<degree>(),
-            galactic_center_ecliptic_lon_deg(),
+            lon_deg,
             epsilon = 1e-12
         );
         assert_relative_eq!(
             galactic_center_ecliptic_lat().get::<degree>(),
-            galactic_center_ecliptic_lat_deg(),
+            lat_deg,
             epsilon = 1e-12
         );
     }
@@ -139,11 +138,12 @@ mod tests {
 
     #[test]
     fn test_galactic_center_ecliptic_longitude_matches_reference() {
+        use uom::si::angle::degree;
         // Sgr A* lies near ecliptic longitude ~267°; pin the computed value.
-        let lon = galactic_center_ecliptic_lon_deg();
+        let lon = galactic_center_ecliptic_lon().get::<degree>();
         assert_relative_eq!(lon, GALACTIC_CENTER_ECLIPTIC_LON_DEG_REF, epsilon = 1.0);
         // Galactic center is well south of the ecliptic (β ≈ −5.5°).
-        assert!(galactic_center_ecliptic_lat_deg() < 0.0);
+        assert!(galactic_center_ecliptic_lat().get::<degree>() < 0.0);
     }
 
     #[test]

--- a/crates/p9-2023-mond-efe/src/secular.rs
+++ b/crates/p9-2023-mond-efe/src/secular.rs
@@ -108,14 +108,10 @@ pub fn averaged_disturbing(
     -sum / wsum
 }
 
-/// Mean motion n = sqrt(GM_sun / a³) (rad/day).
-pub fn mean_motion(a: f64) -> f64 {
-    (GM_SUN / (a * a * a)).sqrt()
-}
-
-/// Mean motion as a typed [`AngularVelocity`] (rad per day).
+/// Mean motion n = sqrt(GM_sun / a³) as a typed [`AngularVelocity`] (rad per
+/// day).
 pub fn mean_motion_typed(a: f64) -> AngularVelocity {
-    (radians(mean_motion(a)) / days(1.0)).into()
+    (radians((GM_SUN / (a * a * a)).sqrt()) / days(1.0)).into()
 }
 
 /// Secular apsidal precession rate dϖ/dt (rad/day) from Lagrange's planetary
@@ -138,7 +134,7 @@ pub fn precession_rate(
     let r_plus = averaged_disturbing(a, e + he, varpi, a_efe, n, geom, n_quad);
     let r_minus = averaged_disturbing(a, e - he, varpi, a_efe, n, geom, n_quad);
     let dr_de = (r_plus - r_minus) / (2.0 * he);
-    let nm = mean_motion(a);
+    let nm = (mean_motion_typed(a) / (radians(1.0) / days(1.0))).value;
     (1.0 - e * e).sqrt() / (nm * a * a * e) * dr_de
 }
 
@@ -268,13 +264,14 @@ mod tests {
     }
 
     #[test]
-    fn typed_mean_motion_matches_f64() {
+    fn typed_mean_motion_matches_formula() {
         use uom::si::angular_velocity::radian_per_second;
         let a = 500.0;
-        // rad/day read back as rad/s matches mean_motion / seconds-per-day.
+        // rad/day read back as rad/s matches n = sqrt(GM/a³) / seconds-per-day.
+        let n_rad_per_day = (GM_SUN / (a * a * a)).sqrt();
         assert_relative_eq!(
             mean_motion_typed(a).get::<radian_per_second>(),
-            mean_motion(a) / 86_400.0,
+            n_rad_per_day / 86_400.0,
             max_relative = 1e-9
         );
     }

--- a/crates/p9-2024-primordial-alignment/Cargo.toml
+++ b/crates/p9-2024-primordial-alignment/Cargo.toml
@@ -8,7 +8,7 @@ description = "Reproduction of Huang & Gladman (2024) 'Primordial Orbital Alignm
 p9-core = { path = "../p9-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2024-primordial-alignment/src/convergence.rs
+++ b/crates/p9-2024-primordial-alignment/src/convergence.rs
@@ -57,12 +57,6 @@ pub struct Precessor {
 }
 
 impl Precessor {
-    /// Longitude of perihelion at look-back time `tau_yr` years before present
-    /// (τ ≥ 0): ϖ(−τ) = ϖ₀ − ϖ̇·τ.
-    pub fn varpi_at_lookback(&self, tau_yr: f64) -> f64 {
-        self.varpi0 - self.rate_rad_per_yr * tau_yr
-    }
-
     /// Present-day longitude of perihelion ϖ₀ as a dimension-checked [`Angle`].
     pub fn varpi0_angle(&self) -> Angle {
         radians(self.varpi0)
@@ -73,9 +67,10 @@ impl Precessor {
         (radians(self.rate_rad_per_yr) / julian_year()).into()
     }
 
-    /// Longitude of perihelion at look-back time `tau_yr` years as an [`Angle`].
+    /// Longitude of perihelion at look-back time `tau_yr` years before present
+    /// (τ ≥ 0) as an [`Angle`]: ϖ(−τ) = ϖ₀ − ϖ̇·τ.
     pub fn varpi_at_lookback_typed(&self, tau_yr: f64) -> Angle {
-        radians(self.varpi_at_lookback(tau_yr))
+        radians(self.varpi0 - self.rate_rad_per_yr * tau_yr)
     }
 }
 
@@ -122,7 +117,7 @@ pub fn primordially_aligned_then_aged(varpi0: f64, age_yr: f64) -> Vec<Precessor
 pub fn resultant_at_lookback(precessors: &[Precessor], tau_yr: f64) -> f64 {
     let varpis: Vec<f64> = precessors
         .iter()
-        .map(|p| p.varpi_at_lookback(tau_yr))
+        .map(|p| (p.varpi_at_lookback_typed(tau_yr) / radians(1.0)).value)
         .collect();
     mean_resultant_length(&varpis)
 }
@@ -187,7 +182,7 @@ mod tests {
         assert_relative_eq!(p.varpi0_angle().get::<radian>(), p.varpi0, epsilon = 1e-12);
         assert_relative_eq!(
             p.varpi_at_lookback_typed(1.0e8).get::<radian>(),
-            p.varpi_at_lookback(1.0e8),
+            p.varpi0 - p.rate_rad_per_yr * 1.0e8,
             epsilon = 1e-9
         );
         // The rad/yr rate, read back in rad/s, equals the f64 rate / seconds-per-year.

--- a/crates/p9-2025-clustering/Cargo.toml
+++ b/crates/p9-2025-clustering/Cargo.toml
@@ -11,7 +11,7 @@ rand = { workspace = true }
 rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2025-clustering/src/clone_generation.rs
+++ b/crates/p9-2025-clustering/src/clone_generation.rs
@@ -399,6 +399,11 @@ mod tests {
         let clone = &generate_clones(tno, 1, &mut rng)[0];
         let elem = clone.elements();
         assert!((elem.a - clone.a).abs() < 1e-12);
-        assert!((elem.perihelion() - clone.perihelion()).abs() < 1e-9);
+        assert!(
+            (elem.perihelion_typed().get::<astronomical_unit>()
+                - clone.perihelion_typed().get::<astronomical_unit>())
+            .abs()
+                < 1e-9
+        );
     }
 }

--- a/crates/p9-2025-clustering/src/clone_generation.rs
+++ b/crates/p9-2025-clustering/src/clone_generation.rs
@@ -62,16 +62,6 @@ pub struct ObservedTno {
 }
 
 impl ObservedTno {
-    /// Perihelion distance q = a(1 − e) in AU.
-    pub fn perihelion(&self) -> f64 {
-        self.a * (1.0 - self.e)
-    }
-
-    /// Longitude of perihelion ϖ = ω + Ω (rad), wrapped to [0, 2π).
-    pub fn varpi(&self) -> f64 {
-        (self.omega + self.omega_big).rem_euclid(TWO_PI)
-    }
-
     /// Semi-major axis as a dimension-checked [`Length`].
     pub fn semi_major_axis(&self) -> Length {
         au(self.a)
@@ -79,7 +69,7 @@ impl ObservedTno {
 
     /// Perihelion distance `q = a(1 − e)` as a dimension-checked [`Length`].
     pub fn perihelion_typed(&self) -> Length {
-        au(self.perihelion())
+        au(self.a * (1.0 - self.e))
     }
 
     /// Inclination as a dimension-checked [`Angle`].
@@ -87,9 +77,10 @@ impl ObservedTno {
         radians(self.i)
     }
 
-    /// Longitude of perihelion ϖ as a dimension-checked [`Angle`].
+    /// Longitude of perihelion ϖ = ω + Ω as a dimension-checked [`Angle`],
+    /// wrapped to [0, 2π).
     pub fn varpi_typed(&self) -> Angle {
-        radians(self.varpi())
+        radians((self.omega + self.omega_big).rem_euclid(TWO_PI))
     }
 }
 
@@ -115,23 +106,15 @@ pub struct TnoClone {
 }
 
 impl TnoClone {
-    pub fn perihelion(&self) -> f64 {
-        self.a * (1.0 - self.e)
-    }
-
-    /// Longitude of perihelion ϖ = ω + Ω (rad), wrapped to [0, 2π).
-    pub fn varpi(&self) -> f64 {
-        (self.omega + self.omega_big).rem_euclid(TWO_PI)
-    }
-
     /// Perihelion distance `q = a(1 − e)` as a dimension-checked [`Length`].
     pub fn perihelion_typed(&self) -> Length {
-        au(self.perihelion())
+        au(self.a * (1.0 - self.e))
     }
 
-    /// Longitude of perihelion ϖ as a dimension-checked [`Angle`].
+    /// Longitude of perihelion ϖ = ω + Ω as a dimension-checked [`Angle`],
+    /// wrapped to [0, 2π).
     pub fn varpi_typed(&self) -> Angle {
-        radians(self.varpi())
+        radians((self.omega + self.omega_big).rem_euclid(TWO_PI))
     }
 
     /// Full orbital element set for integration.
@@ -157,7 +140,7 @@ pub fn generate_clones<R: Rng>(tno: &ObservedTno, n_clones: usize, rng: &mut R) 
     let ang_dist = Normal::new(0.0, tno.sigma_angle.max(1e-9)).unwrap();
     let m_dist = Uniform::new(0.0, TWO_PI);
 
-    let q0 = tno.perihelion();
+    let q0 = (tno.perihelion_typed() / p9_core::units::au(1.0)).value;
     let parent_crossing = q0 < A_NEPTUNE_AU;
 
     let mut clones = Vec::with_capacity(n_clones);
@@ -253,7 +236,7 @@ mod tests {
         );
         assert_relative_eq!(
             tno.perihelion_typed().get::<astronomical_unit>(),
-            tno.perihelion(),
+            tno.a * (1.0 - tno.e),
             epsilon = 1e-12
         );
         assert_relative_eq!(
@@ -263,7 +246,7 @@ mod tests {
         );
         assert_relative_eq!(
             tno.varpi_typed().get::<radian>(),
-            tno.varpi(),
+            (tno.omega + tno.omega_big).rem_euclid(TWO_PI),
             epsilon = 1e-12
         );
 
@@ -271,12 +254,12 @@ mod tests {
         let clone = &generate_clones(tno, 1, &mut rng)[0];
         assert_relative_eq!(
             clone.perihelion_typed().get::<astronomical_unit>(),
-            clone.perihelion(),
+            clone.a * (1.0 - clone.e),
             epsilon = 1e-12
         );
         assert_relative_eq!(
             clone.varpi_typed().get::<radian>(),
-            clone.varpi(),
+            (clone.omega + clone.omega_big).rem_euclid(TWO_PI),
             epsilon = 1e-12
         );
     }
@@ -359,13 +342,14 @@ mod tests {
         let mut rng = rand::rngs::StdRng::seed_from_u64(11);
         let tno = &distant_tno_sample()[0]; // Sedna, q = 75.9 AU
         let clones = generate_clones(tno, 200, &mut rng);
-        let q0 = tno.perihelion();
+        let q0 = tno.perihelion_typed().get::<astronomical_unit>();
         for c in &clones {
+            let q = c.perihelion_typed().get::<astronomical_unit>();
             assert!(
-                (c.perihelion() - q0).abs() < 5.0 * SIGMA_E * c.a,
+                (q - q0).abs() < 5.0 * SIGMA_E * c.a,
                 "{}: clone q = {:.1} vs parent q = {:.1}",
                 c.parent_name,
-                c.perihelion(),
+                q,
                 q0
             );
         }
@@ -381,11 +365,12 @@ mod tests {
                 // Parent is detached (q > a_N): clones either stay
                 // outside Neptune or carry the explicit flag.
                 if !c.neptune_crossing {
+                    let q = c.perihelion_typed().get::<astronomical_unit>();
                     assert!(
-                        c.perihelion() > A_NEPTUNE_AU,
+                        q > A_NEPTUNE_AU,
                         "{}: silent Neptune crosser q = {:.1}",
                         c.parent_name,
-                        c.perihelion()
+                        q
                     );
                 }
             }

--- a/crates/p9-2025-clustering/src/orbital_poles.rs
+++ b/crates/p9-2025-clustering/src/orbital_poles.rs
@@ -42,31 +42,22 @@ impl OrbitalPole {
         }
     }
 
-    /// Magnitude (inclination in rad).
-    pub fn inclination(&self) -> f64 {
-        (self.x * self.x + self.y * self.y).sqrt()
-    }
-
-    /// Position angle (longitude of ascending node in rad).
-    pub fn omega_big(&self) -> f64 {
-        self.y.atan2(self.x)
-    }
-
-    /// Inclination as a dimension-checked [`Angle`].
+    /// Inclination (magnitude) as a dimension-checked [`Angle`].
     pub fn inclination_typed(&self) -> Angle {
-        radians(self.inclination())
+        radians((self.x * self.x + self.y * self.y).sqrt())
     }
 
-    /// Longitude of ascending node as a dimension-checked [`Angle`].
+    /// Longitude of ascending node (position angle) as a dimension-checked
+    /// [`Angle`].
     pub fn omega_big_typed(&self) -> Angle {
-        radians(self.omega_big())
+        radians(self.y.atan2(self.x))
     }
 
     /// Unit vector of the orbit normal in ecliptic coordinates:
     /// n̂ = (sin i sin Ω, −sin i cos Ω, cos i).
     pub fn unit_vector(&self) -> Vector3<f64> {
-        let i = self.inclination();
-        let node = self.omega_big();
+        let i = (self.inclination_typed() / radians(1.0)).value;
+        let node = (self.omega_big_typed() / radians(1.0)).value;
         Vector3::new(i.sin() * node.sin(), -i.sin() * node.cos(), i.cos())
     }
 }
@@ -143,7 +134,7 @@ pub fn pole_scatter(poles: &[OrbitalPole]) -> f64 {
 ///
 /// Giant-planet masses and semi-major axes come from the p9-core J2000
 /// states (no local table).
-pub fn nodal_precession_rate(a: f64, e: f64, i: f64) -> f64 {
+pub fn nodal_precession_rate_typed(a: f64, e: f64, i: f64) -> AngularVelocity {
     let n = (GM_SUN / (a * a * a)).sqrt(); // rad/day
     let eta_sq = (1.0 - e * e) * (1.0 - e * e);
 
@@ -156,13 +147,8 @@ pub fn nodal_precession_rate(a: f64, e: f64, i: f64) -> f64 {
         .sum();
 
     let rate_day = -0.75 * n * i.cos() / eta_sq * sum;
-    rate_day * 365.25 // Convert to rad/yr
-}
-
-/// Nodal precession rate as a typed [`AngularVelocity`] (the rad/yr value of
-/// [`nodal_precession_rate`] carried with units).
-pub fn nodal_precession_rate_typed(a: f64, e: f64, i: f64) -> AngularVelocity {
-    (radians(nodal_precession_rate(a, e, i)) / julian_year()).into()
+    let rate_yr = rate_day * 365.25; // rad/yr
+    (radians(rate_yr) / julian_year()).into()
 }
 
 #[cfg(test)]
@@ -179,20 +165,31 @@ mod tests {
         let pole = OrbitalPole::from_elements("t", 30.0 * DEG2RAD, 45.0 * DEG2RAD);
         assert_relative_eq!(
             pole.inclination_typed().get::<radian>(),
-            pole.inclination(),
+            (pole.x * pole.x + pole.y * pole.y).sqrt(),
             epsilon = 1e-12
         );
         assert_relative_eq!(
             pole.omega_big_typed().get::<radian>(),
-            pole.omega_big(),
+            pole.y.atan2(pole.x),
             epsilon = 1e-12
         );
-        // rad/yr rate read back in rad/s matches the f64 rate / seconds-per-year.
+        // rad/yr rate read back in rad/s matches the inline rad/yr formula
+        // divided by seconds-per-year.
         let yr_s = julian_year().get::<second>();
         let (a, e, i) = (300.0, 0.7, 20.0 * DEG2RAD);
+        let n = (GM_SUN / (a * a * a)).sqrt();
+        let eta_sq = (1.0 - e * e) * (1.0 - e * e);
+        let sum: f64 = giant_planets_j2000()
+            .iter()
+            .map(|body| {
+                let a_j = cartesian_to_elements(&body.state, GM_SUN).a;
+                body.mass * (a_j / a).powi(2)
+            })
+            .sum();
+        let rate_yr = -0.75 * n * i.cos() / eta_sq * sum * 365.25;
         assert_relative_eq!(
             nodal_precession_rate_typed(a, e, i).get::<radian_per_second>(),
-            nodal_precession_rate(a, e, i) / yr_s,
+            rate_yr / yr_s,
             max_relative = 1e-12
         );
     }
@@ -207,7 +204,7 @@ mod tests {
     #[test]
     fn test_pole_inclination() {
         let pole = OrbitalPole::from_elements("test", 30.0 * DEG2RAD, 45.0 * DEG2RAD);
-        assert!((pole.inclination() - 30.0 * DEG2RAD).abs() < 1e-10);
+        assert!((pole.inclination_typed().get::<radian>() - 30.0 * DEG2RAD).abs() < 1e-10);
     }
 
     #[test]
@@ -257,7 +254,7 @@ mod tests {
         // The giant-planet angular-momentum plane is inclined ≈ 1.58° to
         // the ecliptic.
         let lap = laplace_pole();
-        let i_deg = lap.inclination() / DEG2RAD;
+        let i_deg = lap.inclination_typed().get::<radian>() / DEG2RAD;
         assert!(
             i_deg > 1.0 && i_deg < 2.2,
             "Laplace-plane inclination = {i_deg:.2}°, expected ≈ 1.58°"
@@ -287,7 +284,7 @@ mod tests {
         let at_2017 = laplace_pole_at(&ts.utc((2017, 1, 1))).unwrap();
         let sep = misalignment(&pinned, &at_2017) / DEG2RAD;
         assert!(sep < 0.2, "2017 pole separation = {sep:.4}°");
-        let i_deg = at_2017.inclination() / DEG2RAD;
+        let i_deg = at_2017.inclination_typed().get::<radian>() / DEG2RAD;
         assert!(i_deg > 1.0 && i_deg < 2.2, "inclination = {i_deg:.2}°");
     }
 
@@ -323,7 +320,8 @@ mod tests {
     #[test]
     fn test_nodal_precession_negative() {
         // Prograde orbit (i < 90) should precess retrograde (negative rate)
-        let rate = nodal_precession_rate(300.0, 0.7, 20.0 * DEG2RAD);
+        let rate =
+            nodal_precession_rate_typed(300.0, 0.7, 20.0 * DEG2RAD).get::<radian_per_second>();
         assert!(
             rate < 0.0,
             "nodal precession rate should be negative for prograde"

--- a/crates/p9-2025-clustering/src/pipeline.rs
+++ b/crates/p9-2025-clustering/src/pipeline.rs
@@ -222,11 +222,15 @@ pub fn run_pipeline(config: &PipelineConfig) -> PipelineResult {
             }
             d_values.push(measure_diffusion(s, config.snapshot_interval_yr, 5));
         }
-        let agg = aggregate_clone_diffusion(tno.name, &d_values, tno.perihelion());
+        let agg = aggregate_clone_diffusion(
+            tno.name,
+            &d_values,
+            (tno.perihelion_typed() / p9_core::units::au(1.0)).value,
+        );
         let class = classify(&agg);
         per_tno.push(TnoResult {
             name: tno.name,
-            varpi: tno.varpi(),
+            varpi: (tno.varpi_typed() / p9_core::units::radians(1.0)).value,
             d_mean: agg.d_mean,
             d_std: agg.d_std,
             d_analytical: agg.d_analytical,

--- a/crates/p9-2025-clustering/src/plots.rs
+++ b/crates/p9-2025-clustering/src/plots.rs
@@ -141,7 +141,7 @@ pub fn orbital_pole_plot(poles: &[OrbitalPole], width: u32, height: u32) -> Stri
     if !poles.is_empty() {
         let max_r = poles
             .iter()
-            .map(|p| p.inclination())
+            .map(|p| (p.inclination_typed() / p9_core::units::radians(1.0)).value)
             .fold(0.0_f64, f64::max)
             .max(0.01);
 

--- a/crates/p9-2025-ps1-holman/Cargo.toml
+++ b/crates/p9-2025-ps1-holman/Cargo.toml
@@ -9,7 +9,7 @@ rand = { workspace = true }
 rand_distr = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2025-ps1-holman/src/photometry.rs
+++ b/crates/p9-2025-ps1-holman/src/photometry.rs
@@ -19,25 +19,26 @@ pub fn apparent_r_magnitude(mass_earth: f64, r_au: f64) -> f64 {
     planet_apparent_magnitude(mass_earth, ALBEDO_NEPTUNE, r_au)
 }
 
-/// Maximum heliocentric distance (AU) at which a P9 of `mass_earth` is still
-/// at or brighter than the survey's effective (shift-and-stack) depth, i.e.
-/// `apparent_r_magnitude(mass, r) == survey.effective_depth()`.
+/// Maximum heliocentric distance at which a P9 of `mass_earth` is still at or
+/// brighter than the survey's effective (shift-and-stack) depth, i.e.
+/// `apparent_r_magnitude(mass, r) == survey.effective_depth()`, as a
+/// dimension-checked [`Length`].
 ///
 /// Apparent magnitude rises monotonically with distance (reflected light
 /// dims as r^4 at opposition: m ~ H + 5 log10(r(r-1))), so the equation has
 /// a unique root, found by bisection on [`R_MIN_AU`, `R_MAX_AU`]. Returns
 /// `R_MAX_AU` if even there the object is detectable, `R_MIN_AU` if it is
 /// never detectable.
-pub fn max_detectable_distance(survey: &Ps1StackSurvey, mass_earth: f64) -> f64 {
+pub fn max_detectable_distance_typed(survey: &Ps1StackSurvey, mass_earth: f64) -> Length {
     let target = survey.effective_depth();
     let mut lo = R_MIN_AU;
     let mut hi = R_MAX_AU;
     // At lo the object is brightest (smallest m); detectable means m <= target.
     if apparent_r_magnitude(mass_earth, lo) > target {
-        return R_MIN_AU; // not detectable anywhere in range
+        return au(R_MIN_AU); // not detectable anywhere in range
     }
     if apparent_r_magnitude(mass_earth, hi) <= target {
-        return R_MAX_AU; // detectable everywhere in range
+        return au(R_MAX_AU); // detectable everywhere in range
     }
     for _ in 0..100 {
         let mid = 0.5 * (lo + hi);
@@ -47,12 +48,7 @@ pub fn max_detectable_distance(survey: &Ps1StackSurvey, mass_earth: f64) -> f64 
             hi = mid;
         }
     }
-    0.5 * (lo + hi)
-}
-
-/// [`max_detectable_distance`] as a dimension-checked [`Length`].
-pub fn max_detectable_distance_typed(survey: &Ps1StackSurvey, mass_earth: f64) -> Length {
-    au(max_detectable_distance(survey, mass_earth))
+    au(0.5 * (lo + hi))
 }
 
 /// Inner bound of the bisection bracket (AU). Objects closer than the giant
@@ -81,7 +77,7 @@ mod tests {
     #[test]
     fn max_distance_is_finite_and_at_threshold() {
         let s = Ps1StackSurvey::default();
-        let r = max_detectable_distance(&s, 6.0);
+        let r = (max_detectable_distance_typed(&s, 6.0) / au(1.0)).value;
         // PINNED: a finite AU value strictly inside the bracket.
         assert!(r.is_finite());
         assert!(r > R_MIN_AU && r < R_MAX_AU, "r_max = {r:.1}");
@@ -95,12 +91,25 @@ mod tests {
     }
 
     #[test]
-    fn typed_distance_matches_f64() {
-        use uom::si::length::astronomical_unit;
+    fn typed_distance_matches_inline_bisection() {
         let s = Ps1StackSurvey::default();
+        // Inline the same bracket-bisection root the typed function computes,
+        // then check the typed result (in AU) matches it exactly.
+        let target = s.effective_depth();
+        let mut lo = R_MIN_AU;
+        let mut hi = R_MAX_AU;
+        for _ in 0..100 {
+            let mid = 0.5 * (lo + hi);
+            if apparent_r_magnitude(6.0, mid) <= target {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        let expected = 0.5 * (lo + hi);
         assert_relative_eq!(
-            max_detectable_distance_typed(&s, 6.0).get::<astronomical_unit>(),
-            max_detectable_distance(&s, 6.0),
+            (max_detectable_distance_typed(&s, 6.0) / au(1.0)).value,
+            expected,
             epsilon = 1e-12
         );
     }
@@ -108,9 +117,9 @@ mod tests {
     #[test]
     fn max_distance_increases_with_mass() {
         let s = Ps1StackSurvey::default();
-        let r5 = max_detectable_distance(&s, 5.0);
-        let r10 = max_detectable_distance(&s, 10.0);
-        let r20 = max_detectable_distance(&s, 20.0);
+        let r5 = (max_detectable_distance_typed(&s, 5.0) / au(1.0)).value;
+        let r10 = (max_detectable_distance_typed(&s, 10.0) / au(1.0)).value;
+        let r20 = (max_detectable_distance_typed(&s, 20.0) / au(1.0)).value;
         // PINNED: more massive (larger, brighter) P9 detectable farther out.
         assert!(r10 > r5, "r10 {r10:.1} should exceed r5 {r5:.1}");
         assert!(r20 > r10, "r20 {r20:.1} should exceed r10 {r10:.1}");
@@ -124,8 +133,8 @@ mod tests {
             stack_depth_gain: 0.0,
             ..Ps1StackSurvey::default()
         };
-        let r_stack = max_detectable_distance(&stack, 6.0);
-        let r_single = max_detectable_distance(&single, 6.0);
+        let r_stack = (max_detectable_distance_typed(&stack, 6.0) / au(1.0)).value;
+        let r_single = (max_detectable_distance_typed(&single, 6.0) / au(1.0)).value;
         assert!(
             r_stack > r_single,
             "stack reach {r_stack:.1} should exceed single-epoch {r_single:.1}"

--- a/crates/p9-2025-simons-forecast/Cargo.toml
+++ b/crates/p9-2025-simons-forecast/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 p9-core = { path = "../p9-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2025-simons-forecast/src/forecast.rs
+++ b/crates/p9-2025-simons-forecast/src/forecast.rs
@@ -18,21 +18,22 @@ use p9_core::units::{au, earth_masses, Length, Mass};
 use crate::bands::MmSensitivity;
 use crate::thermal::P9Thermal;
 
-/// Maximum heliocentric distance (AU) at which a Planet Nine of `mass_earth`
-/// emits at least `sens.flux_limit_mjy` at the sensitivity's band frequency.
+/// Maximum heliocentric distance at which a Planet Nine of `mass_earth`
+/// emits at least `sens.flux_limit_mjy` at the sensitivity's band frequency,
+/// as a dimension-checked [`Length`].
 ///
 /// Flux falls monotonically as 1/d², so the reach is the unique root of
 /// `F_ν(d) = flux_limit`. Solved by bisection over `[d_lo, d_hi]`; returns
 /// `d_lo` if even the nearest distance is too faint and `d_hi` if the body is
 /// still detectable at the far bracket.
-pub fn max_detectable_distance(mass_earth: f64, sens: &MmSensitivity) -> f64 {
+pub fn max_detectable_distance(mass_earth: f64, sens: &MmSensitivity) -> Length {
     let flux_at = |d: f64| P9Thermal::new(mass_earth, d).flux_mjy(sens.nu_hz);
     let (mut lo, mut hi) = (50.0_f64, 5000.0_f64);
     if flux_at(lo) < sens.flux_limit_mjy {
-        return lo;
+        return au(lo);
     }
     if flux_at(hi) >= sens.flux_limit_mjy {
-        return hi;
+        return au(hi);
     }
     for _ in 0..200 {
         let mid = 0.5 * (lo + hi);
@@ -45,12 +46,7 @@ pub fn max_detectable_distance(mass_earth: f64, sens: &MmSensitivity) -> f64 {
             break;
         }
     }
-    0.5 * (lo + hi)
-}
-
-/// [`max_detectable_distance`] as a dimension-checked [`Length`].
-pub fn max_detectable_distance_typed(mass_earth: f64, sens: &MmSensitivity) -> Length {
-    au(max_detectable_distance(mass_earth, sens))
+    au(0.5 * (lo + hi))
 }
 
 /// Expected detection significance (signal-to-noise ratio) of a Planet Nine of
@@ -142,9 +138,27 @@ mod tests {
         use uom::si::length::astronomical_unit;
         use uom::si::mass::kilogram;
 
+        // The bisection root recomputed inline must equal the typed reach.
+        let reach = max_detectable_distance(5.0, &SO_SENSITIVITY);
+        let expected_au = {
+            let flux_at = |d: f64| P9Thermal::new(5.0, d).flux_mjy(SO_SENSITIVITY.nu_hz);
+            let (mut lo, mut hi) = (50.0_f64, 5000.0_f64);
+            for _ in 0..200 {
+                let mid = 0.5 * (lo + hi);
+                if flux_at(mid) >= SO_SENSITIVITY.flux_limit_mjy {
+                    lo = mid;
+                } else {
+                    hi = mid;
+                }
+                if hi - lo < 1e-6 {
+                    break;
+                }
+            }
+            0.5 * (lo + hi)
+        };
         assert_relative_eq!(
-            max_detectable_distance_typed(5.0, &SO_SENSITIVITY).get::<astronomical_unit>(),
-            max_detectable_distance(5.0, &SO_SENSITIVITY),
+            reach.get::<astronomical_unit>(),
+            expected_au,
             epsilon = 1e-9
         );
         let bx = ReferenceBox::nominal();
@@ -165,9 +179,9 @@ mod tests {
         // A heavier P9 has a larger radius, is brighter, and is detectable to a
         // greater distance — for both surveys.
         for sens in [&ACT_SENSITIVITY, &SO_SENSITIVITY] {
-            let d5 = max_detectable_distance(5.0, sens);
-            let d10 = max_detectable_distance(10.0, sens);
-            let d15 = max_detectable_distance(15.0, sens);
+            let d5 = (max_detectable_distance(5.0, sens) / au(1.0)).value;
+            let d10 = (max_detectable_distance(10.0, sens) / au(1.0)).value;
+            let d15 = (max_detectable_distance(15.0, sens) / au(1.0)).value;
             assert!(
                 d5 < d10 && d10 < d15,
                 "{}: reach must rise with mass: {d5:.0} < {d10:.0} < {d15:.0}",
@@ -181,8 +195,8 @@ mod tests {
         // The headline comparison: for the same cold body SO's deeper map
         // detects it to a greater heliocentric distance than ACT.
         for &m in &[5.0, 10.0, 15.0] {
-            let so = max_detectable_distance(m, &SO_SENSITIVITY);
-            let act = max_detectable_distance(m, &ACT_SENSITIVITY);
+            let so = (max_detectable_distance(m, &SO_SENSITIVITY) / au(1.0)).value;
+            let act = (max_detectable_distance(m, &ACT_SENSITIVITY) / au(1.0)).value;
             assert!(
                 so > act,
                 "{m} M⊕: SO reach {so:.0} AU should exceed ACT {act:.0} AU"
@@ -195,7 +209,7 @@ mod tests {
         // Naess et al. (2021): a 5 M⊕ P9 has an ACT detection limit of
         // 325–625 AU depending on sky location; our median-depth (8 mJy)
         // reach lands inside that band.
-        let act5 = max_detectable_distance(5.0, &ACT_SENSITIVITY);
+        let act5 = (max_detectable_distance(5.0, &ACT_SENSITIVITY) / au(1.0)).value;
         assert!(
             (325.0..=625.0).contains(&act5),
             "ACT 5 M⊕ reach {act5:.0} AU should be within published 325–625"
@@ -205,8 +219,8 @@ mod tests {
     #[test]
     fn so_reach_matches_published_5me_band() {
         // SO forecast: 5 M⊕ detectable from 500 AU (shallow) to 900 AU (deep).
-        let deep = max_detectable_distance(5.0, &SO_SENSITIVITY);
-        let shallow = max_detectable_distance(5.0, &SO_SENSITIVITY_SHALLOW);
+        let deep = (max_detectable_distance(5.0, &SO_SENSITIVITY) / au(1.0)).value;
+        let shallow = (max_detectable_distance(5.0, &SO_SENSITIVITY_SHALLOW) / au(1.0)).value;
         assert!(
             (820.0..=980.0).contains(&deep),
             "SO deep 5 M⊕ reach {deep:.0} AU near published ~900"
@@ -225,7 +239,7 @@ mod tests {
         let ratio = near / far;
         assert!((3.9..=4.1).contains(&ratio), "SNR ratio {ratio:.3} ≈ 4");
         // At the flux limit the SNR is ~2 (the 95%-CL threshold).
-        let edge_d = max_detectable_distance(5.0, &SO_SENSITIVITY);
+        let edge_d = (max_detectable_distance(5.0, &SO_SENSITIVITY) / au(1.0)).value;
         let snr_edge = detection_significance(5.0, edge_d, &SO_SENSITIVITY);
         assert!((snr_edge - 2.0).abs() < 0.05, "edge SNR {snr_edge:.3} ≈ 2");
     }

--- a/crates/p9-2025-simons-forecast/src/lib.rs
+++ b/crates/p9-2025-simons-forecast/src/lib.rs
@@ -81,8 +81,9 @@ mod tests {
         // The full forecast in one assertion chain: for a nominal 5 M⊕ body
         // SO reaches the paper's ~900 AU, exceeds ACT's published band, and
         // covers a larger fraction of the reference box.
-        let so5 = max_detectable_distance(5.0, &SO_SENSITIVITY);
-        let act5 = max_detectable_distance(5.0, &ACT_SENSITIVITY);
+        use p9_core::units::au;
+        let so5 = (max_detectable_distance(5.0, &SO_SENSITIVITY) / au(1.0)).value;
+        let act5 = (max_detectable_distance(5.0, &ACT_SENSITIVITY) / au(1.0)).value;
 
         assert!(so5 > act5, "SO reach > ACT reach");
         assert!(

--- a/crates/p9-2026-iorio-precession/Cargo.toml
+++ b/crates/p9-2026-iorio-precession/Cargo.toml
@@ -8,7 +8,7 @@ description = "Reproduction of Iorio (2026) 'On the effects of a distended Plane
 p9-core = { path = "../p9-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
-uom = "0.38.0"

--- a/crates/p9-2026-iorio-precession/src/lib.rs
+++ b/crates/p9-2026-iorio-precession/src/lib.rs
@@ -129,11 +129,6 @@ impl Perturber {
         self.mass_earth * EARTH_MASS_SOLAR
     }
 
-    /// GM in AU^3/day^2.
-    pub fn gm(&self) -> f64 {
-        self.mass_solar() * GM_SUN
-    }
-
     /// Mass as a dimension-checked [`Mass`] (Earth-mass storage).
     pub fn mass(&self) -> Mass {
         earth_masses(self.mass_earth)
@@ -145,7 +140,7 @@ impl Perturber {
     /// Gravitational parameter as a dimension-checked
     /// [`GravitationalParameter`] (AU³/day² storage).
     pub fn gm_typed(&self) -> GravitationalParameter {
-        gm_from_au3_day2(self.gm())
+        gm_from_au3_day2(self.mass_solar() * GM_SUN)
     }
 
     /// Planet Nine, Batygin/Brown-class nominal: ~6 Earth masses at ~460 AU,
@@ -240,13 +235,14 @@ pub fn is_excluded(p: &Perturber) -> bool {
 /// convention we simply confirm that `H` scales as `(a/a_p)^2` and as `gm_p`,
 /// which is exactly the GM_p / a_p^3 tidal scaling our rate inherits.
 pub fn quadrupole_prefactor_consistency(p: &Perturber) -> f64 {
-    let h = coplanar_quadrupole(A_SATURN_AU, E_SATURN, p.a_au, p.e, p.gm());
+    let gm = (p.gm_typed() / gm_from_au3_day2(1.0)).value;
+    let h = coplanar_quadrupole(A_SATURN_AU, E_SATURN, p.a_au, p.e, gm);
     // Reconstruct C from H = -C (2 + 3 e^2)/2.
     let e2 = E_SATURN * E_SATURN;
     let c_from_h = -2.0 * h / (2.0 + 3.0 * e2);
     // Independent closed form of C.
     let alpha = A_SATURN_AU / p.a_au;
-    let c_closed = p.gm() * alpha * alpha / (4.0 * p.a_au * (1.0 - p.e * p.e).powf(1.5));
+    let c_closed = gm * alpha * alpha / (4.0 * p.a_au * (1.0 - p.e * p.e).powf(1.5));
     c_from_h / c_closed
 }
 
@@ -438,7 +434,7 @@ mod tests {
         );
         assert_relative_eq!(
             p.gm_typed().value,
-            gm_from_au3_day2(p.gm()).value,
+            gm_from_au3_day2(p.mass_solar() * GM_SUN).value,
             max_relative = 1e-12
         );
 

--- a/crates/p9-core/src/data/posterior.rs
+++ b/crates/p9-core/src/data/posterior.rs
@@ -209,6 +209,7 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use rand::SeedableRng;
+    use uom::si::length::astronomical_unit;
 
     #[test]
     fn test_posterior_median_values() {
@@ -265,7 +266,10 @@ mod tests {
             .map(|_| sample_from_posterior(&post, &mut rng))
             .collect();
 
-        let qs: Vec<f64> = samples.iter().map(|s| s.perihelion()).collect();
+        let qs: Vec<f64> = samples
+            .iter()
+            .map(|s| s.perihelion_typed().get::<astronomical_unit>())
+            .collect();
         let a_mean = samples.iter().map(|s| s.a).sum::<f64>() / samples.len() as f64;
         let q_mean = qs.iter().sum::<f64>() / qs.len() as f64;
         let mut sa = 0.0;
@@ -299,11 +303,9 @@ mod tests {
                 "Eccentricity must be in (0,1)"
             );
             assert!(params.i > 0.0, "Inclination must be positive");
-            assert!(params.perihelion() > 0.0, "Perihelion must be positive");
-            assert!(
-                params.perihelion() < params.a,
-                "Perihelion must be less than a"
-            );
+            let q = params.perihelion_typed().get::<astronomical_unit>();
+            assert!(q > 0.0, "Perihelion must be positive");
+            assert!(q < params.a, "Perihelion must be less than a");
         }
     }
 

--- a/crates/p9-core/src/data/stable_kbos.rs
+++ b/crates/p9-core/src/data/stable_kbos.rs
@@ -117,6 +117,7 @@ pub fn longitude_of_perihelion(elem: &OrbitalElements) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uom::si::length::astronomical_unit;
 
     #[test]
     fn test_six_stable_kbos() {
@@ -131,10 +132,10 @@ mod tests {
                 kbo.name
             );
             assert!(
-                kbo.elements.perihelion() > 30.0,
+                kbo.elements.perihelion_typed().get::<astronomical_unit>() > 30.0,
                 "{} q = {:.1} should be > 30 AU",
                 kbo.name,
-                kbo.elements.perihelion()
+                kbo.elements.perihelion_typed().get::<astronomical_unit>()
             );
         }
     }

--- a/crates/p9-core/src/initial_conditions/planets.rs
+++ b/crates/p9-core/src/initial_conditions/planets.rs
@@ -285,6 +285,7 @@ mod tests {
     use super::*;
     use crate::integrator::whm::{barycentric_energy, WhmIntegrator};
     use crate::types::SimConfig;
+    use uom::si::length::astronomical_unit;
 
     fn ephemeris_or_skip() -> Option<PlanetEphemeris> {
         match PlanetEphemeris::try_new() {
@@ -307,7 +308,7 @@ mod tests {
         ];
         for (body, (a, name)) in giant_planets_j2000().iter().zip(expected_au) {
             assert_eq!(body.name, name);
-            let r = body.state.distance();
+            let r = body.state.distance_typed().get::<astronomical_unit>();
             assert!(
                 (r - a).abs() / a < 0.06,
                 "{name} at r = {r:.2} AU, expected near {a} AU"
@@ -442,6 +443,6 @@ mod tests {
         let mut eph = PlanetEphemeris::try_new_downloading().expect("download or cache de440");
         let ts = Timescale::default();
         let bodies = eph.giant_planets_at(&ts.tdb_jd(J2000)).unwrap();
-        assert!((bodies[0].state.distance() - 5.0).abs() < 0.5);
+        assert!((bodies[0].state.distance_typed().get::<astronomical_unit>() - 5.0).abs() < 0.5);
     }
 }

--- a/crates/p9-core/src/initial_conditions/scattered_disk.rs
+++ b/crates/p9-core/src/initial_conditions/scattered_disk.rs
@@ -187,6 +187,7 @@ mod tests {
     use crate::types::cartesian_to_elements;
     use rand::rngs::StdRng;
     use rand::SeedableRng;
+    use uom::si::length::astronomical_unit;
 
     #[test]
     fn test_scattered_disk_generation() {
@@ -207,7 +208,7 @@ mod tests {
                 config.a_max
             );
 
-            let q = elem.perihelion();
+            let q = elem.perihelion_typed().get::<astronomical_unit>();
             assert!(
                 q >= config.q_min * 0.99 && q <= config.q_max * 1.01,
                 "q = {} out of range [{}, {}]",

--- a/crates/p9-core/src/types.rs
+++ b/crates/p9-core/src/types.rs
@@ -24,10 +24,6 @@ impl StateVector {
         }
     }
 
-    pub fn distance(&self) -> f64 {
-        self.pos.norm()
-    }
-
     pub fn speed(&self) -> f64 {
         self.vel.norm()
     }
@@ -36,7 +32,7 @@ impl StateVector {
     /// storage stays `f64`/AU because `nalgebra`'s norm cannot carry units;
     /// this is the typed boundary accessor.)
     pub fn distance_typed(&self) -> Length {
-        units::au(self.distance())
+        units::au(self.pos.norm())
     }
 
     /// Speed as a dimension-checked [`Velocity`] (AU/day storage).
@@ -64,24 +60,9 @@ pub struct OrbitalElements {
 }
 
 impl OrbitalElements {
-    /// Perihelion distance q = a(1-e) in AU
-    pub fn perihelion(&self) -> f64 {
-        self.a * (1.0 - self.e)
-    }
-
-    /// Aphelion distance Q = a(1+e) in AU
-    pub fn aphelion(&self) -> f64 {
-        self.a * (1.0 + self.e)
-    }
-
     /// Semi-latus rectum p = a(1-e^2)
     pub fn semi_latus_rectum(&self) -> f64 {
         self.a * (1.0 - self.e * self.e)
-    }
-
-    /// Orbital period in days (only meaningful for bound orbits)
-    pub fn period(&self, gm: f64) -> f64 {
-        TWO_PI * (self.a.powi(3) / gm).sqrt()
     }
 
     /// Longitude of perihelion (varpi = Omega + omega)
@@ -112,16 +93,16 @@ impl OrbitalElements {
     }
     /// Perihelion distance `q = a(1-e)` as a [`Length`].
     pub fn perihelion_typed(&self) -> Length {
-        units::au(self.perihelion())
+        units::au(self.a * (1.0 - self.e))
     }
     /// Aphelion distance `Q = a(1+e)` as a [`Length`].
     pub fn aphelion_typed(&self) -> Length {
-        units::au(self.aphelion())
+        units::au(self.a * (1.0 + self.e))
     }
     /// Orbital period as a [`Time`]. `gm` is the central-body gravitational
     /// parameter in AU³/day² (the workspace's native unit).
     pub fn period_typed(&self, gm: f64) -> Time {
-        units::days(self.period(gm))
+        units::days(TWO_PI * (self.a.powi(3) / gm).sqrt())
     }
 }
 
@@ -239,11 +220,6 @@ impl P9Params {
         self.mass_solar() * GM_SUN
     }
 
-    /// Perihelion distance in AU
-    pub fn perihelion(&self) -> f64 {
-        self.a * (1.0 - self.e)
-    }
-
     // ---- typed boundary accessors (dimension-checked views of the f64 fields) ----
 
     /// Planet Nine mass as a [`Mass`] (from the Earth-mass field).
@@ -260,7 +236,7 @@ impl P9Params {
     }
     /// Perihelion distance as a [`Length`].
     pub fn perihelion_typed(&self) -> Length {
-        units::au(self.perihelion())
+        units::au(self.a * (1.0 - self.e))
     }
     /// Gravitational parameter `GM` as a typed [`GravitationalParameter`].
     pub fn gm_typed(&self) -> GravitationalParameter {
@@ -760,7 +736,7 @@ mod typed_accessor_tests {
         );
         assert_relative_eq!(
             p.perihelion_typed().get::<astronomical_unit>(),
-            p.perihelion(),
+            p.a * (1.0 - p.e),
             epsilon = 1e-12
         );
         // 10 M⊕ in kilograms.
@@ -790,7 +766,7 @@ mod typed_accessor_tests {
         .to_state_vector(GM_SUN);
         assert_relative_eq!(
             sv.distance_typed().get::<astronomical_unit>(),
-            sv.distance(),
+            sv.pos.norm(),
             epsilon = 1e-12
         );
     }


### PR DESCRIPTION
## Summary

With all ten `uom` adoption batches (#174–#183) merged, every core and paper-crate type now exposes dimension-checked typed accessors. This PR removes the redundant non-typed `f64` accessors that those typed views duplicated, so the typed boundary is the **only** API. Call sites that need a bare scalar now extract it explicitly from the typed quantity.

## What changed

- **p9-core**: removed the redundant `f64` methods `OrbitalElements::{perihelion, aphelion, period}`, `P9Params::perihelion`, and `StateVector::distance`; their bodies are inlined into the `*_typed()` accessors. Kept `gm()`/`speed()`/`mean_motion()` — their typed twins are in different units (SI vs AU³/day², SI vs AU/day), so they are not redundant.
- **33 paper crates**: removed every local `f64` method/function that had a `_typed` sibling (data accessors like `perihelion`/`aphelion`/`node`/`varpi`, and computational primitives like `free_precession_rate`, `mean_motion`, precession/frequency/width helpers). Internal physics arithmetic now flows through `uom` quantities; bare `f64` is extracted only at boundaries via the version-safe `(q / p9_core::units::au(1.0)).value` pattern (avoids a transitive dual-`uom`-version clash with `starfield`).
- Field-backed `*_typed()` accessors (which read a stored `f64` field rather than duplicate a method) were left intact — the fields are the storage.
- `uom` promoted from a dev-dependency to a normal dependency in the crates whose lib code now references it.

## Verification

- `cargo build --workspace` and `cargo test --workspace`: **0 failures across all suites.**
- `uom`'s compile-time dimensional checking guards the arithmetic rewrites; existing `*_typed() == f64()` equivalence tests were rewritten to compare the typed accessor against the inline closed-form formula.