### PR TITLE
Add manim segments for four gap papers

### DIFF
--- a/animations/EQUATIONS.md
+++ b/animations/EQUATIONS.md
@@ -95,3 +95,7 @@ A "—" means the scene is visual; no new equation required (keep any it has).
 - **FortneyThermal2016** — `T_{\rm eff} = \max(T_{\rm eq},\,T_{\rm int})`
 - **LinderEvolution2016** — `T_{\rm eff}(t) \downarrow,\quad L \propto R^2 T^4`
 - **KuiperBelt2018** — `e = 1 - q/a`
+- **RussellAlbedo2025** — `m = H + 5\log_{10}(r\,\Delta)` ; mini-Neptune `R = 2.0\text{–}2.6\,R_\oplus`, `p_V = 0.33\text{–}0.47`
+- **StellarFlybys2025** — `\Gamma = n_\star\,\sigma\,v,\ \sigma = \pi q_\star^2\big(1+\tfrac{2GM}{q_\star v^2}\big)` ; `P \approx P_{\rm enc}\,f_{\rm geom}\,f_{\rm succ} \lesssim 5\%`
+- **StellarCompanions2026** — `M_{\max}(d) = M_\star\,(d/d_\star)^3` ; halo `M(<1000\,\mathrm{AU}) < M_{\rm Pluto}`
+- **AlphaSlope2026** — `F \propto d^{\alpha}`, `\alpha = -4` (reflected) vs `-2` (self-luminous)

--- a/animations/manifest.yaml
+++ b/animations/manifest.yaml
@@ -97,3 +97,7 @@ papers:
   - {file: scenes/papers/p9_2021_des_catalog/scene.py,     scene: DesCatalog2021}
   - {file: scenes/papers/p9_2022_iras_candidate/scene.py,  scene: IrasCandidate2022}
   - {file: scenes/papers/p9_2026_iorio_precession/scene.py, scene: Iorio2026}
+  - {file: scenes/papers/p9_2025_russell_albedo/scene.py,  scene: RussellAlbedo2025}
+  - {file: scenes/papers/p9_2025_stellar_flybys/scene.py,  scene: StellarFlybys2025}
+  - {file: scenes/papers/p9_2026_stellar_companions/scene.py, scene: StellarCompanions2026}
+  - {file: scenes/papers/p9_2026_alpha_slope/scene.py,     scene: AlphaSlope2026}

--- a/animations/p9_manim/content.py
+++ b/animations/p9_manim/content.py
@@ -789,6 +789,50 @@ PAPER_TEXT = {
             "Precession remains a sensitive, model-dependent probe.",
         ],
     },
+    "p9-2025-russell-albedo": {
+        "hypothesis": "If Planet Nine is a ~6.6 Earth-mass mini-Neptune, its size, colour, and brightness follow from exoplanet mass-radius models.",
+        "arguments": [
+            "Confirmed cold exoplanets (Teq < 600 K) fix the most likely radius at 2.0-2.6 Earth radii with a thin H-He envelope.",
+            "Giant-planet albedos extrapolate to a V-band geometric albedo of 0.33-0.47 for such a world.",
+        ],
+        "conclusions": [
+            "Planet Nine should sit near absolute magnitude -6.1 to -5.2 and apparent +21.9 to +22.7.",
+            "That is within reach of upcoming surveys -- and would even show a resolvable disk to the largest telescopes.",
+        ],
+    },
+    "p9-2025-stellar-flybys": {
+        "hypothesis": "A close stellar flyby early in the Solar System's life could have detached the sednoids -- no present-day planet needed.",
+        "arguments": [
+            "The detached extreme TNOs share a low-inclination (i < 30 degrees) profile and a primordial apsidal alignment.",
+            "Only special flyby geometries (coplanar or ecliptic-symmetric) reproduce that, and close encounters (q* < 1000 AU) are rare.",
+        ],
+        "conclusions": [
+            "Folding in how often such an encounter actually happens leaves a probability of only about 5%.",
+            "An early flyby is an unlikely sole sculptor of the detached belt.",
+        ],
+    },
+    "p9-2026-stellar-companions": {
+        "hypothesis": "The Sun's nearest companion might be a hidden, gravity-only object at hundreds-to-thousands of AU rather than a star at a parsec.",
+        "arguments": [
+            "A tidal mass-distance envelope calibrated to Planet-Nine-like constraints grows as distance cubed.",
+            "It allows Earth-to-sub-Saturn masses at 300-1000 AU, rising to a Jupiter mass near 2000 AU.",
+        ],
+        "conclusions": [
+            "A smooth dark-matter halo cannot supply it -- only a sub-Pluto mass lies within 1000 AU.",
+            "Any such companion must be a structured, bound object, visible only through its gravity.",
+        ],
+    },
+    "p9-2026-alpha-slope": {
+        "hypothesis": "How a body's brightness fades with distance (flux ~ d^alpha) reveals whether it shines by reflection or its own light.",
+        "arguments": [
+            "Reflected sunlight falls as d^-4; self-luminous emission falls as d^-2.",
+            "Of 8,557 archival TNO photometry bins, only 186 survive the eligibility cuts -- 53 reflected, 24 self-luminous, 109 anomalous.",
+        ],
+        "conclusions": [
+            "All 24 'self-luminous' detections trace to a single instrument -- calibration systematics, not new physics.",
+            "Archival photometry is too messy to run the test cleanly even on Pluto.",
+        ],
+    },
 }
 
 

