### PR TITLE
Freeze siraj-orbit ridge calibration to the paper's anchor

### DIFF
--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -640,6 +640,19 @@ derived quantities:
 - No shared simulation snapshot driver in p9-core; the 2016-crate run loops were harmonized in
   place but remain three copies.
 
+### 23b. p9-2024-siraj-orbit — MAP 7.0 M⊕ from the vetted 10-object sample vs the published 4.4 M⊕ (stable-21)
+
+The ridge normalization is a one-point calibration frozen to the paper's own headline
+(κ_REF ≈ 1.09 from 2.7σ at n = 21 → the published 4.4 M⊕/290 AU³); the input sample's von Mises
+κ̂ then sets S_obs relative to that anchor. The vetted `p9_core::data::etno` 10-object ϖ sample
+is more concentrated than Siraj, Chyba & Tremaine's stable-21 (κ̂ ≈ 1.7), so the inferred MAP is
+κ̂/κ_REF ≈ 1.6× heavier at the same a_p — a sample difference, not a modeling residual. A
+previous version calibrated from the live sample's κ̂, which cancelled the data identically and
+returned the published orbit for any input; falsifiability tests (uniform input ⇒ collapsed
+mass, tighter input ⇒ heavier MAP) now pin the corrected behavior.
+- Pinned: `crates/p9-2024-siraj-orbit/src/lib.rs` (`test_map_tracks_sample_concentration`),
+  `src/posterior.rs` (`test_inference_is_falsifiable`).
+
 ### 24. p9-2025-stacking — analytic matched-filter / metric reproduction, not a pixel pipeline
 
 Geringer-Sameth et al. (2025) build a full image-stacking search with an orbit-

--- a/crates/p9-2024-siraj-orbit/src/lib.rs
+++ b/crates/p9-2024-siraj-orbit/src/lib.rs
@@ -27,12 +27,17 @@
 //! ## Residuals (documented honestly)
 //!
 //! The forcing scaling S = m/a_p³ is the *reduced* mass-distance dependence of
-//! the secular coupling at fixed test-particle a; the full octupole coupling
-//! also carries a slowly varying a²/a_p² geometric prefactor that we absorb
-//! into the single calibration constant `k_cal`. The MAP is recovered to
-//! within ~1% of the published (4.4 M⊕, 290 AU) — the residual is the grid
-//! resolution and the choice of a_p prior width (20% of a_ref), both
-//! documented in [`posterior`]. The published inclination 6.8° is carried as a
+//! the secular coupling at fixed test-particle a. The ridge normalization is a
+//! ONE-POINT calibration frozen to the paper's own headline (κ_REF ≈ 1.09 from
+//! their 2.7σ at n = 21, mapped to the published 4.4 M⊕/290 AU³ — see
+//! [`posterior::KAPPA_REFERENCE`]); the input sample's κ̂ then sets S_obs
+//! relative to that anchor. A previous version solved the calibration from the
+//! live sample's κ̂, which cancelled the data identically and returned the
+//! published orbit for any input. With the frozen anchor the vetted 10-object
+//! sample — more concentrated (κ̂ ≈ 1.7) than the paper's stable-21 — infers
+//! ≈ 7.0 M⊕ at a_p ≈ 290 AU (κ̂/κ_REF ≈ 1.6× the published mass on the same
+//! ridge), a genuine sample difference pinned in the tests alongside
+//! falsifiability checks (uniform input ⇒ collapsed mass). The published inclination 6.8° is carried as a
 //! reference constant only; this crate models the mass-distance plane.
 
 pub mod confinement;
@@ -81,17 +86,22 @@ mod tests {
     }
 
     #[test]
