### PR TITLE
Fix perihelion-gap TNO table against JPL SBDB

### DIFF
--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -334,11 +334,20 @@ to ~1e-8.
 Oldroyd & Trujillo (2021) report a deficit in the perihelion distribution of distant TNOs at
 q ≈ 50–65 AU separating the Neptune-coupled scattering ETNOs (low q) from the detached
 inner-Oort-cloud Sednoids (high q). The crate bins the perihelia of the vetted
-`p9_core::data::etno::BROWN_2017_SAMPLE` plus a documented `EXTENDED_DISTANT_TNOS` table and
-computes a dip statistic (gap-window count density ÷ mean flank density). The observed sample
-shows a deep deficit: dip ratio ≈ 0.10 (gap density 0.067 obj/AU vs flank densities 1.08 low /
-0.20 high), and the minimum-density interior bin lands at q = 52.5 AU, inside the published
-50–65 AU window (centre 57.5 AU, within tolerance). A seeded two-population synthetic draw
+`p9_core::data::etno::BROWN_2017_SAMPLE` plus a documented `EXTENDED_DISTANT_TNOS` table
+(re-transcribed from JPL SBDB 2026-07 after several rows were found to match no real orbit
+solution — the old table had miscoded 2015 KH163 *into* the gap at q ≈ 58 vs its real 39.9,
+and the genuine gap object 2021 RR205 *out* of it at q ≈ 89 vs its real 55.6) and computes a
+dip statistic (gap-window count density ÷ mean flank density). Two honest epochs:
+
+- **Paper epoch** (`paper_epoch_perihelia()`, excludes the post-submission discovery
+  2021 RR205): the published two-sided deficit reproduces — dip ratio ≈ 0.12, gap density
+  below both flanks, minimum-density bin at q = 52.5 AU inside the published 50–65 AU window.
+- **Current knowledge** (`observed_perihelia()`): 2021 RR205 (q = 55.6) sits squarely in the
+  window and 2015 TG387's current solution (q = 64.8) falls at its upper edge, so the window
+  holds 2 objects — still a deficit relative to the dense low flank (dip ≈ 0.25) but no longer
+  emptier than the (thin: Sedna, 2012 VP113) high flank. The gap has partially filled in since
+  publication, which matters directly for the sednoid/IOC boundary in the search-space work. A seeded two-population synthetic draw
 reproduces the same gap (dip ratio < 0.6) while a single continuous uniform control does not
 (dip ratio ≈ 1) — concretizing the paper's "two populations, not one continuous distribution"
 argument. The high-q scattering edge is tied to `p9_core::analysis::resonance::critical_perihelion`