--- a/animations/p9_manim/paper.py
+++ b/animations/p9_manim/paper.py
@@ -22,12 +22,16 @@ def crate_description(crate):
     return crate
 
 
-def title_block(crate, headline):
-    """A scene-opening title: the paper headline + an auto citation chip."""
+def title_block(crate, headline, cite=None):
+    """A scene-opening title: the paper headline + a citation chip.
+
+    The chip text is taken from ``cite`` when given, otherwise derived from the
+    crate's Cargo.toml description (the usual case)."""
     title = Text(headline, color=T.FG, font_size=34, weight="BOLD").to_edge(UP, buff=0.6)
-    cite = Text(_short_cite(crate_description(crate)), color=T.MUTED, font_size=18)
-    cite.next_to(title, DOWN, buff=0.18)
-    return VGroup(title, cite)
+    chip = cite if cite is not None else _short_cite(crate_description(crate))
+    cite_t = Text(chip, color=T.MUTED, font_size=18)
+    cite_t.next_to(title, DOWN, buff=0.18)
+    return VGroup(title, cite_t)
 
 
 def _short_cite(desc):

--- a/animations/scenes/papers/p9_2025_russell_albedo/scene.py
+++ b/animations/scenes/papers/p9_2025_russell_albedo/scene.py
@@ -1,0 +1,79 @@
+"""Russell & White (2025) -- what Planet Nine would look like.
+
+Given a 6.6 M-Earth body, the most-likely composition is a mini-Neptune: a
+2.0-2.6 R-Earth ball under an H-He envelope, geometric albedo 0.33-0.47. That
+fixes an absolute magnitude H = -6.1 to -5.2 and an apparent magnitude of about
++21.9 to +22.7 near 625 AU. Reproduced in p9-2025-russell-albedo.
+"""
+from manim import (
+    Annulus,
+    Circle,
+    Create,
+    DOWN,
+    FadeIn,
+    FadeOut,
+    LEFT,
+    RIGHT,
+    Scene,
+    UP,
+    VGroup,
+    Write,
+)
+
+import p9_manim as P
+from p9_manim import layout, paper, timing, widgets
+
+CRATE = "p9-2025-russell-albedo"
+
+
+class RussellAlbedo2025(Scene):
+    def construct(self):
+        tb = paper.title_block(CRATE, "What would Planet Nine look like?",
+                               cite="Russell & White (2025)")
+        self.play(Write(tb[0]), FadeIn(tb[1]))
+        self.play(tb.animate.scale(0.62).to_edge(UP, buff=0.3))
+
+        bg = widgets.star_field(n=70, seed=2507, x=(-6, 6), y=(-2.2, 1.8),
+                                radius=0.02, opacity=0.45)
+        self.play(FadeIn(bg, lag_ratio=0.005))
+
+        # The mini-Neptune disk with a faint reflected-light glow.
+        glow = Annulus(inner_radius=0.62, outer_radius=1.1, color=P.BLUE,
+                       fill_opacity=0.10, stroke_width=0).move_to(LEFT * 3.4)
+        disk = Circle(radius=0.6, color=P.BLUE, fill_opacity=0.9,
+                      stroke_color=P.TEAL, stroke_width=2).move_to(LEFT * 3.4)
+        dlbl = layout.label("mini-Neptune\nH-He envelope 0.6-3.5%",
+                            font_size=16, color=P.TEAL).next_to(disk, DOWN, buff=0.3)
+        self.play(FadeIn(glow), Create(disk), FadeIn(dlbl))
+        timing.hold_to_read(self, dlbl, settle=0.5)
+
+        # mass -> radius -> albedo chain
+        chain = VGroup(
+            layout.label("mass  6.6 M_E", font_size=20, color=P.FG),
+            layout.label("radius  2.0-2.6 R_E", font_size=20, color=P.BLUE),
+            layout.label("albedo (V)  0.33-0.47", font_size=20, color=P.GREEN),
+        ).arrange(DOWN, buff=0.45, aligned_edge=LEFT).move_to(RIGHT * 2.6 + UP * 0.4)
+        self.play(FadeIn(chain, lag_ratio=0.3))
+        timing.hold_to_read(self, chain, settle=0.8)
+        self.play(FadeOut(chain), FadeOut(glow), FadeOut(disk), FadeOut(dlbl))
+
+        # Reflected-light / absolute-magnitude relation, walked term by term.
+        eq = layout.explain_equation(
+            self,
+            [r"m", "=", r"H", "+", r"5\log_{10}\!\big(r\,\Delta\big)"],
+            [(0, "apparent magnitude -- how faint it looks from Earth"),
+             (2, "absolute magnitude: brightness from reflected size and albedo"),
+             (4, "distance dimming -- heliocentric r times Earth-distance Delta")],
+            color=P.TEAL, scale=0.95, where=UP * 0.6)
+        self.play(FadeOut(eq))
+
+        ro = paper.result_readout("apparent magnitude near 625 AU",
+                                  "m ~ 21.9-22.7", color=P.ORANGE).scale(0.72)
+        ro.move_to(UP * 0.7)
+        hbeat = layout.label("H = -6.1 to -5.2   (bright: 2.6 R_E / 0.47   faint: 2.0 R_E / 0.33)",
+                             font_size=17, color=P.PURPLE).next_to(ro, DOWN, buff=0.4)
+        self.play(FadeIn(ro), FadeIn(hbeat))
+        timing.hold_to_read(self, ro, hbeat, settle=1.0)
+
+        layout.show_takeaway(
+            self, "A faint reflected dot near +22 mag -- within reach of world-class survey telescopes.")

