### PR TITLE
Expose phase contingency of napier-critique debiasing flip

### DIFF
--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -559,6 +559,14 @@ derived quantities:
 - `p9-2019-clustering` / `p9-2021-orbit` survey-bias null: longitude suppression near
   λ ≈ 95°/275° + δ > −30° coverage — same caveat.
 - `p9-2025-clustering` selection weighting w(ϖ) = 1 + 0.3cos(ϖ − 60°) in the bias-resampling MC.
+- `p9-2021-napier-critique` composite selection function (A₁ = 0.90, ϕ₁ = 52°, A₂ = 0.09,
+  ϕ₂ = 52°) — an assumed stand-in for the OSSOS/DES/S&T pointing histories, with the lobe
+  placed on the observed cluster direction and an order-ten contrast chosen so the debiasing
+  flip lands in the published band. The crate's sensitivity tests document the contingency:
+  the R̄-only consistency statistic is phase-blind (amplitude alone decides the flip), and the
+  direction-aware statistic shows the flip failing outright with the lobe rotated 90° off the
+  cluster. Deriving the selection from the real footprints is the survey-geometry
+  consolidation work.
 - `p9-2021-oort-cloud` `IOC_TRAPPING_FRACTION_ASSUMED` (Brasser et al. 2006 provenance) —
   replaces the previously invented √ρ scaling.
 - `p9-2021-orbit` posterior emulator: (a, e) sampled jointly with an assumed ρ = 0.85

--- a/crates/p9-2021-napier-critique/src/critique.rs
+++ b/crates/p9-2021-napier-critique/src/critique.rs
@@ -181,6 +181,72 @@ pub fn consistency_p_value<R: Rng>(
     (count + 1) as f64 / (n_mc + 1) as f64
 }
 
