### PR TITLE
Route 2017-dynamics Neptune-crossers through the hybrid integrator

### DIFF
--- a/crates/p9-2017-dynamics/src/simulation.rs
+++ b/crates/p9-2017-dynamics/src/simulation.rs
@@ -17,6 +17,8 @@
 use p9_core::constants::{DEG2RAD, GM_SUN, GYR_DAYS, YEAR_DAYS};
 use p9_core::forces::ExtraForce;
 use p9_core::initial_conditions::planets;
+use p9_core::integrator::hybrid::hybrid_step_with_forces;
+#[cfg(test)]
 use p9_core::integrator::whm::WhmIntegrator;
 use p9_core::types::{cartesian_to_elements, OrbitalElements, P9Params, SimConfig as CoreConfig};
 use p9_core::units::{au, days, degrees, radians, Angle, Length, Time};
@@ -310,7 +312,12 @@ pub fn run_simulation(config: &SimConfig, seed: u64, include_p9: bool) -> RunRes
         bs_epsilon: 1e-11,
     };
 
-    let integrator = WhmIntegrator::with_extra_forces(vec![ExtraForce::J2Jsu]);
+    // Hybrid integrator: WHM everywhere, Bulirsch-Stoer through close
+    // Neptune encounters (the seeded q ∈ [30, 36] AU population crosses
+    // Neptune, where fixed-step WHM produced unphysical kicks — the
+    // hybrid_changeover_hill config field was previously dead). The averaged
+    // J+S+U quadrupole rides along as the extra kick force.
+    let extra = [ExtraForce::J2Jsu];
 
     let mut max_i_deg: Vec<f64> = initial.iter().map(|p| p.inclination_deg()).collect();
 
@@ -319,12 +326,13 @@ pub fn run_simulation(config: &SimConfig, seed: u64, include_p9: bool) -> RunRes
     let snap_every = (config.snapshot_interval / config.dt).ceil().max(1.0) as usize;
 
     for step in 1..=n_steps {
-        integrator.step(
+        hybrid_step_with_forces(
             &mut bodies,
             &mut particles,
             &mut active,
             config.dt,
             &core_config,
+            &extra,
         );
 
         if step % snap_every == 0 || step == n_steps {

--- a/crates/p9-core/src/integrator/hybrid.rs
+++ b/crates/p9-core/src/integrator/hybrid.rs
@@ -33,6 +33,7 @@
 use nalgebra::Vector3;
 
 use crate::constants::GM_SUN;
+use crate::forces::{total_extra_acceleration, ExtraForce};
 use crate::integrator::bulirsch_stoer::{self, changeover_k};
 use crate::integrator::kepler_step::kepler_drift;
 use crate::integrator::kick;
@@ -138,7 +139,40 @@ pub fn hybrid_step(
     dt: f64,
     config: &SimConfig,
 ) -> usize {
+    hybrid_step_with_forces(bodies, particles, active, dt, config, &[])
+}
+
+/// [`hybrid_step`] with extra kick-stage accelerations (e.g.
+/// [`ExtraForce::J2Jsu`], the averaged J+S+U quadrupole), applied to bodies
+/// and non-encounter particles in both dt/2 kicks exactly as
+/// `WhmIntegrator::with_extra_forces` does. Particles inside the BS
+/// changeover get the direct planet forces from the BS integration itself;
+/// the smooth extra field still applies to them through the kicks (it varies
+/// on solar-system scales, not encounter scales).
+pub fn hybrid_step_with_forces(
+    bodies: &mut [MassiveBody],
+    particles: &mut [StateVector],
+    active: &mut [bool],
+    dt: f64,
+    config: &SimConfig,
+    extra_forces: &[ExtraForce],
+) -> usize {
     let half_dt = 0.5 * dt;
+
+    let apply_extra =
+        |bodies: &mut [MassiveBody], particles: &mut [StateVector], active: &[bool], dt: f64| {
+            if extra_forces.is_empty() {
+                return;
+            }
+            for body in bodies.iter_mut() {
+                body.state.vel += dt * total_extra_acceleration(extra_forces, &body.state.pos);
+            }
+            for (k, particle) in particles.iter_mut().enumerate() {
+                if active[k] {
+                    particle.vel += dt * total_extra_acceleration(extra_forces, &particle.pos);
+                }
+            }
+        };
 
     // Changeover radii and encounter mask, evaluated at the step start with
     // predicted minimum separations over [t, t+dt].
@@ -148,6 +182,7 @@ pub fn hybrid_step(
     // === KICK dt/2 ===
     kick::kick_bodies(bodies, half_dt);
     kick_particles_changeover(particles, active, bodies, &r_crit, half_dt);
+    apply_extra(bodies, particles, active, half_dt);
 
     // Snapshot body states for the BS force evaluation (BS drifts them to the
     // substep epochs internally).
@@ -183,6 +218,7 @@ pub fn hybrid_step(
     // === KICK dt/2 ===
     kick::kick_bodies(bodies, half_dt);
     kick_particles_changeover(particles, active, bodies, &r_crit, half_dt);
+    apply_extra(bodies, particles, active, half_dt);
 
     // === BOUNDARY CHECK ===
     for (i, particle) in particles.iter().enumerate() {


### PR DESCRIPTION
Fixes #228.

The simulation seeded particles at q ∈ [30, 36] AU — straddling Neptune — but integrated with plain fixed-step WHM at dt = 3000 d; the `hybrid_changeover_hill` config field was dead (only core hybrid.rs reads it), so close Neptune encounters produced unphysical kicks feeding `survival_fraction`/`high_i_fraction`.

- New core entry point `hybrid_step_with_forces`: the Chambers-style hybrid with extra kick-stage accelerations (e.g. `ExtraForce::J2Jsu`) applied to bodies and particles in both dt/2 kicks exactly as `WhmIntegrator::with_extra_forces` does — the smooth averaged field composes with the BS encounter rescue. `hybrid_step` delegates with no forces (signature unchanged for existing callers).
- p9-2017-dynamics' production path now uses it (Neptune + P9 direct, J+S+U averaged, encounters BS-rescued); `hybrid_changeover_hill: 3.0` is now genuinely consumed. The bare-WHM path remains only in the Jacobi-constant unit test where no encounters occur.

p9-core and p9-2017-dynamics suites green.