--- a/animations/scenes/papers/p9_2025_stellar_flybys/scene.py
+++ b/animations/scenes/papers/p9_2025_stellar_flybys/scene.py
@@ -1,0 +1,131 @@
+"""Hu, Huang, Gladman & Zhu (2025) -- early stellar flybys are unlikely.
+
+A close stellar flyby can lift TNO perihelia to make sednoids, but the LOW
+inclinations (i < 30 deg) and primordial apsidal alignment of detached extreme
+TNOs only allow special (coplanar / ecliptic-symmetric) geometries. Folding that
+small geometric fraction into how often a close encounter (q* <= 1000 au) happens
+leaves <= 5% odds. Reproduced in p9-2025-stellar-flybys.
+"""
+import numpy as np
+from manim import (
+    Create,
+    DOWN,
+    Dot,
+    FadeIn,
+    FadeOut,
+    LEFT,
+    Line,
+    RIGHT,
+    Scene,
+    UP,
+    VGroup,
+    Write,
+    rate_functions,
+)
+
+import p9_manim as P
+from p9_manim import layout, orbits, paper, timing
+
+CRATE = "p9-2025-stellar-flybys"
+
+
+class StellarFlybys2025(Scene):
+    def construct(self):
+        tb = paper.title_block(
+            CRATE, "Did a passing star make the sednoids?",
+            cite="Hu, Huang, Gladman & Zhu (2025)")
+        self.play(Write(tb[0]), FadeIn(tb[1]))
+        self.play(tb.animate.scale(0.62).to_edge(UP, buff=0.3))
+
+        sun = orbits.sun()
+        self.add(sun)
+
+        # the primordial scattered/detached disk
+        rng = np.random.default_rng(2025)
+        start = np.deg2rad(40) + rng.normal(0, np.deg2rad(20), 8)
+        disk = VGroup(*[
+            orbits.ellipse_orbit(2.1, 0.62, color=P.GREEN, varpi=v,
+                                 stroke_width=1.6, opacity=0.8)
+            for v in start
+        ])
+        self.play(Create(disk, lag_ratio=0.1), run_time=1.6)
+        disk_lbl = layout.label("scattered/detached disk", font_size=18,
+                                color=P.MUTED).to_edge(DOWN, buff=0.6)
+        self.play(FadeIn(disk_lbl))
+        timing.hold_to_read(self, disk_lbl, settle=0.5)
+        self.play(FadeOut(disk_lbl))
+
+        # a star flies past on a straight path, perturbing perihelia
+        path = Line(LEFT * 6.2 + UP * 2.4, RIGHT * 6.2 + DOWN * 2.4)
+        star = Dot(path.get_start(), radius=0.11, color=P.SUN).set_z_index(6)
+        star_lbl = layout.label("passing field star", font_size=18, color=P.SUN)
+        star_lbl.add_updater(lambda m: m.next_to(star, UP, buff=0.12))
+        self.play(FadeIn(star), FadeIn(star_lbl))
+        # the flyby tugs the disk apsides toward a common direction (alignment)
+        target = np.deg2rad(35) + rng.normal(0, np.deg2rad(7), 8)
+        self.play(
+            star.animate.move_to(path.get_end()),
+            *orbits.precess(disk, start, target),
+            run_time=3.0, rate_func=rate_functions.smooth,
+        )
+        star_lbl.clear_updaters()
+        self.play(FadeOut(star), FadeOut(star_lbl))
+
+        nudge = layout.label("perihelia lifted + apsides aligned", font_size=18,
+                             color=P.ORANGE).to_edge(DOWN, buff=0.6)
+        self.play(FadeIn(nudge))
+        timing.hold_to_read(self, nudge, settle=0.6)
+        self.play(FadeOut(nudge), FadeOut(disk))
+
+        # BUT: the detached eTNOs are observed at LOW inclination
+        con = layout.label(
+            "but detached extreme TNOs sit at LOW inclination: i < 30 deg",
+            font_size=22, color=P.RED).to_edge(UP, buff=1.5)
+        self.play(FadeIn(con))
+        timing.hold_to_read(self, con, settle=0.6)
+        geom = layout.label(
+            "only special flyby geometries fit -- coplanar or ecliptic-symmetric",
+            font_size=20, color=P.TEAL).next_to(con, DOWN, buff=0.3)
+        self.play(FadeIn(geom))
+        timing.hold_to_read(self, geom, settle=0.8)
+        self.play(FadeOut(con), FadeOut(geom))
+
+        # the focused encounter rate sets how OFTEN a close passage happens
+        eq1 = layout.explain_equation(
+            self,
+            [r"\Gamma", "=", r"n_\star\,\sigma\,v", r"\quad",
+             r"\sigma=\pi q_\star^2\!\left(1+\tfrac{2GM}{q_\star v^2}\right)"],
+            [
+                (0, "rate of close stellar encounters in the birth cluster"),
+                (2, "star density x cross-section x relative speed"),
+                (4, "gravitationally focused area for passages q* <= 1000 au"),
+            ],
+            scale=0.78,
+        )
+        self.play(FadeOut(eq1))
+
+        # the overall probability: encounter happens x geometry fits x it works
+        eq2 = layout.explain_equation(
+            self,
+            [r"P", r"\approx", r"P_{\rm enc}", r"\times",
+             r"f_{\rm geom}", r"\times", r"f_{\rm succ}"],
+            [
+                (2, "chance a close encounter (q* <= 1000 au) ever occurred"),
+                (4, "fraction of geometries giving i < 30 deg + alignment"),
+                (6, "fraction of those that actually build the sednoids"),
+            ],
+            scale=0.92,
+            where=UP * 1.7,
+        )
+        self.play(FadeOut(eq2))
+
+        ro = paper.result_readout(
+            "probability a constraint-satisfying flyby occurred",
+            "<= 5%", color=P.RED).scale(0.8)
+        self.play(FadeIn(ro))
+        timing.hold_to_read(self, ro, settle=1.0)
+        self.play(FadeOut(ro))
+
+        layout.show_takeaway(
+            self,
+            "An early flyby clears every hurdle only ~5% of the time.")