-    fn test_map_within_15pct_of_published() {
+    fn test_map_tracks_sample_concentration() {
+        // With the calibration frozen to the paper's own 2.7σ/n=21 anchor
+        // (κ_REF ≈ 1.09), the vetted 10-object ϖ sample — which is MORE
+        // concentrated (κ̂ ≈ 1.7) than Siraj et al.'s stable-21 — infers a
+        // proportionally stronger perturber: MAP ≈ 7.0 M⊕ at a_p ≈ 290 AU,
+        // i.e. κ̂/κ_REF ≈ 1.6× the published 4.4 M⊕ on the same ridge. This
+        // is a genuine sample difference, not a reproduction failure; the
+        // published orbit is recovered exactly when the input concentration
+        // matches the paper's (see the falsifiability tests in `posterior`).
         let map = infer_from_etnos(&longitudes_of_perihelion());
-        let dm = (map.mass_earth - SIRAJ_2024_MASS_EARTH).abs() / SIRAJ_2024_MASS_EARTH;
-        let da = (map.a_p - SIRAJ_2024_A_AU).abs() / SIRAJ_2024_A_AU;
         assert!(
-            dm < 0.15,
-            "MAP mass {:.3} M⊕ vs published {:.1} (rel {:.3})",
-            map.mass_earth,
-            SIRAJ_2024_MASS_EARTH,
-            dm
+            (6.3..7.7).contains(&map.mass_earth),
+            "MAP mass {:.3} M⊕",
+            map.mass_earth
         );
+        let da = (map.a_p - SIRAJ_2024_A_AU).abs() / SIRAJ_2024_A_AU;
         assert!(
             da < 0.15,
             "MAP a {:.1} AU vs published {:.1} (rel {:.3})",
@@ -99,6 +109,9 @@ mod tests {
             SIRAJ_2024_A_AU,
             da
         );
+        // And the published orbit is inside a factor-2 band of the MAP.
+        let dm = (map.mass_earth - SIRAJ_2024_MASS_EARTH).abs() / SIRAJ_2024_MASS_EARTH;
+        assert!(dm < 1.0, "MAP within factor 2 of published: rel {dm:.3}");
     }
 
     #[test]

--- a/crates/p9-2024-siraj-orbit/src/posterior.rs
+++ b/crates/p9-2024-siraj-orbit/src/posterior.rs
@@ -129,21 +129,33 @@ impl ForcingPosterior {
     }
 }
 
-/// Build the Siraj et al. (2024) posterior from the clustered-ETNO ϖ sample,
-/// with the calibration solved so that the apsidal-confinement ridge passes
-/// through the published reference orbit (4.4 M⊕, 290 AU). This is a single
-/// scale-setting step, not a hard-coded answer: the MAP is still recovered by
-/// the numerical grid search, and the m ∝ a_p³ ridge geometry is determined by
-/// the physics, not the calibration.
+/// Fixed calibration anchor: the von Mises concentration of the clustered
+/// ETNO ϖ sample AT THE PAPER'S EPOCH, frozen as a labelled constant
+/// (derived from the paper's own headline: 2.7σ Rayleigh significance at
+/// n = 21 means p = exp(−nR̄²) ≈ 0.0069, so R̄ ≈ 0.487 and the Mardia-Jupp
+/// inverse gives κ ≈ 1.09 — a number taken from the publication, not from
+/// this repo's sample).
+///
+/// This one-point calibration ties (κ_REF → the published reference orbit's
+/// forcing m_ref/a_ref³) once. Crucially it is NOT recomputed from the input
+/// angles: a previous version solved k_cal from the live sample's κ̂, which
+/// made κ̂ cancel identically out of S_obs — the "inference" returned the
+/// published orbit for ANY input angles. With the frozen anchor, S_obs = κ̂ ·
+/// (m_ref/a_ref³)/κ_REF moves with the data (see the falsifiability tests).
+pub const KAPPA_REFERENCE: f64 = 1.09;
+
+/// Build the Siraj et al. (2024) posterior from the clustered-ETNO ϖ sample.
+/// The ridge scale is anchored by the frozen one-point calibration
+/// [`KAPPA_REFERENCE`] → (4.4 M⊕/290 AU³); the input sample's κ̂ then sets
+/// S_obs relative to that anchor, so a weaker-clustered sample infers a
+/// proportionally weaker perturber.
 pub fn calibrated_posterior(angles: &[f64]) -> ForcingPosterior {
-    // Solve k_cal so that S_obs maps exactly to the reference ridge:
-    //   S_obs = S(m_ref, a_ref) = m_ref / a_ref³,  and  S_obs = κ̂ / k_cal
-    //   ⇒ k_cal = κ̂ · a_ref³ / m_ref.
-    let kappa = crate::confinement::kappa_from_angles(angles);
-    let k_cal = kappa * SIRAJ_2024_A_AU.powi(3) / SIRAJ_2024_MASS_EARTH;
-    // Independent a_p prior: centered on the inclination-derived a, with a 20%
-    // width — broad enough that the forcing likelihood meaningfully shapes the
-    // MAP, tight enough to break the m ∝ a_p³ degeneracy.
+    let k_cal = KAPPA_REFERENCE * SIRAJ_2024_A_AU.powi(3) / SIRAJ_2024_MASS_EARTH;
+    // Independent a_p prior: centered on the paper's inclination/node-derived
+    // semi-major-axis scale (a labelled paper input, distinct from the ridge
+    // normalization), with a 20% width — broad enough that the forcing
+    // likelihood meaningfully shapes the MAP, tight enough to break the
+    // m ∝ a_p³ degeneracy.
     let sigma_a = 0.20 * SIRAJ_2024_A_AU;
     ForcingPosterior::from_sample(angles, k_cal, SIRAJ_2024_A_AU, sigma_a)
 }
@@ -179,16 +191,44 @@ mod tests {
     #[test]
     fn test_neg2_log_post_minimized_on_ridge_at_aref() {
         let post = calibrated_posterior(&longitudes_of_perihelion());
-        // At a_ref, the best mass is the one on the ridge; perturbing mass
-        // away from it raises the objective.
+        // At a_ref, the best mass is the one on the DATA's ridge
+        // (m = S_obs·a_ref³); perturbing mass away raises the objective.
+        let m_ridge = crate::forcing::mass_for_strength(post.s_obs, SIRAJ_2024_A_AU);
         let on = OrbitPoint {
-            mass_earth: SIRAJ_2024_MASS_EARTH,
+            mass_earth: m_ridge,
             a_p: SIRAJ_2024_A_AU,
         };
         let off = OrbitPoint {
-            mass_earth: SIRAJ_2024_MASS_EARTH * 2.0,
+            mass_earth: m_ridge * 2.0,
             a_p: SIRAJ_2024_A_AU,
         };
         assert!(post.neg2_log_post(on) < post.neg2_log_post(off));
+    }
+
+    #[test]
+    fn test_inference_is_falsifiable() {
+        use p9_core::constants::TWO_PI;
+        // A uniform (unclustered) ϖ sample must NOT return the published
+        // orbit: with κ̂ ≈ 0 the inferred mass collapses far below 4.4 M⊕.
+        // (The pre-fix calibration returned the published orbit for ANY
+        // input — the data cancelled identically.)
+        let uniform: Vec<f64> = (0..21).map(|k| k as f64 * TWO_PI / 21.0).collect();
+        let map_u = calibrated_posterior(&uniform).map_estimate();
+        assert!(
+            map_u.mass_earth < 0.5 * SIRAJ_2024_MASS_EARTH,
+            "uniform sample inferred {:.2} M⊕",
+            map_u.mass_earth
+        );
+
+        // A more concentrated sample infers a stronger perturber.
+        let tight: Vec<f64> = (0..21).map(|k| 0.9 + 0.02 * k as f64).collect();
+        let map_t = calibrated_posterior(&tight).map_estimate();
+        let map_obs = calibrated_posterior(&longitudes_of_perihelion()).map_estimate();
+        assert!(
+            map_t.mass_earth > map_obs.mass_earth,
+            "tight {:.2} vs observed {:.2} M⊕",
+            map_t.mass_earth,
+            map_obs.mass_earth
+        );
     }
 }


### PR DESCRIPTION
Fixes #212.

`calibrated_posterior` solved k_cal = κ̂·a_ref³/m_ref from the live sample, so κ̂ cancelled identically out of S_obs and the a_p prior was centered on the same published value — the exact global minimum sat at (4.4 M⊕, 290 AU) for ANY input angles, and `test_map_within_15pct_of_published` could not fail.

- The calibration is now a frozen one-point anchor derived from the paper's own headline: 2.7σ Rayleigh at n = 21 → R̄ ≈ 0.487 → κ_REF ≈ 1.09, tied once to the published 4.4 M⊕/290 AU³ ridge. The input sample's κ̂ sets S_obs relative to that anchor.
- Result: the inference is now data-driven. The vetted 10-object sample (κ̂ ≈ 1.7, more concentrated than the paper's stable-21) infers ≈ 7.0 M⊕ at a_p ≈ 290 AU — a genuine sample difference, pinned and documented in REPRODUCTION_NOTES §23b.
- New falsifiability tests: uniform ϖ input collapses the inferred mass (< 2.2 M⊕); tighter input infers heavier; the ridge test now uses the data's own S_obs.
- lib.rs's "recovered to within ~1%" claim replaced with the honest description.