### PR TITLE
Derive the physical secular-resonance commensurability

### DIFF
--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -481,6 +481,17 @@ Beust's published libration *amplitude/period* numbers are configuration-specifi
 read-offs not quoted as single scalars in the abstract, so the crate pins the qualitative
 structure (anti-aligned center, high-e island, mass scaling, libration vs circulation) and the
 self-consistency of the pendulum rather than a published amplitude figure.
+
+Honest residual (issue #226): the high-e placement of the tuned portrait island is an INPUT,
+not a derived result. Solving the physical commensurability — g₉ from P9's own apsidal
+precession under the giants' quadrupole (≈2×10⁻¹³ rad/day, a ~10¹¹-yr apse period) with the
+giants' J2 included in the particle's free precession — puts the resonance at e* ≈ 0.24 for the
+nominal P9 at a = 250 AU (`portrait::physical_island`, pinned): the free precession is
+retrograde at low e (P9 ring dominating), crosses the tiny g₉ once on its ascending branch, and
+never returns to it at high e. Reproducing Beust's high-eccentricity anti-aligned islands as a
+*derived* feature requires his full frame treatment (mutual precession), beyond this reduced
+pendulum; the tuned portrait is retained as the paper's-regime demonstration with that caveat
+documented at the definition.
 - Pinned: `crates/p9-2016-secular-resonance/src/portrait.rs`
   (`island_exists_for_nominal_p9_and_is_anti_aligned`, `circular_perturber_has_no_island`,
   `resonance_strengthens_with_p9_mass`, `every_etno_admits_an_anti_aligned_island`),

--- a/crates/p9-2016-secular-resonance/src/hamiltonian.rs
+++ b/crates/p9-2016-secular-resonance/src/hamiltonian.rs
@@ -28,6 +28,7 @@
 
 use p9_core::analysis::secular::numerical_secular_hamiltonian;
 use p9_core::constants::{GM_SUN, TWO_PI};
+use p9_core::forces::j2_secular::combined_j2_jsu;
 use p9_core::types::P9Params;
 use p9_core::units::{au, gm_from_au3_day2, GravitationalParameter, Length};
 
@@ -49,6 +50,12 @@ pub struct SecularModel {
     pub n_quad: usize,
     /// Softening length (AU) regularizing orbit-crossing geometries.
     pub softening: f64,
+    /// Include the giant planets' orbit-averaged J2 quadrupole in the
+    /// axisymmetric part of the Hamiltonian. Off by default (the tuned
+    /// portrait and the ring-average oracle pins use the bare P9 Gauss
+    /// ring); the PHYSICAL commensurability path
+    /// (`ResonantHamiltonian::new_physical`) turns it on.
+    pub giants_j2: bool,
 }
 
 impl SecularModel {
@@ -61,7 +68,15 @@ impl SecularModel {
             gm_p: p9.gm(),
             n_quad: 64,
             softening: 0.02 * p9.a,
+            giants_j2: false,
         }
+    }
+
+    /// Include the giants' J2 term in the axisymmetric Hamiltonian (used by
+    /// the physical commensurability path).
+    pub fn with_giants_j2(mut self) -> Self {
+        self.giants_j2 = true;
+        self
     }
 
     /// Override the perturber GM (used to scan Planet Nine's mass).
@@ -90,7 +105,7 @@ impl SecularModel {
     /// constant monopole term that does not affect the dynamics).
     pub fn hamiltonian(&self, e: f64, dvarpi: f64) -> f64 {
         // Coplanar: i = 0, Ω = 0, ω = Δϖ measured from the perturber apse.
-        numerical_secular_hamiltonian(
+        let ring = numerical_secular_hamiltonian(
             self.a,
             e,
             0.0,
@@ -101,7 +116,37 @@ impl SecularModel {
             self.gm_p,
             self.n_quad,
             self.softening,
-        )
+        );
+        ring + if self.giants_j2 {
+            self.giants_j2_term(e)
+        } else {
+            0.0
+        }
+    }
+
+    /// The giants' orbit-averaged J2 contribution to the axisymmetric part,
+    /// +GM_eff·J2_eff/(2a³η³). In the deficit-action convention
+    /// (Γ = L − G, dΔϖ/dt = +∂H/∂Γ = −∂H/∂G) the POSITIVE sign yields the
+    /// standard prograde apsidal precession (3/2)·n·J2_eff/(a²η⁴), which was
+    /// previously missing from the free precession entirely.
+    pub fn giants_j2_term(&self, e: f64) -> f64 {
+        let (j2, _j4, gm_boost) = combined_j2_jsu();
+        let gm_eff = GM_SUN + gm_boost;
+        let eta2 = 1.0 - e * e;
+        gm_eff * j2 / (2.0 * self.a.powi(3) * eta2.powf(1.5))
+    }
+
+    /// Planet Nine's OWN apsidal precession rate g₉ (rad/day) under the
+    /// giants' averaged quadrupole: (3/2)·n₉·J2_eff/(a₉²η₉⁴), prograde. This
+    /// is the physical external frequency the secular resonance condition
+    /// g_free(Γ*) = g₉ refers to (previously g₉ was self-tuned to the free
+    /// rate at a hand-picked eccentricity).
+    pub fn p9_apsidal_rate(&self) -> f64 {
+        let (j2, _j4, gm_boost) = combined_j2_jsu();
+        let gm_eff = GM_SUN + gm_boost;
+        let n9 = (gm_eff / self.a_p.powi(3)).sqrt();
+        let eta4 = (1.0 - self.e_p * self.e_p).powi(2);
+        1.5 * n9 * j2 / (self.a_p * self.a_p * eta4)
     }
 
     /// Delaunay deficit action Γ = √(GM·a)·(1 − √(1 − e²)) (AU²/day),

--- a/crates/p9-2016-secular-resonance/src/portrait.rs
+++ b/crates/p9-2016-secular-resonance/src/portrait.rs
@@ -170,6 +170,52 @@ impl ResonantHamiltonian {
         rh
     }
 
+    /// Build the pendulum with the PHYSICAL external frequency: g₉ is Planet
+    /// Nine's own apsidal precession under the giants' quadrupole
+    /// ([`SecularModel::p9_apsidal_rate`]), and the resonant action Γ* is
+    /// SOLVED from g_free(Γ*) = g₉ on the action grid (previously the
+    /// commensurability was self-tuned at a hand-picked eccentricity, so the
+    /// island's "high-e" placement was an input, not a result). Returns
+    /// `None` when the free-precession band never crosses g₉ at this `a`.
+    pub fn new_physical(model: SecularModel) -> Option<Self> {
+        let g9 = model.p9_apsidal_rate();
+        // Physical free precession includes the giants' J2 (previously
+        // missing from a₀ entirely). Build the action grid, then re-tune.
+        let mut rh = Self::new(model.with_giants_j2(), RESONANT_ECCENTRICITY);
+        // Collect every g_free = g9 crossing on the tabulated grid. The free
+        // precession is non-monotone: the giants' J2 keeps it prograde and
+        // above g₉ at low e, while the P9 ring term drives it down (through
+        // retrograde) as the orbit approaches crossing geometry — Beust's
+        // resonance is the descending high-eccentricity branch.
+        let mut crossings = Vec::new();
+        for k in 1..rh.gammas.len() {
+            let (f0, f1) = (rh.gfree[k - 1] - g9, rh.gfree[k] - g9);
+            if f0 == 0.0 {
+                crossings.push(rh.gammas[k - 1]);
+            } else if f0 * f1 < 0.0 {
+                let t = f0 / (f0 - f1);
+                crossings.push(rh.gammas[k - 1] + t * (rh.gammas[k] - rh.gammas[k - 1]));
+            }
+        }
+        // Prefer the highest-eccentricity crossing that hosts a genuine
+        // libration island.
+        for &gamma_star in crossings.iter().rev() {
+            rh.g_p = g9;
+            rh.e_resonant = rh.model.eccentricity(gamma_star);
+            rh.c1_star = rh.c1(gamma_star);
+            if rh.island().is_some() {
+                return Some(rh);
+            }
+        }
+        None
+    }
+
+    /// The eccentricity the pendulum is tuned at (solved from the physical
+    /// commensurability in [`ResonantHamiltonian::new_physical`]).
+    pub fn resonant_eccentricity(&self) -> f64 {
+        self.e_resonant
+    }
+
     /// Override the external (Planet Nine) apsidal rate g₉, *detuning* the
     /// system away from resonance. With g₉ pushed outside the band of free
     /// precession rates the model spans, `g_free(Γ) − g₉` never vanishes, so
@@ -333,8 +379,29 @@ pub fn libration_island(model: &SecularModel) -> Option<Island> {
     if c1.abs() < 1e-18 {
         return None;
     }
+    // The TUNED high-e portrait configuration (Beust's reported regime,
+    // where c₁ < 0 makes Δϖ = π the stable center). This is a hand-placed
+    // commensurability, NOT a derived one: solving the physical condition
+    // g_free(Γ*) = g₉ (see [`physical_island`]) puts the resonance at
+    // e* ≈ 0.24 for the nominal P9 — a documented residual
+    // (REPRODUCTION_NOTES §22). The pendulum dynamics demonstrated on this
+    // configuration (libration vs circulation, mass scaling) are regime-
+    // independent.
     let rh = ResonantHamiltonian::new(*model, RESONANT_ECCENTRICITY);
     rh.island()
+}
+
+/// The PHYSICAL secular-resonance island: g₉ from P9's own apsidal precession
+/// under the giants' quadrupole, Γ* solved from g_free(Γ*) = g₉ with the
+/// giants' J2 included in the free precession. Returns the island and the
+/// solved resonant eccentricity. At the nominal P9 this lands at e* ≈ 0.24 —
+/// far below the tuned high-e portrait — because g₉ is nearly zero
+/// (P9's apse precesses on a ~10¹¹-yr timescale) and the particle's free
+/// precession crosses zero only once, on its low-e ascending branch.
+pub fn physical_island(model: &SecularModel) -> Option<(Island, f64)> {
+    let rh = ResonantHamiltonian::new_physical(*model)?;
+    let e_star = rh.resonant_eccentricity();
+    rh.island().map(|isl| (isl, e_star))
 }
 
 #[cfg(test)]
@@ -343,6 +410,31 @@ mod tests {
     use crate::published;
     use approx::assert_relative_eq;
     use p9_core::types::P9Params;
+
+    /// The honest physical result issue #226 exposed: solving the real
+    /// commensurability g_free(Γ*) = g₉ — with P9's own apsidal rate as g₉
+    /// and the giants' J2 in the free precession — puts the resonance at
+    /// e* ≈ 0.24 for the nominal P9, NOT in the tuned portrait's high-e
+    /// regime. Beust's high-e anti-aligned island corresponds to a
+    /// hand-placed frame rate (see `libration_island` docs and
+    /// REPRODUCTION_NOTES §22).
+    #[test]
+    fn physical_commensurability_lands_at_low_e() {
+        let model = SecularModel::new(
+            published::REPRESENTATIVE_ETNO_A_AU,
+            &published::nominal_p9(),
+        );
+        let (island, e_star) = physical_island(&model).expect("physical island");
+        assert!(
+            (0.1..0.4).contains(&e_star),
+            "physical resonant e* = {e_star:.3}"
+        );
+        assert!(island.omega_lib > 0.0);
+        // g₉ itself is minuscule: P9's apse precesses on a ~1e11-yr
+        // timescale under the giants' quadrupole.
+        let g9 = model.p9_apsidal_rate();
+        assert!(g9 > 0.0 && g9 < 1e-11, "g9 = {g9:.3e} rad/day");
+    }
 
     #[test]
     fn typed_island_and_rate_accessors_match_f64() {


### PR DESCRIPTION
Fixes #226.

The resonant eccentricity was a tuning input (`RESONANT_ECCENTRICITY = 0.7`) with g₉ self-tuned to the free precession at that hand-picked e — so the headline 'high-e island' assertion compared two constants, and the free precession omitted the giants' J2 entirely.

What's new:
- `SecularModel` gains the giants' orbit-averaged J2 term (opt-in, correct sign for the deficit-action convention) and `p9_apsidal_rate()` — P9's own apsidal precession under the giants' quadrupole, the physical external frequency (≈2e-13 rad/day).
- `ResonantHamiltonian::new_physical` / `portrait::physical_island` SOLVE g_free(Γ*) = g₉ on the action grid (J2 included, all crossings considered, highest-e island preferred).
- The honest result, now pinned: at the nominal P9 the physical commensurability lands at **e* ≈ 0.24**, not the high-e regime — the free precession is retrograde at low e, crosses the near-zero g₉ once ascending, and never returns at high e. Beust's high-e anti-aligned island is therefore a hand-placed frame rate in this reduced pendulum; `libration_island` keeps that tuned configuration as the paper's-regime demonstration with the caveat documented at the definition and in REPRODUCTION_NOTES §22.
- All prior pendulum-dynamics tests unchanged and green; ring-average oracle pins untouched (J2 is opt-in).