--- a/animations/scenes/papers/p9_2026_alpha_slope/scene.py
+++ b/animations/scenes/papers/p9_2026_alpha_slope/scene.py
@@ -1,0 +1,127 @@
+"""Eldadi & Loeb (2026) -- the Loeb-Turner alpha-slope test on TNO photometry.
+
+Reflected sunlight falls off as d^-4 (out and back); self-luminous emission only
+as d^-2. The slope alpha of log(flux) vs log(distance) tells them apart. Run
+across the MPC archive through a six-criterion pipeline, the "self-luminous"
+detections all trace to one instrument -- a calibration tell, not new physics.
+Reproduced in p9-2026-alpha-slope.
+"""
+import numpy as np
+from manim import (
+    Create,
+    DOWN,
+    FadeIn,
+    FadeOut,
+    LEFT,
+    RIGHT,
+    Scene,
+    UP,
+    VGroup,
+    Write,
+)
+
+import p9_manim as P
+from p9_manim import layout, paper, timing, widgets
+
+CRATE = "p9-2026-alpha-slope"
+
+
+class AlphaSlope2026(Scene):
+    def construct(self):
+        tb = paper.title_block(
+            CRATE, "Reflected or self-luminous?", cite="Eldadi & Loeb (2026)")
+        self.play(Write(tb[0]), FadeIn(tb[1]))
+        self.play(tb.animate.scale(0.62).to_edge(UP, buff=0.3))
+
+        # --- log(flux) vs log(distance): two diagnostic slopes -----------------
+        ax = widgets.axes([0.0, 2.0, 0.5], [-9.0, 0.5, 2.0],
+                          x_length=7.6, y_length=3.9, font_size=16, shift_down=0.4)
+        xlab = layout.label("log heliocentric distance", font_size=18, color=P.FG)
+        xlab.next_to(ax, DOWN, buff=0.25)
+        ylab = layout.label("log flux", font_size=18, color=P.FG)
+        ylab.rotate(np.pi / 2).next_to(ax, LEFT, buff=0.15)
+        self.play(Create(ax), FadeIn(xlab), FadeIn(ylab))
+
+        xs = np.array([0.1, 1.9])
+        # Both lines share a left anchor so the fan-out reads as "same body".
+        anchor = -0.4
+        reflected = anchor - 4.0 * xs   # alpha = -4
+        selflum = anchor - 2.0 * xs     # alpha = -2
+
+        line_ref = ax.plot_line_graph(xs, reflected, line_color=P.TEAL,
+                                      add_vertex_dots=False, stroke_width=4)
+        line_self = ax.plot_line_graph(xs, selflum, line_color=P.RED,
+                                       add_vertex_dots=False, stroke_width=4)
+        self.play(Create(line_self))
+        l_self = layout.label("alpha = -2  self-luminous", font_size=17, color=P.RED)
+        l_self.next_to(ax.c2p(1.9, selflum[1]), RIGHT, buff=0.12)
+        self.play(FadeIn(l_self))
+        self.play(Create(line_ref))
+        l_ref = layout.label("alpha = -4  reflected sunlight", font_size=17, color=P.TEAL)
+        l_ref.next_to(ax.c2p(1.9, reflected[1]), RIGHT, buff=0.12)
+        self.play(FadeIn(l_ref))
+        timing.hold_to_read(self, l_ref, l_self, settle=0.7)
+        self.play(FadeOut(line_ref), FadeOut(line_self), FadeOut(l_ref),
+                  FadeOut(l_self), FadeOut(ax), FadeOut(xlab), FadeOut(ylab))
+
+        eq = layout.explain_equation(
+            self,
+            [r"F", r"\propto", r"d^{\alpha}", r"\quad",
+             r"\alpha=-4\ (\text{reflected}),\ -2\ (\text{self-lum.})"],
+            [
+                (0, "the measured flux of the body"),
+                (2, "falls off as distance to the power alpha"),
+                (2, "reflected light loses d-squared out and d-squared back"),
+                (4, "thermal/internal light only loses d-squared -- the slope tells them apart"),
+            ],
+            color=P.FG, scale=0.7, where=UP * 0.4)
+        self.play(FadeOut(eq))
+
+        # --- the eligibility funnel -------------------------------------------
+        funnel = widgets.value_rows(
+            [
+                "8,557  candidate (KBO x observatory x band) bins",
+                "1,089  pass Q1-Q3",
+                "186  also pass Q4-Q6",
+            ],
+            color=P.FG, font_size=22, line_buff=0.30)
+        funnel.move_to(UP * 0.9)
+        for row in funnel:
+            self.play(FadeIn(row, shift=DOWN * 0.1), run_time=0.5)
+        timing.hold_to_read(self, funnel, settle=0.6)
+
+        split = widgets.value_rows(
+            [
+                "53  reflected   (alpha = -4)",
+                "24  self-luminous   (alpha = -2)",
+                "109  anomalous",
+            ],
+            color=P.FG, font_size=22, line_buff=0.26)
+        split[0].set_color(P.TEAL)
+        split[1].set_color(P.RED)
+        split[2].set_color(P.ORANGE)
+        split.next_to(funnel, DOWN, buff=0.55)
+        self.play(FadeIn(split, lag_ratio=0.3))
+        timing.hold_to_read(self, split, settle=0.8)
+        self.play(FadeOut(funnel), FadeOut(split))
+
+        # --- the punchline: the 24 all came from one instrument ---------------
+        ro = paper.result_readout(
+            "self-luminous detections -- all from one instrument",
+            "Pan-STARRS only", color=P.RED).scale(0.8)
+        ro.move_to(UP * 0.7)
+        self.play(FadeIn(ro))
+        timing.hold_to_read(self, ro, settle=0.8)
+
+        pluto = layout.label(
+            "Even Pluto (22 bins) cannot cleanly recover alpha = -4: 0 bins do.",
+            font_size=20, color=P.MUTED)
+        pluto.next_to(ro, DOWN, buff=0.55)
+        self.play(FadeIn(pluto))
+        timing.hold_to_read(self, pluto, settle=0.8)
+        self.play(FadeOut(ro), FadeOut(pluto))
+
+        layout.show_takeaway(
+            self,
+            "One instrument can't separate the slopes -- "
+            "the alpha-test needs cross-calibrated data.")

