### PR TITLE
Centralize mean_motion, albedo, solar luminosity, dec-limit into p9-core

### DIFF
--- a/crates/p9-2016-cowan-thermal/src/sed.rs
+++ b/crates/p9-2016-cowan-thermal/src/sed.rs
@@ -30,7 +30,7 @@
 //! body "could be as faint as 1 mJy at 1 mm". We keep these as labelled
 //! reference constants and document the residual against our computed value.
 
-use p9_core::analysis::photometry::mass_radius_neptunian;
+use p9_core::analysis::photometry::{mass_radius_neptunian, ALBEDO_NEPTUNE};
 use p9_core::analysis::thermal::{planck_bnu, reflected_flux_jy, thermal_flux_jy, C_LIGHT, JY};
 use p9_core::units::{au, earth_masses, meters, Length, Mass};
 
@@ -46,10 +46,6 @@ pub const COWAN_DISTANCE_AU: f64 = 700.0;
 /// Cowan et al. (2016) nominal mass scale (Earth masses): the paper's fiducial
 /// is a ~10 M⊕ ice giant, consistent with Batygin & Brown (2016).
 pub const COWAN_MASS_EARTH: f64 = 10.0;
-
-/// Neptune-like geometric albedo for the reflected-light channel (shared
-/// workspace value).
-pub const DEFAULT_ALBEDO: f64 = 0.41;
 
 /// Reference headline flux: Cowan et al. (2016) quote "~30 mJy at 1 mm" for the
 /// nominal 40 K, 700 AU body. Labelled reference only — not used in the
@@ -96,7 +92,7 @@ impl P9Sed {
             mass_earth: COWAN_MASS_EARTH,
             distance_au: COWAN_DISTANCE_AU,
             temp_k: COWAN_TEMP_K,
-            albedo: DEFAULT_ALBEDO,
+            albedo: ALBEDO_NEPTUNE,
         }
     }
 
@@ -107,7 +103,7 @@ impl P9Sed {
             mass_earth,
             distance_au,
             temp_k,
-            albedo: DEFAULT_ALBEDO,
+            albedo: ALBEDO_NEPTUNE,
         }
     }
 

--- a/crates/p9-2016-fortney-thermal/src/lib.rs
+++ b/crates/p9-2016-fortney-thermal/src/lib.rs
@@ -51,7 +51,7 @@
 use std::f64::consts::PI;
 
 use p9_core::analysis::photometry::{mass_radius_neptunian, ALBEDO_NEPTUNE};
-use p9_core::analysis::thermal::{planck_bnu, thermal_flux_jy, C_LIGHT};
+use p9_core::analysis::thermal::{planck_bnu, thermal_flux_jy, C_LIGHT, L_SUN_W};
 use p9_core::constants::AU_M;
 use p9_core::units::{au, earth_masses, meters, Length, Mass};
 
@@ -63,8 +63,6 @@ pub const SIGMA_SB: f64 = 5.670_374_419e-8;
 pub const WIEN_B_M_K: f64 = 2.897_771_955e-3;
 /// Earth radius (m); matches the photometry mass-radius anchor.
 pub const R_EARTH_M: f64 = 6.371e6;
-/// Solar luminosity (W).
-pub const L_SUN_W: f64 = 3.828e26;
 
 /// WISE W2 effective wavelength (4.6 µm); the redder of the two short WISE
 /// bands and the one the Meisner et al. (2018) shift-and-stack search uses.

--- a/crates/p9-2018-wise-search/src/thermal_model.rs
+++ b/crates/p9-2018-wise-search/src/thermal_model.rs
@@ -31,7 +31,7 @@
 //! is the shared Neptune-anchored mass-radius relation in
 //! `p9_core::analysis::photometry` (R ≈ 3.34 R⊕ at 10 M⊕).
 
