### PR TITLE
Adopt BB21 radius/albedo assumptions in reference population

### DIFF
--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -26,25 +26,30 @@ normalization for the disk potential, or its <2% quote refers to a different dec
 - Pinned: `crates/p9-2024-oort-selfgrav/src/hamiltonian.rs:152` (NOTE comment), test at `:209-222`
   asserts the computed ~7% and the monotone 75→50→30 AU trend.
 
-### 2. p9-2024-panstarrs — combined exclusion: computed 0.807 vs published 0.785
+### 2. p9-2024-panstarrs — combined exclusion: computed 0.713 vs published 0.785
 
 The per-orbit OR over one shared seeded reference population, run through all three survey
-models, gives ZTF 0.608 / DES-unique 0.024 / PS1-unique 0.175 / combined 0.807 vs the published
-0.564 / 0.050 / 0.171 / 0.785. The ZTF over-exclusion (see #3) propagates: a hotter ZTF model
-absorbs orbits DES would otherwise uniquely exclude, which is why DES-unique under-shoots while
-the combined total over-shoots. The published-table arithmetic (0.564 + 0.050 + 0.171 = 0.785)
-is preserved exactly via the shared `p9_core::analysis::surveys` table as a cross-check.
+models, gives ZTF 0.466 / DES-unique 0.036 / PS1-unique 0.211 / combined 0.713 (ephemeris path
+0.466 / 0.036 / 0.206 / 0.708) vs the published 0.564 / 0.050 / 0.171 / 0.785. The population
+now follows BB21's stated catalog assumptions (r₉ = (m₉/3)R⊕, per-object albedo U(0.2, 0.75));
+the remaining ZTF undershoot (see #3) propagates into the combined total. The published-table
+arithmetic (0.564 + 0.050 + 0.171 = 0.785) is preserved exactly via the shared
+`p9_core::analysis::surveys` table as a cross-check.
 - Pinned: `crates/p9-2024-panstarrs/src/combined_exclusion.rs:227-252` (table identity to 1e-10;
   population-based values within stated tolerances).
 
-### 3. p9-2021-ztf — exclusion fraction: computed 0.609 vs published 0.564
+### 3. p9-2021-ztf — exclusion fraction: computed 0.477 vs published 0.564
 
 Our per-orbit model (sky position from elements, δ > −30° footprint, logistic
-magnitude efficiency, linking factor) over-excludes by ~4.5 points. The paper injected synthetic
-P9s into the actual ZTF epoch/pointing/depth stream; our static footprint + global efficiency is
-optimistic about cadence losses. Untuned — no free parameter was adjusted to close the gap.
-- Pinned: `crates/p9-2021-ztf/src/exclusion.rs:74-98` (asserted within 0.08 of 0.564, fed by a
-  seeded p9-2021-orbit reference population).
+magnitude efficiency, linking factor), fed by the BB21-faithful reference population
+(r₉ = (m₉/3)R⊕, per-object albedo U(0.2, 0.75)), under-excludes by ~9 points. The dominant
+remaining model difference is the depth semantics: we treat V = 20.5 as a 50% logistic
+midpoint, while BB21 define it as the 95%-completeness depth for ≥7 detections — an
+effectively deeper survey (issue #255). (Before the population fix the model computed 0.609:
+a reference population ~0.6 mag brighter than BB21's stated assumptions more than compensated
+for the shallow efficiency reading.) Untuned — no free parameter was adjusted to close the gap.
+- Pinned: `crates/p9-2021-ztf/src/exclusion.rs` (asserted within 0.12 of 0.564, fed by the
+  seeded BB21-faithful reference population).
 
 ### 4. p9-2021-orbit — clustering confidence: computed ≈0.989 vs published 0.996
 
@@ -666,8 +671,9 @@ All four published directions reproduce as *monotone* effects: the discoverable
 fraction is in (0, 1); requiring more visits-for-linking never raises it;
 shrinking the declination extent never raises it; the ten-year co-add never
 lowers it. The honest finding behind the magnitudes: the nominal-orbit P9
-population is **bright** — V p50 ≈ 19.9, p99 ≈ 23.0 (dwell-weighted current
-positions), all brighter than the 24.5 single-visit depth — so per-visit
+population is **bright** — V p50 ≈ 20.4, p99 ≈ 24.1 (dwell-weighted current
+positions, BB21-faithful photometry), essentially all brighter than the 24.5
+single-visit depth — so per-visit
 ε ≈ 1 and a single LSST visit already reaches essentially every nominal
 solution. The **footprint is therefore the binding constraint** (the dec/|b|
 gate moves the fraction by tens of percent), while the depth and linking levers

--- a/crates/p9-2021-ztf/src/exclusion.rs
+++ b/crates/p9-2021-ztf/src/exclusion.rs
@@ -96,8 +96,14 @@ mod tests {
         let result = compute_exclusion(&survey, &population);
 
         let published = EXCLUSION_FRACTIONS[0].unique_fraction; // ZTF: 0.564
+                                                                // Computed 0.477 with the BB21-faithful reference population
+                                                                // ((m/3)R⊕ radius, U(0.2, 0.75) per-object albedo). The undershoot vs
+                                                                // the published 0.564 reflects reading the V = 20.5 limit as a 50%
+                                                                // logistic midpoint where BB21 define it as the 95% completeness
+                                                                // depth (issue #255); the old +0.045 overshoot came from a reference
+                                                                // population ~0.6 mag brighter than BB21's stated assumptions.
         assert!(
-            (result.fraction_excluded - published).abs() < 0.08,
+            (result.fraction_excluded - published).abs() < 0.12,
             "exclusion {:.3} vs published {published}",
             result.fraction_excluded
         );

--- a/crates/p9-2024-panstarrs/src/combined_exclusion.rs
+++ b/crates/p9-2024-panstarrs/src/combined_exclusion.rs
@@ -356,8 +356,10 @@ mod tests {
     fn per_orbit_combination_near_published_fractions() {
         let ex = compute_combined_from_population(4000, 2024);
         let paper = CombinedExclusion::paper_values();
+        // ZTF computed 0.466 vs published 0.564 with the BB21-faithful
+        // population (see p9-2021-ztf exclusion notes / issue #255).
         assert!(
-            (ex.ztf_frac - paper.ztf_frac).abs() < 0.08,
+            (ex.ztf_frac - paper.ztf_frac).abs() < 0.12,
             "ZTF {:.3} vs published {:.3}",
             ex.ztf_frac,
             paper.ztf_frac
@@ -401,8 +403,10 @@ mod tests {
         };
         let ex = compute_combined_from_population_with_earth(4000, 2024, &mut earth);
         let paper = CombinedExclusion::paper_values();
+        // ZTF computed 0.466 vs published 0.564 with the BB21-faithful
+        // population (see p9-2021-ztf exclusion notes / issue #255).
         assert!(
-            (ex.ztf_frac - paper.ztf_frac).abs() < 0.08,
+            (ex.ztf_frac - paper.ztf_frac).abs() < 0.12,
             "ZTF {:.3} vs published {:.3}",
             ex.ztf_frac,
             paper.ztf_frac

--- a/crates/p9-core/src/analysis/photometry.rs
+++ b/crates/p9-core/src/analysis/photometry.rs
@@ -49,6 +49,32 @@ pub fn mass_radius_neptunian(mass_earth: f64) -> f64 {
     NEPTUNE_RADIUS_EARTH * (mass_earth / NEPTUNE_MASS_EARTH).powf(0.27)
 }
 
+/// Brown & Batygin (2021) reference-catalog mass-radius relation:
+/// r₉ = (m₉ / 3 M⊕) · R⊕ (their stated "simple mass-diameter relationship"),
+/// giving 2.07 R⊕ at the 6.2 M⊕ posterior median — ~30% smaller than the
+/// Fortney-anchored [`mass_radius_neptunian`]. Use this (with the
+/// [`BB21_ALBEDO_MIN`]..[`BB21_ALBEDO_MAX`] albedo range) when reproducing
+/// the BB21 reference population that the ZTF/DES/PS1 exclusion papers
+/// inject; use the Neptune-anchored relation for thermal-model work where
+/// Fortney et al. radii are the sourced choice.
+pub fn mass_radius_bb21(mass_earth: f64) -> f64 {
+    mass_earth / 3.0
+}
+
+/// Lower edge of the BB21 reference-catalog albedo range (Neptune-like dark).
+pub const BB21_ALBEDO_MIN: f64 = 0.2;
+/// Upper edge of the BB21 reference-catalog albedo range (Eris-like bright).
+pub const BB21_ALBEDO_MAX: f64 = 0.75;
+
+/// Apparent V magnitude of a BB21 reference-catalog planet of `mass_earth`
+/// and geometric albedo `albedo` at heliocentric distance `r_au`, observed at
+/// opposition, using the BB21 mass-diameter relation.
+pub fn bb21_apparent_magnitude(mass_earth: f64, albedo: f64, r_au: f64) -> f64 {
+    let radius_km = mass_radius_bb21(mass_earth) * crate::constants::EARTH_RADIUS_KM;
+    let h = absolute_magnitude(radius_km, albedo);
+    apparent_magnitude(h, r_au, opposition_delta(r_au))
+}
+
 /// Absolute magnitude H from radius (km) and geometric albedo:
 ///
 ///   H = 5 log10( 1329 km / (√p · D_km) ),  D = 2R.

--- a/crates/p9-core/src/data/reference_population.rs
+++ b/crates/p9-core/src/data/reference_population.rs
@@ -4,16 +4,19 @@
 //! drawn from the posterior emulator, computing observable properties
 //! (apparent magnitude, heliocentric distance) for each.
 //!
-//! Photometry comes from `p9_core::analysis::photometry` (Neptune-anchored
-//! mass-radius relation, reflected-sunlight distance law, Neptune's geometric
-//! albedo 0.41) — the previous inline model invented an albedo ~ U(0.3, 0.7)
-//! and a super-Earth mass-radius exponent inconsistent with the rest of the
-//! workspace.
+//! Photometry follows Brown & Batygin (2021)'s stated catalog assumptions:
+//! the r₉ = (m₉/3 M⊕)·R⊕ mass-diameter relation and per-object geometric
+//! albedos drawn from U(0.2, 0.75) (`p9_core::analysis::photometry::bb21_*`).
+//! The previous model used the Fortney-anchored Neptune relation with a fixed
+//! 0.41 albedo, which made the population ~0.6 mag brighter than BB21's
+//! actual catalog and erased the albedo scatter that sets the faint tail.
 
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 
-use crate::analysis::photometry::{planet_apparent_magnitude, ALBEDO_NEPTUNE};
+use crate::analysis::photometry::{
+    bb21_apparent_magnitude, planet_apparent_magnitude, BB21_ALBEDO_MAX, BB21_ALBEDO_MIN,
+};
 use crate::data::posterior::{mcmc_2021_posterior, sample_from_posterior, P9Posterior};
 use crate::types::{solve_kepler, P9Params};
 
@@ -34,7 +37,7 @@ pub struct ReferenceP9 {
     pub omega_big: f64,
     /// Mean anomaly in radians
     pub mean_anomaly: f64,
-    /// Geometric albedo (Neptune's V-band value, 0.41)
+    /// Geometric albedo, drawn per object from the BB21 U(0.2, 0.75) range
     pub albedo: f64,
     /// Apparent V-band magnitude at current position
     pub v_magnitude: f64,
@@ -64,10 +67,11 @@ pub fn generate_reference_population_with_posterior<R: Rng>(
 
     for _ in 0..n {
         let params = sample_from_posterior(posterior, rng);
-        let albedo = ALBEDO_NEPTUNE;
+        // BB21: "a full range of albedos from 0.2 ... to 0.75", per object.
+        let albedo = rng.gen_range(BB21_ALBEDO_MIN..BB21_ALBEDO_MAX);
 
         let helio_dist = heliocentric_distance(&params);
-        let v_mag = brightness_at_position(params.mass_earth, helio_dist, albedo);
+        let v_mag = bb21_apparent_magnitude(params.mass_earth, albedo, helio_dist);
 
         population.push(ReferenceP9 {
             mass: params.mass_earth,
@@ -97,6 +101,7 @@ pub fn heliocentric_distance(params: &P9Params) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::analysis::photometry::ALBEDO_NEPTUNE;
     use crate::constants::DEG2RAD;
     use rand::SeedableRng;
 
@@ -137,9 +142,33 @@ mod tests {
             assert!(obj.mass > 0.0);
             assert!(obj.a > 0.0);
             assert!(obj.e > 0.0 && obj.e < 1.0);
-            assert!((obj.albedo - ALBEDO_NEPTUNE).abs() < 1e-12);
+            assert!((BB21_ALBEDO_MIN..BB21_ALBEDO_MAX).contains(&obj.albedo));
             assert!(obj.v_magnitude.is_finite());
         }
+        // Per-object albedos actually scatter across the BB21 range.
+        let a_min = pop.iter().map(|o| o.albedo).fold(f64::INFINITY, f64::min);
+        let a_max = pop.iter().map(|o| o.albedo).fold(0.0, f64::max);
+        assert!(a_max - a_min > 0.3, "albedo scatter {a_min:.2}..{a_max:.2}");
+    }
+
+    #[test]
+    fn test_population_matches_bb21_brightness_scale() {
+        // With the BB21 (m/3)Re radius and U(0.2, 0.75) per-object albedo the
+        // population median is V = 20.4 — 0.55 mag fainter than the old
+        // fixed-0.41/Fortney model (19.9), matching the documented ~0.6 mag
+        // radius+albedo offset vs BB21's stated catalog assumptions.
+        let mut rng = rand::rngs::StdRng::seed_from_u64(2021);
+        let pop = generate_reference_population(4000, &mut rng);
+        let mut v: Vec<f64> = pop.iter().map(|o| o.v_magnitude).collect();
+        v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let med = v[v.len() / 2];
+        assert!(
+            (20.0..21.0).contains(&med),
+            "median V = {med:.2} (BB21-scale population)"
+        );
+        let p1 = v[v.len() / 100];
+        let p99 = v[99 * v.len() / 100];
+        assert!(p1 > 16.5 && p99 < 27.5, "V range {p1:.1}..{p99:.1}");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #199.

Brown & Batygin 2021 state r9 = (m9/3 M⊕)·R⊕ and per-object albedos U(0.2, 0.75) for the reference catalog the ZTF/DES/PS1 exclusion papers inject. Our population used the Fortney-anchored Neptune mass-radius relation with a fixed 0.41 albedo — ~0.6 mag brighter, with no albedo scatter.

- Add `mass_radius_bb21`, `BB21_ALBEDO_MIN/MAX`, `bb21_apparent_magnitude` to core photometry (the Neptune-anchored relation stays for thermal work where Fortney radii are the sourced choice).
- `generate_reference_population` now draws per-object albedos and uses the BB21 radius. Population median V: 19.9 → 20.4; new brightness-scale pin.
- Re-pins: ZTF exclusion 0.609 → 0.477 (now undershooting the published 0.564 — the remaining gap is the 95%-vs-50% completeness semantics, #255); PanSTARRS combined 0.807 → 0.713 (ZTF 0.466 / DES-unique 0.036 / PS1-unique 0.211); DES-unique moves toward the published 0.050.
- REPRODUCTION_NOTES §2, §3, §26 updated to the corrected-population numbers.

Full workspace suite green (1647/0).