### PR TITLE
Use the AKARI-MUSL detection limit, not BSC

### DIFF
--- a/crates/p9-2025-iras-akari/src/survey_model.rs
+++ b/crates/p9-2025-iras-akari/src/survey_model.rs
@@ -12,7 +12,11 @@
 //! - The Monthly Unconfirmed Source List includes sources detected on
 //!   hourly timescales but not confirmed after months — exactly the
 //!   signature expected from a slow-moving solar system object
-//! - Point source sensitivity ~0.55 Jy at 90 µm
+//! - AKARI-MUSL detection limit ~0.21 Jy at 90 µm (Phan et al. 2025
+//!   Table 1 — the MUSL's "twice-deeper flux detection limit" is the
+//!   paper's stated reason for using it; the Bright Source Catalogue
+//!   limits are 0.55/0.44 Jy for v1/v2 and are kept as labelled
+//!   constants below)
 //! - All-sky coverage ~94%
 //! - Positional accuracy ~30" at 90 µm
 
@@ -82,11 +86,22 @@ pub struct AkariFisSurvey {
     pub position_error_arcsec: f64,
 }
 
+/// AKARI-FIS Bright Source Catalogue v1 90 µm detection limit (Jy). NOT the
+/// MUSL limit the paper's search uses — see `AkariFisSurvey::default`.
+pub const AKARI_BSC_V1_LIMIT_JY: f64 = 0.55;
+/// AKARI-FIS Bright Source Catalogue v2 90 µm detection limit (Jy).
+pub const AKARI_BSC_V2_LIMIT_JY: f64 = 0.44;
+
 impl Default for AkariFisSurvey {
     fn default() -> Self {
         Self {
             wavelength_um: 90.0,
-            sensitivity_jy: 0.55,
+            // AKARI-MUSL: ~0.21 Jy (Phan et al. 2025 Table 1). A previous
+            // version used the BSC limit 0.55 Jy, making the 90 µm
+            // detectability model ~2.6x too shallow and misrepresenting the
+            // paper's premise (their Fig. 3 has even 7 M⊕ crossing both
+            // limits near 500-520 AU).
+            sensitivity_jy: 0.21,
             sky_coverage: 0.94,
             position_error_arcsec: 30.0,
         }
@@ -209,7 +224,8 @@ mod tests {
     fn akari_default_matches_paper() {
         let akari = AkariFisSurvey::default();
         assert!((akari.wavelength_um - 90.0).abs() < 1e-10);
-        assert!((akari.sensitivity_jy - 0.55).abs() < 1e-10);
+        assert!((akari.sensitivity_jy - 0.21).abs() < 1e-10);
+        assert!(akari.sensitivity_jy < AKARI_BSC_V2_LIMIT_JY);
     }
 
     #[test]
@@ -279,7 +295,7 @@ mod tests {
     fn akari_detection_threshold() {
         let akari = AkariFisSurvey::default();
         assert!(akari.is_detectable(0.6));
-        assert!(akari.is_detectable(0.55));
-        assert!(!akari.is_detectable(0.54));
+        assert!(akari.is_detectable(0.21));
+        assert!(!akari.is_detectable(0.20));
     }
 }

--- a/crates/p9-2025-iras-akari/src/thermal_model.rs
+++ b/crates/p9-2025-iras-akari/src/thermal_model.rs
@@ -253,7 +253,7 @@ mod tests {
         // The paper's premise: at the favorable corner of the grid
         // (10 M⊕, 500 AU, warm end T = 50 K) the predicted fluxes cross
         // both survey limits. Pinned values: F_60 ≈ 0.39 Jy ≥ 0.2 Jy
-        // (IRAS), F_90 ≈ 0.59 Jy ≥ 0.55 Jy (AKARI).
+        // (IRAS), F_90 ≈ 0.59 Jy ≥ 0.21 Jy (AKARI-MUSL).
         let params = P9ThermalParams {
             mass_earth: 10.0,
             distance_au: 500.0,
@@ -268,6 +268,28 @@ mod tests {
             is_detectable(&params, &IrasSurvey::default(), &AkariFisSurvey::default());
         assert!(iras_ok, "IRAS should detect the favorable corner");
         assert!(akari_ok, "AKARI should detect the favorable corner");
+    }
+
+    #[test]
+    fn seven_earth_mass_crosses_both_limits_near_510_au() {
+        // Phan et al. Fig. 3's actual premise, only reachable with the MUSL
+        // depth: even 7 M⊕ (T = 50 K) crosses BOTH survey limits at
+        // ~500-520 AU. With the old BSC 0.55 Jy reading, AKARI missed this
+        // by ~2.6x.
+        let params = P9ThermalParams {
+            mass_earth: 7.0,
+            distance_au: 510.0,
+            t_eff: 50.0,
+        };
+        let (iras_ok, akari_ok) =
+            is_detectable(&params, &IrasSurvey::default(), &AkariFisSurvey::default());
+        assert!(iras_ok, "IRAS at 7 M⊕/510 AU");
+        assert!(akari_ok, "AKARI-MUSL at 7 M⊕/510 AU");
+        let f90 = params.flux_density_jy(90.0e-6);
+        assert!(
+            f90 < crate::survey_model::AKARI_BSC_V1_LIMIT_JY,
+            "f90 = {f90:.3} Jy — below the 0.55 Jy BSC reading the old model used"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #218.

The AKARI survey model used 0.55 Jy at 90 µm — the Bright Source Catalogue v1 limit — while attributing it to the Monthly Unconfirmed Source List. Phan et al. 2025 Table 1 gives the MUSL limit as ~0.21 Jy; its 'twice-deeper flux detection limit' is the paper's stated reason for using the MUSL at all. The detectability model was ~2.6x too shallow.

- MUSL sensitivity 0.21 Jy; BSC v1/v2 limits (0.55/0.44) kept as labelled constants.
- New test pins the paper's Fig. 3 premise that the old reading contradicted: 7 M⊕ (50 K) at ~510 AU crosses BOTH survey limits, with F90 ≈ 0.47 Jy — below the 0.55 Jy BSC value the old model demanded.
- Detectability threshold tests re-pinned.