-use p9_core::analysis::photometry::mass_radius_neptunian;
+use p9_core::analysis::photometry::{mass_radius_neptunian, ALBEDO_NEPTUNE};
 use p9_core::analysis::thermal::{
     effective_temp, flux_to_magnitude, reflected_flux_jy, solar_equilibrium_temp, thermal_flux_jy,
     C_LIGHT,
@@ -48,10 +48,6 @@ pub const W1_WAVELENGTH_M: f64 = 3.3526e-6;
 /// has F_ν = 309.540 Jy at W1 (Wright et al. 2010, Table 1). A source of
 /// flux F has W1 = −2.5 log10(F / F_ν0).
 pub const W1_ZERO_POINT_JY: f64 = 309.540;
-
-/// Default geometric/Bond-like albedo for the reflected-light channel
-/// (Neptune-like, used by the workspace photometry).
-pub const DEFAULT_ALBEDO: f64 = 0.41;
 
 /// Internal-luminosity temperature floor (K). A cold ice giant retains
 /// formation/radiogenic heat; Fortney et al. (2016) and the Meisner et al.
@@ -82,7 +78,7 @@ impl P9Thermal {
         Self {
             mass_earth,
             distance_au,
-            albedo: DEFAULT_ALBEDO,
+            albedo: ALBEDO_NEPTUNE,
             internal_temp_k: INTERNAL_TEMP_FLOOR_K,
         }
     }

--- a/crates/p9-2019-selfgrav-disk/src/secular.rs
+++ b/crates/p9-2019-selfgrav-disk/src/secular.rs
@@ -43,7 +43,7 @@
 use crate::disk::DiskProfile;
 use crate::laplace::softened_laplace;
 use p9_core::analysis::circular::wrap_to_pi;
-use p9_core::constants::GM_SUN;
+use p9_core::analysis::elements::mean_motion;
 use p9_core::units::{days, radians, Angle, AngularVelocity, Time};
 use std::f64::consts::PI;
 
@@ -100,11 +100,6 @@ impl SecularSolution {
     pub fn forced_delta_varpi_angle(&self) -> Angle {
         radians(self.forced_delta_varpi())
     }
-}
-
-/// Test-particle mean motion (radians/day).
-fn mean_motion(a: f64) -> f64 {
-    (GM_SUN / a.powi(3)).sqrt()
 }
 
 /// Solve the coplanar Laplace-Lagrange problem for a test particle at

--- a/crates/p9-2020-clement-precession/src/precession.rs
+++ b/crates/p9-2020-clement-precession/src/precession.rs
@@ -34,6 +34,7 @@
 //! (the exact Gauss-ring average), which captures the same dϖ/dt = +∂H/∂(action)
 //! structure without any α expansion.
 
+use p9_core::analysis::elements::mean_motion;
 use p9_core::analysis::secular::numerical_secular_hamiltonian;
 use p9_core::constants::{
     GM_SUN, GYR_DAYS, MASS_JUPITER_SOLAR, MASS_NEPTUNE_SOLAR, MASS_SATURN_SOLAR, MASS_URANUS_SOLAR,
@@ -85,11 +86,6 @@ pub fn giant_planets() -> [Perturber; 4] {
             mass_solar: MASS_NEPTUNE_SOLAR,
         },
     ]
-}
-
-/// Mean motion n = √(GM_⊙ / a³) in rad/day for a heliocentric orbit.
-pub fn mean_motion(a_au: f64) -> f64 {
-    (GM_SUN / a_au.powi(3)).sqrt()
 }
 
 /// Leading-order quadrupole apsidal precession rate dϖ/dt (rad/day) imposed on

--- a/crates/p9-2021-ztf/src/survey_model.rs
+++ b/crates/p9-2021-ztf/src/survey_model.rs
@@ -5,7 +5,7 @@
 //! used in Brown & Batygin (2021). The depth limit comes from the shared
 //! survey table in `p9_core::analysis::surveys`.
 
-use p9_core::analysis::surveys::limiting_magnitude;
+use p9_core::analysis::surveys::{limiting_magnitude, NORTHERN_SURVEY_DEC_LIMIT_DEG};
 use p9_core::units::{degrees, Angle};
 use serde::{Deserialize, Serialize};
 
@@ -28,7 +28,7 @@ impl Default for ZtfSurvey {
         Self {
             depth_limit: limiting_magnitude("ZTF").expect("ZTF in shared survey table"),
             efficiency_steepness: 4.0,
-            dec_limit_deg: -30.0,
+            dec_limit_deg: NORTHERN_SURVEY_DEC_LIMIT_DEG,
         }
     }
 }

--- a/crates/p9-2023-mond-efe/src/secular.rs
+++ b/crates/p9-2023-mond-efe/src/secular.rs
@@ -29,7 +29,7 @@ use std::f64::consts::{PI, TAU};
 
 use nalgebra::Vector3;
 
-use p9_core::constants::GM_SUN;
+use p9_core::analysis::elements::mean_motion;
 use p9_core::units::{days, radians, AngularVelocity};
 
 use crate::efe::efe_potential;