+/// Direction-aware consistency p-value on the full resultant VECTOR.
+///
+/// The R̄-only consistency test above is phase-blind: the null distribution
+/// of R̄ under isotropic-times-selection depends only on the selection
+/// amplitudes, so ANY order-ten-contrast lobe "dissolves" the observed
+/// clustering regardless of whether it points where the surveys actually
+/// looked. Napier et al.'s likelihood is direction-aware. This statistic
+/// compares the observed mean resultant vector (C̄, S̄) against the null
+/// cloud of synthetic resultant vectors via Mahalanobis ordering: p is the
+/// fraction of null samples at least as far (in the null covariance metric)
+/// from the null mean as the observation.
+///
+/// With the selection lobe aligned to the observed cluster the observation
+/// sits inside the null cloud (large p, consistent); with the same lobe
+/// rotated 90° off the cluster the observation is far from the cloud and
+/// the "debiased" verdict correctly reverts to inconsistency (small p).
+pub fn directional_consistency_p_value<R: Rng>(
+    angles: &[f64],
+    sel: &SelectionFunction,
+    n_mc: usize,
+    rng: &mut R,
+) -> f64 {
+    assert!(!angles.is_empty(), "need a non-empty sample");
+    let n = angles.len();
+    let resultant = |xs: &[f64]| {
+        let c = xs.iter().map(|a| a.cos()).sum::<f64>() / xs.len() as f64;
+        let s = xs.iter().map(|a| a.sin()).sum::<f64>() / xs.len() as f64;
+        (c, s)
+    };
+    let (c_obs, s_obs) = resultant(angles);
+    let w_max = sel.weight_max();
+
+    let mut pts = Vec::with_capacity(n_mc);
+    let mut sample = vec![0.0_f64; n];
+    for _ in 0..n_mc {
+        for x in sample.iter_mut() {
+            *x = sel.draw(rng, w_max);
+        }
+        pts.push(resultant(&sample));
+    }
+
+    // Null-cloud mean and covariance.
+    let m = n_mc as f64;
+    let (mc, ms) = (
+        pts.iter().map(|p| p.0).sum::<f64>() / m,
+        pts.iter().map(|p| p.1).sum::<f64>() / m,
+    );
+    let (mut vcc, mut vss, mut vcs) = (0.0, 0.0, 0.0);
+    for &(c, sv) in &pts {
+        vcc += (c - mc) * (c - mc);
+        vss += (sv - ms) * (sv - ms);
+        vcs += (c - mc) * (sv - ms);
+    }
+    vcc /= m;
+    vss /= m;
+    vcs /= m;
+    let det = (vcc * vss - vcs * vcs).max(1e-30);
+    let maha = |c: f64, sv: f64| {
+        let (dc, ds) = (c - mc, sv - ms);
+        (vss * dc * dc - 2.0 * vcs * dc * ds + vcc * ds * ds) / det
+    };
+    let d_obs = maha(c_obs, s_obs);
+    let count = pts.iter().filter(|&&(c, sv)| maha(c, sv) >= d_obs).count();
+    (count + 1) as f64 / (n_mc + 1) as f64
+}
+
 /// Run the full comparison: naive Rayleigh p against uniformity, and the
 /// bias-aware consistency p against isotropic-times-selection.
 pub fn run_critique<R: Rng>(
@@ -202,6 +268,69 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use p9_core::data::etno::longitudes_of_perihelion;
+
+    /// The R̄-only consistency statistic is PHASE-BLIND: its null depends
+    /// only on the selection amplitudes, so rotating the lobe 90° off the
+    /// cluster leaves the R̄-consistency verdict unchanged — the flip is
+    /// decided entirely by the assumed contrast. The direction-aware
+    /// statistic sees the mis-phased lobe: the observed resultant vector is
+    /// then far from the null cloud and the flip correctly fails.
+    #[test]
+    fn flip_fails_with_lobe_rotated_off_the_cluster() {
+        let varpis = longitudes_of_perihelion();
+        let rotated = SelectionFunction {
+            phi1: (52.0 + 90.0) * DEG2RAD,
+            phi2: (52.0 + 90.0) * DEG2RAD,
+            ..SelectionFunction::default()
+        };
+
+        // Phase-blindness of the R̄-only statistic (a property, not a virtue).
+        let mut rng = rand::rngs::StdRng::seed_from_u64(2021);
+        let p_rbar = consistency_p_value(&varpis, &rotated, 4000, &mut rng);
+        assert!(
+            p_rbar > 0.05,
+            "R-bar-only consistency is phase-blind; got p = {p_rbar:.3}"
+        );
+
+        // The direction-aware statistic exposes the contingency.
+        let mut rng = rand::rngs::StdRng::seed_from_u64(2021);
+        let p_dir = directional_consistency_p_value(&varpis, &rotated, 4000, &mut rng);
+        assert!(
+            p_dir < 0.05,
+            "rotated-lobe directional consistency p = {p_dir:.3}: the \
+             debiasing flip should FAIL with a mis-phased lobe"
+        );
+
+        // And with the documented (aligned) lobe the observation is inside
+        // the null cloud: the flip stands under the direction-aware test.
+        let mut rng = rand::rngs::StdRng::seed_from_u64(2021);
+        let p_aligned =
+            directional_consistency_p_value(&varpis, &SelectionFunction::default(), 4000, &mut rng);
+        assert!(
+            p_aligned > 0.05,
+            "aligned-lobe directional consistency p = {p_aligned:.3}"
+        );
+    }
+
+    /// The flip also weakens with the lobe amplitude: at A₁ = 0.3 (a
+    /// peak-to-trough contrast ~1.9 instead of ~10) the same phase no
+    /// longer produces the published consistency band.
+    #[test]
+    fn flip_weakens_with_lobe_amplitude() {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(2021);
+        let varpis = longitudes_of_perihelion();
+        let strong = consistency_p_value(&varpis, &SelectionFunction::default(), 4000, &mut rng);
+        let weak_sel = SelectionFunction {
+            a1: 0.3,
+            ..SelectionFunction::default()
+        };
+        let weak = consistency_p_value(&varpis, &weak_sel, 4000, &mut rng);
+        assert!(
+            weak < strong,
+            "consistency p should fall with amplitude: A1=0.9 -> {strong:.3}, A1=0.3 -> {weak:.3}"
+        );
+    }
+
     use rand::rngs::StdRng;
     use rand::SeedableRng;
     use uom::si::angle::radian;

--- a/crates/p9-2021-napier-critique/src/lib.rs
+++ b/crates/p9-2021-napier-critique/src/lib.rs
@@ -35,7 +35,13 @@
 //! `SelectionFunction`), and the ϖ sample is the 10-object vetted
 //! `BROWN_2017_SAMPLE` rather than Napier's exact OSSOS-debiased set. The
 //! qualitative reproduction — the conclusion flips from "clustered" to
-//! "consistent with isotropy" under debiasing — is robust; the precise
-//! consistency p depends on the assumed amplitudes/phases.
+//! "consistent with isotropy" under debiasing — is CONTINGENT on the
+//! assumed selection function, not robust: it requires the lobe to point
+//! near the observed cluster direction (ϕ₁ ≈ 52°) with an order-ten
+//! contrast (A₁ ≈ 0.9). The sensitivity tests in `critique` show the flip
+//! failing outright with the lobe rotated 90° off the cluster and weakening
+//! with amplitude. Napier et al. derive their selection from survey
+//! simulators; deriving ours from the p9-2017-bias footprints is tracked
+//! as the survey-geometry consolidation work.
 
 pub mod critique;


### PR DESCRIPTION
Fixes #203.

The headline "debiasing flips the conclusion" was guaranteed by two tuned constants — a contrast-10 selection lobe centered exactly on the observed cluster direction — absent from REPRODUCTION_NOTES' tuned list while lib.rs called the flip "robust".

Investigating exposed something sharper: the crate's R̄-only consistency statistic is **phase-blind** (its null depends only on the selection amplitudes), so ANY order-ten-contrast lobe dissolves the clustering no matter where it points — the tuned phase was decorative in the statistic and the flip was decided by amplitude alone.

- Add `directional_consistency_p_value`: Mahalanobis ordering of the observed mean resultant VECTOR against the null cloud (direction-aware, closer to Napier et al.'s likelihood).
- New tests pin the contingency: aligned lobe → flip stands (p > 0.05); same lobe rotated 90° → flip fails (p < 0.05); R̄-only statistic shown phase-blind; amplitude sensitivity pinned.
- lib.rs re-worded from "robust" to contingent; tuned (A₁, ϕ₁) documented in REPRODUCTION_NOTES' tuned-parameters list.

Deriving the phase from real footprints stays with the survey-geometry consolidation issue (#257).