### PR TITLE
Fix reflected-light geometric-albedo flux law

### DIFF
--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -214,11 +214,14 @@ overtakes reflected sunlight above ≈175 K (at 15 M⊕, 400 AU), far hotter tha
 So the W1 detectability this crate computes is, for a cold body, set by **reflected sunlight**;
 the thermal term is retained and would dominate for an implausibly warm planet. (The real search's
 W2 4.6 µm band is more thermally favorable; the shared survey table pins the deeper, bluer W1.)
-- Consequence for the exclusion: the reflected-light W1 reach is ≈186 AU (5 M⊕) to ≈222 AU
+- Consequence for the exclusion: the reflected-light W1 reach is ≈263 AU (5 M⊕) to ≈313 AU
   (18 M⊕), only clipping the near edge of the Brown & Batygin posterior (q ≈ 300 AU), so the
-  computed exclusion fraction over that posterior is a few percent (≈2% at 6.2 M⊕, ≈7% at 18 M⊕)
+  computed exclusion fraction over that posterior is ≈7% at 6.2 M⊕ and ≈16% at 18 M⊕
   — far below the optical ZTF 56%. This is an honest finding, not a tuned number; it increases
-  monotonically with assumed mass as required.
+  monotonically with assumed mass as required. (Reach/exclusion re-pinned after fixing the
+  geometric-albedo /4 error in `p9_core::analysis::thermal::reflected_flux_jy`, which had made
+  all reflected-light magnitudes 1.5 mag too faint; the two core reflected-light paths are now
+  cross-pinned against each other on Neptune.)
 - Pinned: `crates/p9-2018-wise-search/src/thermal_model.rs` (Planck/reflected model, W1 zero
   point 309.54 Jy), `detectability.rs` (finite max-distance bisection), `exclusion.rs`.
 

--- a/crates/p9-2018-wise-search/src/detectability.rs
+++ b/crates/p9-2018-wise-search/src/detectability.rs
@@ -78,6 +78,18 @@ mod tests {
         );
     }
 