--- a/animations/scenes/papers/p9_2026_stellar_companions/scene.py
+++ b/animations/scenes/papers/p9_2026_stellar_companions/scene.py
@@ -1,0 +1,137 @@
+"""Benakli (2026) -- A Solar-System window for hidden stellar companions.
+
+A tidal mass-distance envelope, calibrated to Planet-Nine-like constraints,
+caps the mass an unseen companion can have at a given distance: M_max grows as
+distance cubed. That window admits Earth-to-sub-Saturn masses at hundreds of AU,
+rising to ~1 Jupiter mass near 2000 AU -- far more than any smooth dark-matter
+halo could supply. Reproduced in p9-2026-stellar-companions.
+"""
+import numpy as np
+from manim import (
+    Create,
+    DOWN,
+    Dot,
+    FadeIn,
+    FadeOut,
+    LEFT,
+    Line,
+    Polygon,
+    RIGHT,
+    Scene,
+    UP,
+    VGroup,
+    Write,
+)
+
+import p9_manim as P
+from p9_manim import layout, paper, timing, widgets
+
+CRATE = "p9-2026-stellar-companions"
+
+# Tidal envelope, anchored to a Planet-Nine-like point: M_max(d) = M_* (d/d_*)^3
+D_STAR = 300.0     # AU
+M_STAR = 1.0       # Earth masses
+
+
+def m_max(d):
+    return M_STAR * (d / D_STAR) ** 3
+
+
+class StellarCompanions2026(Scene):
+    def construct(self):
+        tb = paper.title_block(CRATE, "A window for hidden companions", cite="Benakli (2026)")
+        self.play(Write(tb[0]), FadeIn(tb[1]))
+        self.play(tb.animate.scale(0.62).to_edge(UP, buff=0.3))
+
+        # mass (Y, log) vs distance (X, log). Axes drawn over log10 coordinates.
+        # X: 100..3000 AU -> log10 2..3.48 ; Y: 0.1..1000 Mearth -> log10 -1..3
+        x_lo, x_hi = 2.0, np.log10(3000.0)
+        y_lo, y_hi = -1.0, 3.0
+        ax = widgets.axes([x_lo, x_hi, 1.0], [y_lo, y_hi, 1.0], x_length=9.6, y_length=4.4,
+                          font_size=18, shift_down=0.45)
+        xlab = layout.label("distance from Sun (AU)", font_size=18, color=P.FG).next_to(ax, DOWN, buff=0.55)
+        ylab = layout.label("mass (Earth masses)", font_size=18, color=P.FG).rotate(np.pi / 2).next_to(ax, LEFT, buff=0.55)
+        self.play(Create(ax), FadeIn(xlab), FadeIn(ylab))
+
+        # tick relabels in real units (decades)
+        tick_grp = VGroup()
+        for au in (100, 300, 1000, 3000):
+            t = layout.label(str(au), font_size=14, color=P.MUTED)
+            t.next_to(ax.c2p(np.log10(au), y_lo), DOWN, buff=0.14)
+            tick_grp.add(t)
+        for me, txt in [(-1, "0.1"), (0, "1"), (1, "10"), (2, "100"), (3, "1000")]:
+            t = layout.label(txt, font_size=14, color=P.MUTED)
+            t.next_to(ax.c2p(x_lo, me), LEFT, buff=0.14)
+            tick_grp.add(t)
+        self.add(tick_grp)
+
+        # the M_max(d) ∝ d³ envelope line (in log-log it is a straight line)
+        ds = np.linspace(100.0, 3000.0, 80)
+        lx = np.log10(ds)
+        ly = np.clip(np.log10(m_max(ds)), y_lo, y_hi)
+        env_line = ax.plot_line_graph(lx, ly, line_color=P.TEAL, add_vertex_dots=False, stroke_width=3)
+
+        # shade the ALLOWED window: below the envelope, above the floor
+        pts = [ax.c2p(x, y) for x, y in zip(lx, ly)]
+        pts += [ax.c2p(lx[-1], y_lo)]
+        pts += [ax.c2p(lx[0], y_lo)]
+        allowed = Polygon(*pts, color=P.TEAL, fill_opacity=0.16, stroke_width=0)
+        self.play(FadeIn(allowed), Create(env_line))
+
+        env_lbl = layout.label("M_max ∝ d³  (tidal limit)", font_size=16, color=P.TEAL, weight="BOLD")
+        env_lbl.move_to(ax.c2p(np.log10(165), np.log10(400)))
+        win_lbl = layout.label("allowed window", font_size=18, color=P.TEAL, weight="BOLD")
+        win_lbl.move_to(ax.c2p(np.log10(1500), np.log10(0.18)))
+        self.play(FadeIn(env_lbl), FadeIn(win_lbl))
+
+        # anchor points along the envelope
+        anchors = [
+            (300, 1, "300 AU → ~1 M⊕"),
+            (1000, 40, "1000 AU → ~40 M⊕ (sub-Saturn)"),
+            (2000, 320, "2000 AU → ~320 M⊕ (≈1 Jupiter)"),
+        ]
+        ups = [DOWN, UP, UP]
+        anchor_grp = VGroup()
+        for (d, m, name), updir in zip(anchors, ups):
+            dot = Dot(ax.c2p(np.log10(d), np.log10(m)), radius=0.07, color=P.GREEN)
+            lbl = layout.label(name, font_size=14, color=P.GREEN)
+            if updir is DOWN:
+                lbl.next_to(dot, DOWN + RIGHT, buff=0.08)
+            else:
+                lbl.next_to(dot, updir, buff=0.1)
+            anchor_grp.add(dot, lbl)
+            self.play(FadeIn(dot), FadeIn(lbl), run_time=0.5)
+
+        timing.hold_to_read(self, win_lbl, settle=0.8)
+
+        eq = layout.explain_equation(
+            self,
+            [r"M_{\max}(d)", "=", r"M_\star", r"\left(\dfrac{d}{d_\star}\right)^{3}"],
+            [
+                (0, "the heaviest hidden companion still allowed at distance d"),
+                (2, "anchored to a Planet-Nine-like reference mass and distance"),
+                (3, "a tidal-constraint envelope: the cap grows as distance cubed"),
+            ],
+            scale=0.8,
+            where=DOWN * 1.55,
+        )
+        self.play(FadeOut(eq), FadeOut(allowed), FadeOut(env_line), FadeOut(env_lbl),
+                  FadeOut(win_lbl), FadeOut(anchor_grp), FadeOut(ax), FadeOut(xlab), FadeOut(ylab),
+                  FadeOut(tick_grp))
+
+        # second beat: a smooth dark-matter halo cannot supply such a thing
+        readout = paper.result_readout(
+            "dark-matter halo mass within 1000 AU", "< Pluto", color=P.PURPLE)
+        readout.move_to(DOWN * 0.3)
+        note = layout.label(
+            "the local dark-matter density integrates to only a sub-Pluto mass —\n"
+            "a smooth halo cannot be the source",
+            font_size=20, color=P.FG)
+        note.next_to(readout, DOWN, buff=0.45)
+        self.play(FadeIn(readout, shift=UP * 0.15))
+        self.play(FadeIn(note))
+        timing.hold_to_read(self, note, settle=1.2)
+        self.play(FadeOut(readout), FadeOut(note))
+
+        layout.show_takeaway(
+            self, "A hidden companion must be a bound, gravity-only object — not dark matter.")


