### PR TITLE
Label inclination-instability growth prefactor honestly

### DIFF
--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -653,6 +653,18 @@ mass, tighter input ⇒ heavier MAP) now pin the corrected behavior.
 - Pinned: `crates/p9-2024-siraj-orbit/src/lib.rs` (`test_map_tracks_sample_concentration`),
   `src/posterior.rs` (`test_inference_is_falsifiable`).
 
+### 23c. p9-2016-inclination-instability — C_GROWTH is an ansatz, not a derived eigenvalue
+
+The growth-rate prefactor (γ = (M_d/M_⊙)·n / C_GROWTH with C_GROWTH = 2π, i.e. one e-fold per
+disc secular time) is anchored to Madigan & McCourt's N-body measurement that the inclination
+e-folds in about one t_sec — it is NOT derived here. Deriving it requires the full N-ring
+linearised secular operator (the collective eccentric-disc mode), beyond this reduced crate.
+Tests pin the paper's order-unity τ/t_sec band and the M_d/a scalings against independent
+p9-core machinery rather than the constant against itself; the suppression-criterion crossover
+(giants' precession vs disc frequency) is the crate's genuinely computed content.
+- Pinned: `crates/p9-2016-inclination-instability/src/growth.rs`
+  (`efolding_time_in_the_published_order_unity_band`), `src/suppression.rs`.
+
 ### 24. p9-2025-stacking — analytic matched-filter / metric reproduction, not a pixel pipeline
 
 Geringer-Sameth et al. (2025) build a full image-stacking search with an orbit-

--- a/crates/p9-2016-inclination-instability/src/growth.rs
+++ b/crates/p9-2016-inclination-instability/src/growth.rs
@@ -37,9 +37,11 @@ use p9_core::units::{days, radians, AngularVelocity, Time};
 /// Madigan & McCourt (2016) find the inclination e-folds on the order of one
 /// disc secular time t_sec (their Fig. 3 / Section 4). Choosing C_GROWTH = 2 pi
 /// sets one e-fold per disc secular *period* (tau = 1 * t_sec), the published
-/// order. This is a *labelled* reference value tied to the paper's reported
-/// secular-time scaling, not a free fit; the resulting fiducial timescale is
-/// pinned in the tests and documented in the crate's residual notes.
+/// order. This is an ANSATZ anchored to the paper's N-body measurement — no
+/// eigenvalue is derived in this crate (that needs the full N-ring linearised
+/// secular operator; documented in REPRODUCTION_NOTES). Tests therefore pin
+/// the *scalings* against independent p9-core machinery and the paper's
+/// order-unity band, not tau/t_sec == 1 (which is true by construction).
 pub const C_GROWTH: f64 = TWO_PI;
 
 /// Mean motion n = sqrt(GM_sun / a^3) as a typed [`AngularVelocity`] for an
@@ -216,14 +218,26 @@ mod tests {
     }
 
     #[test]
-    fn test_efolding_time_is_one_secular_time() {
-        // With C_GROWTH = 2 pi the e-folding time equals one disc secular
-        // time t_sec = (M_sun/M_d) P exactly.
+    fn efolding_time_in_the_published_order_unity_band() {
+        // The e-folding time in units of the disc secular time must sit in
+        // Madigan & McCourt's measured order-unity band (their Fig. 3:
+        // e-folding within a few t_sec). Unlike the previous
+        // tau/t_sec == 1 assertion (true by construction of C_GROWTH), this
+        // band is the actual published constraint the ansatz must satisfy —
+        // a different C_GROWTH convention (e.g. the old lib.rs multiplier
+        // form, off by (2pi)^2) fails it.
         let m = fiducial_mass_solar();
         let a = FIDUCIAL_A_AU;
-        let tau = efolding_time_typed(m, a);
-        let t_sec = secular_time_typed(m, a);
-        assert!(((tau / t_sec).value - 1.0).abs() < 1e-12);
+        let ratio = (efolding_time_typed(m, a) / secular_time_typed(m, a)).value;
+        assert!(
+            (0.3..3.0).contains(&ratio),
+            "tau / t_sec = {ratio:.2} outside the published order-unity band"
+        );
+        // And the growth rate is the secular frequency over C_GROWTH,
+        // cross-checked against the independent p9-core mean motion.
+        let n = ref_mean_motion(a);
+        let gamma_days = growth_rate_typed(m, a).get::<radian_per_second>() * 86_400.0;
+        assert!((gamma_days - m * n / C_GROWTH).abs() / gamma_days < 1e-12);
     }
 
     #[test]

--- a/crates/p9-2016-inclination-instability/src/lib.rs
+++ b/crates/p9-2016-inclination-instability/src/lib.rs
@@ -21,13 +21,16 @@
 //! self-gravity secular frequency of a near-Keplerian disc). The instability
 //! grows on this secular time, so the e-folding growth rate scales as
 //!
-//!   gamma = C_growth * (M_d / M_sun) * n,
+//!   gamma = (M_d / M_sun) * n / C_growth,
 //!
 //! a *linear-theory* growth rate proportional to the disc mass (collective
-//! self-gravity). C_growth is an order-unity dimensionless eigenvalue of the
-//! linearised secular problem; Madigan & McCourt's N-body experiments give
-//! e-folding times of order a few disc secular times, and we adopt the labelled
-//! constant [`growth::C_GROWTH`] documented there.
+//! self-gravity). C_growth is an order-unity (times 2π) dimensionless
+//! prefactor standing in for the eigenvalue of the linearised secular
+//! problem — an ANSATZ anchored to Madigan & McCourt's N-body measurement
+//! that the inclination e-folds in about one disc secular time, NOT a
+//! derived quantity (see [`growth::C_GROWTH`] and the REPRODUCTION_NOTES
+//! entry). A previous version of this header wrote the formula with
+//! C_growth as a multiplier, contradicting the code by (2π)².
 //!
 //! See [`growth`] for the growth rate / e-folding time, and [`suppression`]
 //! for the Das & Batygin (2023) critical-mass criterion.


### PR DESCRIPTION
Fixes #227.

- The headline test asserted τ/t_sec == 1 — true by definition of C_GROWTH = 2π. Replaced with the actual published constraint: τ/t_sec inside Madigan & McCourt's measured order-unity band (0.3–3), which a wrong convention (e.g. the multiplier form) fails, plus a cross-check of γ against the independent p9-core mean motion.
- lib.rs stated γ = C_growth·(M_d/M)·n while the code computes γ = (M_d/M)·n / C_GROWTH — off by (2π)² if read literally. Fixed.
- The docstring claimed the fiducial timescale was 'documented in the crate's residual notes' — no such entry existed. Added REPRODUCTION_NOTES §23c stating plainly that C_GROWTH is an ansatz anchored to the paper's N-body measurement, with the N-ring linearised-operator derivation documented as out of reach of this reduced crate (the suppression-criterion crossover is the crate's genuinely computed content).