### PR TITLE
Fix inverted N/1 and N/2 resonance classification

### DIFF
--- a/crates/p9-2018-resonance/src/probability_analysis.rs
+++ b/crates/p9-2018-resonance/src/probability_analysis.rs
@@ -306,9 +306,9 @@ mod tests {
     #[test]
     fn test_p_simple_resonance() {
         let census = vec![
-            (Resonance::new(1, 3), 10), // N/1 (p=1, period ratio 3)
-            (Resonance::new(5, 3), 5),  // High-order (p=5)
-            (Resonance::new(2, 5), 5),  // N/2 (p=2, period ratio 5/2)
+            (Resonance::new(3, 1), 10), // N/1 (interior particle, 3 orbits per P9 orbit)
+            (Resonance::new(5, 3), 5),  // High-order (q=3)
+            (Resonance::new(5, 2), 5),  // N/2 (5 orbits per 2 P9 orbits)
         ];
 
         let p = p_simple_resonance(&census);

--- a/crates/p9-2018-resonance/src/resonance_catalog.rs
+++ b/crates/p9-2018-resonance/src/resonance_catalog.rs
@@ -46,14 +46,20 @@ impl Resonance {
         au(a_p9 * self.period_ratio().powf(2.0 / 3.0))
     }
 
-    /// Whether this is an N/1 period ratio (integer period ratio, p=1).
+    /// Whether this is an N/1 resonance: the (interior) particle completes N
+    /// orbits per Planet Nine orbit, i.e. T_particle/T_p9 = q/p = 1/N — so
+    /// **q = 1** (with p = N). The 1:1 co-orbital counts. A previous version
+    /// tested p == 1, which selects exterior integer-period-ratio orbits and
+    /// inverted the whole N/1-vs-high-order classification (10:1, 11:1, 20:1
+    /// were "high-order" while 1:2, 1:3 were "N/1").
     pub fn is_n_over_1(&self) -> bool {
-        self.p == 1
+        self.q == 1
     }
 
-    /// Whether this is an N/2 period ratio (half-integer period ratio, p=2).
+    /// Whether this is an N/2 resonance (particle completes N orbits per two
+    /// P9 orbits, N odd in reduced form): **q = 2**.
     pub fn is_n_over_2(&self) -> bool {
-        self.p == 2
+        self.q == 2
     }
 
     /// Whether this is N/1 or N/2 (the "simple" resonances).
@@ -257,13 +263,32 @@ mod tests {
 
     #[test]
     fn test_resonance_classification() {
-        // p=1 → N/1 (integer period ratio)
-        assert!(Resonance::new(1, 3).is_n_over_1());
-        // p=2 → N/2 (half-integer period ratio)
-        assert!(Resonance::new(2, 5).is_n_over_2());
-        // p=5 → high-order
+        // q=1 → N/1: an interior particle doing N orbits per P9 orbit.
+        assert!(Resonance::new(3, 1).is_n_over_1());
+        assert!(Resonance::new(20, 1).is_n_over_1());
+        // q=2 → N/2 (half-integer commensurability).
+        assert!(Resonance::new(5, 2).is_n_over_2());
+        // Exterior integer ratios are NOT the paper's N/1 class.
+        assert!(!Resonance::new(1, 3).is_n_over_1());
+        assert!(!Resonance::new(2, 5).is_n_over_2());
+        // q=3 → high-order.
         assert!(!Resonance::new(5, 3).is_simple());
         assert_eq!(Resonance::new(5, 3).order(), 2);
+    }
+
+    #[test]
+    fn most_populated_resonances_are_simple() {
+        // The paper's occupied resonances (10:1, 11:1, 20:1, 5:2, ...) must
+        // classify as N/1 or N/2 — the inverted classifier called them all
+        // "high-order".
+        let n_simple = most_populated_resonances()
+            .iter()
+            .filter(|r| r.is_simple())
+            .count();
+        assert!(
+            n_simple >= 4,
+            "only {n_simple} of the populated resonances classify simple"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #208.

Under the crate's convention (period_ratio = T_particle/T_p9 = q/p; interior particle at a = a9·(q/p)^{2/3}), a particle in the paper's N/1 resonance completes N orbits per P9 orbit — q = 1, p = N. `is_n_over_1` tested p == 1 (exterior integer ratios) and `is_n_over_2` p == 2, so the crate's own most-populated resonances (10:1, 11:1, 20:1) classified as "high-order" while exterior 1:2/1:3 counted as "N/1" — inverting `p_simple_resonance`, `classify_by_resonance_type`, and the histogram coloring.

- Classifiers now test q == 1 / q == 2 with the convention documented at the definition.
- Test fixtures corrected (they had baked the inversion in); new test asserts the populated-resonance list classifies simple.

The companion issue #239 (headline P<5% never computed end-to-end) remains open — that end-to-end pin is what would have caught this.