+    /// Pin the documented reflected-light W1 reach (REPRODUCTION_NOTES §13):
+    /// ≈263 AU at 5 M⊕ and ≈313 AU at 18 M⊕ with the geometric-albedo
+    /// opposition flux law (no isotropic /4).
+    #[test]
+    fn reach_values_match_documented_reproduction_notes() {
+        let survey = WiseSurvey::default();
+        let d5 = max_detectable_distance(&survey, 5.0).expect("5 Me detectable");
+        let d18 = max_detectable_distance(&survey, 18.0).expect("18 Me detectable");
+        assert!((d5 - 263.4).abs() < 3.0, "reach(5 M⊕) = {d5:.1} AU");
+        assert!((d18 - 313.0).abs() < 3.0, "reach(18 M⊕) = {d18:.1} AU");
+    }
+
     #[test]
     fn crossover_magnitude_equals_depth() {
         let survey = WiseSurvey::default();

--- a/crates/p9-2021-act-mm/src/detectability.rs
+++ b/crates/p9-2021-act-mm/src/detectability.rs
@@ -207,18 +207,23 @@ mod tests {
     }
 
     #[test]
-    fn mm_vastly_outreaches_wise_w1_for_a_cold_body() {
+    fn mm_outreaches_wise_w1_for_a_cold_body() {
         // The headline: at the same cold (40 K) temperature, the mm band
-        // reaches a P9 at far greater distance than WISE W1, which for a cold
-        // body is essentially blind (W1 reach is set by reflected light and is
-        // limited to the low hundreds of AU even at high mass).
+        // reaches a P9 at greater distance than WISE W1, whose cold-body reach
+        // is set by reflected sunlight and tops out around ~290 AU at 10 M⊕
+        // (with the geometric-albedo opposition flux law; the pre-fix /4 error
+        // had it near 190 AU, which made this margin look like >2x).
         let cmp = compare_reach(&ActSurvey::default(), 10.0);
         let w1 = cmp.wise_w1_au.expect("W1 reach finite for 10 M⊕");
         assert!(
-            cmp.act_mm_au > 2.0 * w1,
-            "ACT mm reach {:.0} AU should far exceed WISE W1 {:.0} AU",
+            cmp.act_mm_au > 1.4 * w1,
+            "ACT mm reach {:.0} AU should exceed WISE W1 {:.0} AU by >40%",
             cmp.act_mm_au,
             w1
+        );
+        assert!(
+            (250.0..350.0).contains(&w1),
+            "cold-body W1 reflected reach at 10 M⊕ = {w1:.0} AU"
         );
     }
 

--- a/crates/p9-core/src/analysis/thermal.rs
+++ b/crates/p9-core/src/analysis/thermal.rs
@@ -85,21 +85,24 @@ pub fn thermal_flux_jy(t: f64, radius_m: f64, distance_au: f64, nu_hz: f64) -> f
 }
 
 /// Reflected-sunlight flux density (Jy) of a body of radius `radius_m` and
-/// reflectance `albedo` at heliocentric distance `distance_au`, observed near
-/// opposition (Δ = d − 1 AU, floored at 1 AU), evaluated at frequency `nu_hz`.
+/// **geometric** albedo `albedo` at heliocentric distance `distance_au`,
+/// observed near opposition (Δ = d − 1 AU, floored at 1 AU), evaluated at
+/// frequency `nu_hz`.
 ///
 /// The Sun is a blackbody at [`T_SUN`]; the solar flux at the planet is
-/// π B_ν(T_sun) (R_sun / r)². The planet intercepts a disc πR_p², reflects a
-/// fraction `albedo` into ~2π sr (Lambert factor absorbed into the geometric
-/// albedo), and that reradiated flux falls as 1/Δ² to the observer:
+/// π B_ν(T_sun) (R_sun / r)². By definition of the geometric albedo p, the
+/// opposition flux received by the observer is
 ///
-///   F_refl = albedo · [π B_ν(T_sun) (R_sun/r)²] · (R_p² / (4 Δ²)).
+///   F_refl = p · [π B_ν(T_sun) (R_sun/r)²] · (R_p / Δ)².
+///
+/// (No isotropic /4 — that factor belongs to the Bond-albedo phase-averaged
+/// form. This convention is consistent with `analysis::photometry`'s
+/// H + 5·log₁₀(rΔ) magnitude law; see the cross-check test below.)
 pub fn reflected_flux_jy(albedo: f64, radius_m: f64, distance_au: f64, nu_hz: f64) -> f64 {
     let bnu_sun = planck_bnu(T_SUN, nu_hz);
     let solar_flux_at_planet = PI * bnu_sun * (R_SUN_M / (distance_au * AU_M)).powi(2);
     let delta_m = (distance_au - 1.0).max(1.0) * AU_M;
-    let reflected =
-        albedo * solar_flux_at_planet * (radius_m * radius_m) / (4.0 * delta_m * delta_m);
+    let reflected = albedo * solar_flux_at_planet * (radius_m * radius_m) / (delta_m * delta_m);
     reflected / JY
 }
 
@@ -197,6 +200,35 @@ mod tests {
         let a = thermal_flux_jy(40.0, 1.0e7, 500.0, 150e9);
         let b = thermal_flux_jy(40.0, 2.0e7, 500.0, 150e9);
         assert!((b / a - 4.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn reflected_flux_matches_photometry_magnitude_law() {
+        // The same body through the two core reflected-light paths must agree:
+        // Neptune (R = 3.865 R⊕, p_V = 0.41, r = 30.07 AU) at opposition.
+        // The blackbody-Sun approximation is good to ~0.1 mag in V; before the
+        // /4 fix these paths disagreed by exactly 2.5·log10(4) = 1.505 mag.
+        use crate::analysis::photometry::{
+            absolute_magnitude, apparent_magnitude, ALBEDO_NEPTUNE, NEPTUNE_RADIUS_EARTH,
+        };
+        const R_EARTH_M: f64 = 6.371e6;
+        const V_BAND_HZ: f64 = C_LIGHT / 0.55e-6;
+        const V_VEGA_ZP_JY: f64 = 3636.0;
+
+        let r_au = 30.07;
+        let radius_m = NEPTUNE_RADIUS_EARTH * R_EARTH_M;
+        let flux = reflected_flux_jy(ALBEDO_NEPTUNE, radius_m, r_au, V_BAND_HZ);
+        let v_thermal = flux_to_magnitude(flux, V_VEGA_ZP_JY);
+
+        let h = absolute_magnitude(radius_m / 1.0e3, ALBEDO_NEPTUNE);
+        let v_phot = apparent_magnitude(h, r_au, r_au - 1.0);
+
+        assert!(
+            (v_thermal - v_phot).abs() < 0.2,
+            "thermal-path V = {v_thermal:.2} vs photometry-path V = {v_phot:.2}"
+        );
+        // And both land near Neptune's actual V ≈ 7.8.
+        assert!((v_phot - 7.8).abs() < 0.3, "V_phot = {v_phot:.2}");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #197.

`reflected_flux_jy` divided by 4 (the Bond-albedo isotropic phase-average) while documenting and receiving geometric albedos — making every reflected-light magnitude 1.505 mag too faint and disagreeing with `photometry`'s H + 5log10(rΔ) law by exactly 2.5·log10(4).

- Drop the /4 and document the geometric-albedo opposition convention.
- Add a cross-module test pinning the thermal-path V against the photometry-path V for Neptune (agree to <0.2 mag; both land at Neptune's actual V ≈ 7.8).
- Re-pin the WISE W1 consequences: reach 263 AU (5 M⊕) → 313 AU (18 M⊕), exclusion ≈7% (6.2 M⊕) / ≈16% (18 M⊕); new regression test locks the reach values; REPRODUCTION_NOTES §13 updated (was 186–222 AU, 2–7%).

Consumers p9-2016-cowan-thermal, p9-2016-wise-coadd, p9-2026-alpha-slope all green.