@@ -351,7 +360,8 @@ the *gap statistic* (a real deficit at the published q and a two-vs-one-populati
 the full debiased completeness argument, and we do not assert the paper's ∼20% relative-abundance
 prediction as a computed number (kept as `published::GAP_RELATIVE_ABUNDANCE` for reference).
 - Pinned: `crates/p9-2021-perihelion-gap/src/distribution.rs`
-  (`observed_sample_has_a_perihelion_deficit_at_50_to_65`,
+  (`paper_epoch_sample_has_a_perihelion_deficit_at_50_to_65`,
+  `current_sample_gap_partially_filled_by_post_paper_discoveries`,
   `observed_gap_center_matches_published_window`), `src/synthetic.rs`
   (`two_population_shows_a_gap`, `single_continuous_population_has_no_gap`), `src/boundaries.rs`
   (`scattering_boundary_sits_below_the_gap`).

--- a/crates/p9-2021-perihelion-gap/src/distribution.rs
+++ b/crates/p9-2021-perihelion-gap/src/distribution.rs
@@ -176,21 +176,47 @@ mod tests {
     // ---- Headline reproduction: the gap in the OBSERVED distant-TNO sample ----
 
     #[test]
-    fn observed_sample_has_a_perihelion_deficit_at_50_to_65() {
+    fn paper_epoch_sample_has_a_perihelion_deficit_at_50_to_65() {
         use crate::published::{GAP_Q_HIGH_AU, GAP_Q_LOW_AU};
-        use crate::sample::observed_perihelia;
+        use crate::sample::paper_epoch_perihelia;
 
-        let qs = observed_perihelia();
+        // At the paper's 2021 epoch (before 2021 RR205) the vetted sample
+        // shows the published two-sided deficit at q = 50-65 AU: dip 0.123,
+        // below both flank densities.
+        let qs = paper_epoch_perihelia();
         let d = dip_statistic(&qs, GAP_Q_LOW_AU, GAP_Q_HIGH_AU, 12.0);
-        // The real, vetted sample shows a strong deficit at q = 50-65 AU:
-        // the count density there is far below both flanks.
         assert!(
-            d.dip_ratio < 0.3,
-            "observed sample dip_ratio = {} (expected a deep deficit)",
+            d.dip_ratio < 0.2,
+            "paper-epoch dip_ratio = {} (expected a deep deficit)",
             d.dip_ratio
         );
         assert!(d.gap_density < d.low_flank_density);
         assert!(d.gap_density < d.high_flank_density);
+    }
+
+    #[test]
+    fn current_sample_gap_partially_filled_by_post_paper_discoveries() {
+        use crate::published::{GAP_Q_HIGH_AU, GAP_Q_LOW_AU};
+        use crate::sample::observed_perihelia;
+
+        // With SBDB-verified elements and the post-paper discovery 2021 RR205
+        // (q = 55.6) the window holds two objects (RR205, plus 2015 TG387 at
+        // the q = 64.8 upper edge). The deficit relative to the dense low
+        // flank persists (dip 0.246), but the window is no longer emptier
+        // than the (very thin) high flank — the gap has partially filled in.
+        let qs = observed_perihelia();
+        let d = dip_statistic(&qs, GAP_Q_LOW_AU, GAP_Q_HIGH_AU, 12.0);
+        assert!(
+            (0.15..0.35).contains(&d.dip_ratio),
+            "current-sample dip_ratio = {}",
+            d.dip_ratio
+        );
+        assert!(d.gap_density < d.low_flank_density);
+        let in_gap = qs
+            .iter()
+            .filter(|&&q| (GAP_Q_LOW_AU..GAP_Q_HIGH_AU).contains(&q))
+            .count();
+        assert_eq!(in_gap, 2, "objects in the 50-65 AU window");
     }
 
     #[test]

--- a/crates/p9-2021-perihelion-gap/src/sample.rs
+++ b/crates/p9-2021-perihelion-gap/src/sample.rs
@@ -15,13 +15,14 @@
 //!     the flanks. Objects already present in the Brown sample are NOT
 //!     duplicated here.
 //!
-//! Provenance of the extended table: distant high-e TNOs from the Sheppard &
-//! Trujillo / Minor Planet Center distant-object lists (osculating elements,
-//! a and e to map perihelion; angles are not used here so are omitted). Live
-//! JPL SBDB cross-check 2026-06: q values match within rounding. As with the
-//! core table these pin paper-epoch solutions and may drift from live SBDB as
-//! arcs lengthen — do not "fix" toward current SBDB without re-pinning the
-//! gap regression.
+//! Provenance of the extended table: osculating elements re-transcribed from
+//! JPL SBDB 2026-07 (a and e to map perihelion; angles are not used here so
+//! are omitted). The previous table carried several rows whose elements
+//! matched no JPL solution — most damagingly 2015 KH163 coded into the gap at
+//! q ≈ 58 (real q ≈ 40) and the genuine gap object 2021 RR205 coded onto the
+//! high flank at q ≈ 89 (real q ≈ 55.6) — which manufactured a deeper deficit
+//! than the data support. 2014 SS349 (a ≈ 146) and 2010 ER65 (a ≈ 98) fail
+//! the a ≳ 150 AU membership criterion outright and were removed.
 
 use p9_core::data::etno::BROWN_2017_SAMPLE;
 use p9_core::units::{au, Length};
@@ -59,70 +60,60 @@ impl DistantTno {
 /// q ≳ 40 AU, plus the canonical Sednoids. The deliberate sparseness in
 /// q ≈ 50–65 AU is the observed gap, not a curation choice — these are the
 /// known distant high-e objects in this q range.
-pub const EXTENDED_DISTANT_TNOS: [DistantTno; 12] = [
-    // --- Low-q scattering-coupled ETNOs (q ~ 40-50 AU) ---
+pub const EXTENDED_DISTANT_TNOS: [DistantTno; 10] = [
+    // --- Low-q scattering-coupled ETNOs (q ~ 35-50 AU) ---
     DistantTno {
         name: "2014 FE72",
-        a: 1560.0,
-        e: 0.973,
-    }, // q ~ 42
+        a: 2690.0,
+        e: 0.987,
+    }, // q ~ 36 (scattering)
     DistantTno {
         name: "2015 KG163",
-        a: 680.0,
-        e: 0.940,
-    }, // q ~ 41
+        a: 640.0,
+        e: 0.937,
+    }, // q ~ 40.5
     DistantTno {
         name: "2013 SY99",
-        a: 730.0,
-        e: 0.932,
-    }, // q ~ 50
-    DistantTno {
-        name: "2010 ER65",
-        a: 295.0,
-        e: 0.835,
-    }, // q ~ 49
+        a: 813.0,
+        e: 0.939,
+    }, // q ~ 49.9 (top of the low flank)
     DistantTno {
         name: "2014 WB556",
-        a: 290.0,
-        e: 0.847,
-    }, // q ~ 44
+        a: 285.0,
+        e: 0.850,
+    }, // q ~ 42.8
     DistantTno {
         name: "2016 SD106",
-        a: 350.0,
-        e: 0.870,
-    }, // q ~ 46
+        a: 357.0,
+        e: 0.881,
+    }, // q ~ 42.7
     DistantTno {
         name: "2015 GT50",
-        a: 312.0,
-        e: 0.876,
-    }, // q ~ 39 (just below floor, scattering edge)
+        a: 314.0,
+        e: 0.878,
+    }, // q ~ 38.3 (just below floor, scattering edge)
     DistantTno {
         name: "2002 GB32",
-        a: 207.0,
-        e: 0.823,
-    }, // q ~ 37 (scattering)
-    // --- Gap region (q ~ 50-65 AU): deliberately sparse, the observed deficit.
+        a: 205.0,
+        e: 0.828,
+    }, // q ~ 35.3 (scattering)
     DistantTno {
         name: "2015 KH163",
-        a: 153.0,
-        e: 0.620,
-    }, // q ~ 58 (a rare gap-region object)
+        a: 151.0,
+        e: 0.735,
+    }, // q ~ 39.9 (low flank — NOT a gap object; the old table miscoded it at q ~ 58)
+    // --- Gap region (q ~ 50-65 AU): sparse, the observed deficit.
+    DistantTno {
+        name: "2021 RR205",
+        a: 949.0,
+        e: 0.941,
+    }, // q ~ 55.6 (a genuine gap-region object)
     // --- High-q detached / inner-Oort-cloud Sednoids (q ~ 65+ AU) ---
     DistantTno {
         name: "2015 TG387",
-        a: 1170.0,
-        e: 0.940,
-    }, // q ~ 70 (Leleakuhonua, "the Goblin")
-    DistantTno {
-        name: "2014 SS349",
-        a: 295.0,
-        e: 0.776,
-    }, // q ~ 66, detached IOC edge
-    DistantTno {
-        name: "2021 RR205",
-        a: 990.0,
-        e: 0.910,
-    }, // q ~ 89 (deep IOC)
+        a: 1350.0,
+        e: 0.952,
+    }, // q ~ 64.7 (Leleakuhonua — at the gap's upper edge)
 ];
 
 /// The full perihelion sample (AU): perihelia of the vetted Brown sample plus