@@ -111,7 +111,7 @@ pub fn averaged_disturbing(
 /// Mean motion n = sqrt(GM_sun / a³) as a typed [`AngularVelocity`] (rad per
 /// day).
 pub fn mean_motion_typed(a: f64) -> AngularVelocity {
-    (radians((GM_SUN / (a * a * a)).sqrt()) / days(1.0)).into()
+    (radians(mean_motion(a)) / days(1.0)).into()
 }
 
 /// Secular apsidal precession rate dϖ/dt (rad/day) from Lagrange's planetary
@@ -255,6 +255,7 @@ mod tests {
     use super::*;
     use crate::efe::galactic_center_ecliptic;
     use approx::assert_relative_eq;
+    use p9_core::constants::GM_SUN;
 
     /// A representative ETNO orbital plane. We use the ecliptic plane (small
     /// ETNO inclinations) so the GC projection's ecliptic longitude is the

--- a/crates/p9-2024-panstarrs/src/survey_model.rs
+++ b/crates/p9-2024-panstarrs/src/survey_model.rs
@@ -7,7 +7,9 @@
 //! cuts, and the measured 99.2% linking efficiency. The single-exposure
 //! depth comes from the shared `p9_core::analysis::surveys` table.
 
-use p9_core::analysis::surveys::{limiting_magnitude, poisson_binomial_tail};
+use p9_core::analysis::surveys::{
+    limiting_magnitude, poisson_binomial_tail, NORTHERN_SURVEY_DEC_LIMIT_DEG,
+};
 use p9_core::coords::observer::{Time, Timescale};
 use serde::{Deserialize, Serialize};
 
@@ -51,7 +53,7 @@ impl Default for Ps1Survey {
     fn default() -> Self {
         Self {
             depth_limit: limiting_magnitude("PS1 3pi").expect("PS1 in shared survey table"),
-            dec_limit_deg: -30.0,
+            dec_limit_deg: NORTHERN_SURVEY_DEC_LIMIT_DEG,
             n_epochs: 17,
             linking_threshold: 9,
             efficiency_steepness: 3.0,

--- a/crates/p9-2024-primordial-alignment/src/precession.rs
+++ b/crates/p9-2024-primordial-alignment/src/precession.rs
@@ -34,14 +34,10 @@
 //! Giant-planet masses and semi-major axes are taken from the p9-core J2000
 //! ephemeris states (no local planet table), matching the nodal-rate code.
 
+use p9_core::analysis::elements::mean_motion;
 use p9_core::constants::{GM_SUN, YEAR_DAYS};
 use p9_core::initial_conditions::planets::giant_planets_j2000;
 use p9_core::types::cartesian_to_elements;
-
-/// Mean motion n = √(GM_sun/a³) in rad/day.
-pub fn mean_motion(a: f64) -> f64 {
-    (GM_SUN / (a * a * a)).sqrt()
-}
 
 /// The dimensionless secular forcing sum Σ_j (m_j/M_sun)(a_j/a)³ from the four
 /// giant planets (Jupiter…Neptune), evaluated from their J2000 ephemeris

--- a/crates/p9-2025-planet-y/src/laplace_plane.rs
+++ b/crates/p9-2025-planet-y/src/laplace_plane.rs
@@ -51,8 +51,9 @@
 //! the Laplace-surface treatment of §5.3; Siraj, Loeb & Siegel (2025),
 //! arXiv:2508.14156.
 
+use p9_core::analysis::elements::mean_motion;
 use p9_core::constants::{
-    DEG2RAD, EARTH_MASS_SOLAR, GM_SUN, MASS_JUPITER_SOLAR, MASS_NEPTUNE_SOLAR, MASS_SATURN_SOLAR,
+    DEG2RAD, EARTH_MASS_SOLAR, MASS_JUPITER_SOLAR, MASS_NEPTUNE_SOLAR, MASS_SATURN_SOLAR,
     MASS_URANUS_SOLAR,
 };
 use p9_core::forces::j2_secular::effective_j2;
@@ -124,11 +125,6 @@ impl PlanetY {
     pub fn inclination_angle(&self) -> Angle {
         radians(self.inclination)
     }
-}
-
-/// Mean motion of a test particle (rad/day) about the Sun.
-fn mean_motion(a_au: f64) -> f64 {
-    (GM_SUN / (a_au * a_au * a_au)).sqrt()
 }
 
 /// Inner (giant-planet quadrupole) nodal-precession coefficient at semi-major

--- a/crates/p9-2025-simons-forecast/src/thermal.rs
+++ b/crates/p9-2025-simons-forecast/src/thermal.rs
@@ -33,7 +33,7 @@
 //! the floor dominates) — the same temperature model as the WISE crate, so the
 //! two reproductions share a physical body.
 
-use p9_core::analysis::photometry::mass_radius_neptunian;
+use p9_core::analysis::photometry::{mass_radius_neptunian, ALBEDO_NEPTUNE};
 use p9_core::analysis::thermal::{
     effective_temp, planck_bnu, rayleigh_jeans_bnu, solar_equilibrium_temp, thermal_flux_jy,
 };
@@ -41,10 +41,6 @@ use p9_core::units::{au, earth_masses, meters, Length, Mass};
 
 /// Earth radius (m).
 const R_EARTH_M: f64 = 6.371e6;
-
-/// Neptune-like geometric/Bond albedo, used only for the solar-equilibrium
-/// temperature term.
-pub const DEFAULT_ALBEDO: f64 = 0.41;
 
 /// Internal-luminosity effective-temperature floor (K). A several-Earth-mass
 /// ice giant retains formation/radiogenic heat; Fortney et al. (2016) and the
@@ -74,7 +70,7 @@ impl P9Thermal {
         Self {
             mass_earth,
             distance_au,
-            albedo: DEFAULT_ALBEDO,
+            albedo: ALBEDO_NEPTUNE,
             internal_temp_k: INTERNAL_TEMP_FLOOR_K,
         }
     }

--- a/crates/p9-core/src/analysis/elements.rs
+++ b/crates/p9-core/src/analysis/elements.rs
@@ -4,6 +4,14 @@ use super::Snapshot;
 use crate::constants::GM_SUN;
 use crate::types::{cartesian_to_elements, StateVector};
 
+/// Mean motion `n = sqrt(GM_sun / a^3)` (rad/day) for a heliocentric orbit of
+/// semi-major axis `a_au` (AU), in the workspace's native units (GM in
+/// AU^3/day^2). For an arbitrary central mass use
+/// [`crate::types::OrbitalElements::mean_motion`].
+pub fn mean_motion(a_au: f64) -> f64 {
+    (GM_SUN / a_au.powi(3)).sqrt()
+}
+
 /// Compute orbital elements for all active particles and record a snapshot.
 pub fn record_snapshot(
     particles: &[StateVector],

--- a/crates/p9-core/src/analysis/surveys.rs
+++ b/crates/p9-core/src/analysis/surveys.rs
@@ -5,6 +5,10 @@
 //! 0.56 and 0.612-combined in three crates, and two crates disagreed about
 //! the DES depth (23.8 vs 24.1).
 
+/// Southern declination cutoff (deg) of the wide northern surveys: both ZTF
+/// (Palomar) and the Pan-STARRS1 3π survey adopt a footprint of δ > −30°.
+pub const NORTHERN_SURVEY_DEC_LIMIT_DEG: f64 = -30.0;
+
 /// A survey's published contribution to the Planet Nine parameter-space
 /// exclusion.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/crates/p9-core/src/analysis/thermal.rs
+++ b/crates/p9-core/src/analysis/thermal.rs
@@ -26,6 +26,8 @@ pub const C_LIGHT: f64 = 2.997_924_58e8;
 pub const R_SUN_M: f64 = 6.957e8;
 /// Solar effective temperature (K).
 pub const T_SUN: f64 = 5778.0;
+/// Solar bolometric luminosity (W).
+pub const L_SUN_W: f64 = 3.828e26;
 /// 1 AU in meters.
 pub const AU_M: f64 = 1.495_978_707e11;
 /// 1 Jansky in W/m²/Hz.


### PR DESCRIPTION
Acts on the duplication audit: pulls the remaining genuinely-shared values/logic into `p9-core` and repoints the duplicates. No behavior change (all touched crates' tests pass).

## New in p9-core
- `analysis::elements::mean_motion(a_au) -> f64` — `√(GM_⊙/a³)` in rad/day (the workspace's native units). Complements the existing `OrbitalElements::mean_motion(gm)` method for the common GM_⊙ case.
- `analysis::thermal::L_SUN_W` — solar luminosity.
- `analysis::surveys::NORTHERN_SURVEY_DEC_LIMIT_DEG` — the δ > −30° footprint cutoff shared by ZTF and PS1 3π.
- (`photometry::ALBEDO_NEPTUNE` already existed.)

## Repointed
- **`mean_motion`**: removed the local `√(GM_⊙/a³)` reimplementations in `selfgrav-disk`, `clement-precession`, `primordial-alignment`, `planet-y`, and routed `mond-efe`'s typed wrapper through core. **Left local on purpose:** `secular-dynamics` (uses a J2-boosted GM), `uranus-tilt` (rad/yr form), `inclination-instability` (already builds `OrbitalElements`), and the `iorio-precession` struct methods.
- **Neptune albedo 0.41**: `cowan-thermal`, `wise-search`, `simons-forecast` now import `ALBEDO_NEPTUNE` instead of a local `DEFAULT_ALBEDO`.
- **Solar luminosity**: `fortney-thermal` imports `L_SUN_W`.
- **Dec limit −30°**: `ztf` and `panstarrs` defaults reference the shared constant. `ps1-holman` keeps its value in its `published` module (consistent with how the repo documents published reference numbers).

## Deliberately not centralized
Per-survey detection-efficiency steepness (instrument-calibrated), DES footprint bands, WISE galactic mask, paper-specific observed-TNO tables, and the octupole/galactic Hamiltonian extensions — these are genuinely local, not duplication.

Verified: `cargo build --workspace` clean (no warnings), and tests green across p9-core + all 11 touched paper crates.