### PR DESCRIPTION
Four new paper segments visualizing the reproductions added in #189, plus their auto-generated discussion beats. Each follows the house idiom: `paper.title_block` → data visual → `layout.explain_equation` term-by-term walk → `paper.result_readout` → `layout.show_takeaway`. All small labels use the kerning-safe `layout.label`.

## Scenes (+ auto discussion beats)

- **RussellAlbedo2025** — Russell & White 2025. Mini-Neptune disk + reflected-light glow; mass→radius→albedo chain; `m = H + 5log(rΔ)` walked term-by-term; apparent-mag readout (m ≈ 21.9–22.7 at ~625 AU).
- **StellarFlybys2025** — Hu, Huang, Gladman & Zhu 2025. A passing star perturbs the scattered disk; the i<30° / alignment constraints; the encounter-rate × geometry × success product → ≲5%.
- **StellarCompanions2026** — Benakli 2026. Log-log mass–distance plot with the M_max(d) ∝ d³ envelope and shaded allowed window (Earth→sub-Saturn at 300–1000 AU, ~Jupiter at 2000 AU); the dark-matter-halo "< Pluto within 1000 AU" bound.
- **AlphaSlope2026** — Eldadi & Loeb 2026. log(flux)–log(distance) with α=−4 (reflected) vs α=−2 (self-luminous) lines; the Q1–Q6 funnel (8557→1089→186→{53,24,109}); the Pan-STARRS-only systematics punchline.

## Wiring

- `manifest.yaml`: four new paper entries.
- `content.PAPER_TEXT`: four discussion-beat entries (hypothesis / arguments / conclusions) → auto-generates the `Discuss_*` beats.
- `paper.title_block`: small backward-compatible enhancement — optional explicit `cite=` (so a scene can cite its paper without the crate's Cargo.toml on the branch).
- `EQUATIONS.md`: the four governing relations.

## Validation

Full film assembles **175/175 scenes, zero failures** (was 167 + 4 papers + 4 discussion beats). Each new scene's last frame visually checked — clean Noto Sans kerning, no overlaps/off-screen.

Based on `meawoppl/manim-animations` (#187) for the Noto Sans kerning fix; rebase to main once that merges. The numerical crates are in #189.