@@ -136,6 +127,24 @@ pub fn observed_perihelia() -> Vec<f64> {
             EXTENDED_DISTANT_TNOS
                 .iter()
                 .map(|t| (t.perihelion_typed() / au(1.0)).value),
+        )
+        .collect()
+}
+
+/// The perihelion sample as it stood at the paper's 2021 epoch: excludes
+/// 2021 RR205 (announced 2022, after Oldroyd & Trujillo's submission), whose
+/// q ≈ 55.6 AU sits squarely inside the published gap window. Use this for
+/// reproducing the paper's statistic; use [`observed_perihelia`] for the
+/// current state of knowledge (where the gap has partially filled in).
+pub fn paper_epoch_perihelia() -> Vec<f64> {
+    BROWN_2017_SAMPLE
+        .iter()
+        .map(|k| k.perihelion())
+        .chain(
+            EXTENDED_DISTANT_TNOS
+                .iter()
+                .filter(|t| t.name != "2021 RR205")
+                .map(|t| t.a * (1.0 - t.e)),
         )
         .collect()
 }
@@ -216,11 +225,23 @@ mod tests {
     fn sample_spans_both_flanks_of_the_gap() {
         let qs = observed_perihelia();
         // The combined sample has both a low-q scattering flank (q < 50)
-        // and a high-q detached flank (q > 65).
+        // and a high-q detached flank (q > 65). With SBDB-verified elements
+        // the strict high flank is thin — Sedna and 2012 VP113 (2015 TG387's
+        // current solution sits at q = 64.8, the gap window's upper edge).
         let low = qs.iter().filter(|&&q| q < 50.0).count();
         let high = qs.iter().filter(|&&q| q >= IOC_Q_FLOOR_AU).count();
         assert!(low >= 5, "scattering flank only {low} objects");
-        assert!(high >= 3, "detached flank only {high} objects");
+        assert!(high >= 2, "detached flank only {high} objects");
+    }
+
+    #[test]
+    fn paper_epoch_sample_excludes_only_rr205() {
+        let all = observed_perihelia();
+        let paper = paper_epoch_perihelia();
+        assert_eq!(all.len(), paper.len() + 1);
+        // The excluded object is the in-gap 2021 RR205 (q ~ 55.6).
+        assert!(all.iter().any(|&q| (q - 55.6).abs() < 0.5));
+        assert!(!paper.iter().any(|&q| (q - 55.6).abs() < 0.5));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #200.

The `EXTENDED_DISTANT_TNOS` table carried elements matching no real orbit solution, and the errors all deepened the apparent gap:
- **2015 KH163** was coded INTO the gap at q ≈ 58 — its real orbit is a = 151, e = 0.735, q = 39.9 (low flank). (Found during the SBDB re-verification; beyond the four objects in the issue.)
- **2021 RR205** was coded OUT of the gap at q ≈ 89 — real q = 55.6, a genuine gap object.
- **2015 TG387** q ≈ 70 → real 64.7 (window's upper edge); **2014 FE72** q ≈ 42 → real 36.1.
- **2014 SS349** (real a = 146) and **2010 ER65** (real a = 98) fail the table's own a ≥ 150 criterion and are removed; every remaining row re-transcribed from JPL SBDB 2026-07.

The corrected data change the result honestly: a new `paper_epoch_perihelia()` (pre-RR205) reproduces the published two-sided deficit (dip 0.12); the current-knowledge sample shows the gap partially filled (2 objects in-window, dip 0.25, still far below the low flank). Tests re-pinned to both epochs; REPRODUCTION_NOTES §18 rewritten.

(Wiring this table into the sbdb-refresh guard is #258.)