### PR TITLE
Use published OSSOS block longitudes in the bias model

### DIFF
--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -575,6 +575,11 @@ derived quantities:
 - `p9-2019-clustering` / `p9-2021-orbit` survey-bias null: longitude suppression near
   λ ≈ 95°/275° + δ > −30° coverage — same caveat.
 - `p9-2025-clustering` selection weighting w(ϖ) = 1 + 0.3cos(ϖ − 60°) in the bias-resampling MC.
+- `p9-2017-ossos-bias` discovery-longitude windows: now the PUBLISHED OSSOS block centres
+  (Bannister et al. 2018 Table 1; two clumps, λ ≈ 7–48° and 203–240°). With the real bimodal
+  layout the bias-induced R̄ from isotropy is ≈ 0.29 (pinned) — weaker than the ~0.5–0.65 a
+  previously invented single-side window layout manufactured. The window half-widths remain
+  simplified block-clump extents (no per-field depth/cadence history).
 - `p9-2021-napier-critique` composite selection function (A₁ = 0.90, ϕ₁ = 52°, A₂ = 0.09,
   ϕ₂ = 52°) — an assumed stand-in for the OSSOS/DES/S&T pointing histories, with the lobe
   placed on the observed cluster direction and an order-ten contrast chosen so the debiasing

--- a/crates/p9-2017-ossos-bias/src/bias.rs
+++ b/crates/p9-2017-ossos-bias/src/bias.rs
@@ -149,15 +149,20 @@ mod tests {
     }
 
     /// Reproduced quantity: pin the magnitude of the bias-induced R̄ for the
-    /// default model at a fixed seed. Documents that the apparent clustering
-    /// strength produced from isotropy is ~0.3–0.6 in mean resultant length.
+    /// default model at a fixed seed. With the PUBLISHED OSSOS block layout
+    /// (two clumps roughly opposite on the circle, Bannister et al. 2018)
+    /// the apparent clustering strength produced from isotropy is R̄ ≈ 0.29 —
+    /// weaker than the ~0.5–0.65 the previously invented single-side window
+    /// layout manufactured (opposite clumps partially cancel the resultant),
+    /// but still Rayleigh-significant at survey sample sizes: selection alone
+    /// creates apparent ϖ structure.
     #[test]
     fn test_bias_induced_r_bar_magnitude() {
         let exp = run_default(80_000, 42);
         let r = exp.detected.r_bar;
         assert!(
-            r > 0.3 && r < 0.85,
-            "detected R̄ = {r:.4} outside expected bias-induced band [0.3, 0.85]"
+            r > 0.15 && r < 0.5,
+            "detected R̄ = {r:.4} outside expected bias-induced band [0.15, 0.5]"
         );
         // Document the value in the test output.
         eprintln!(

--- a/crates/p9-2017-ossos-bias/src/detection.rs
+++ b/crates/p9-2017-ossos-bias/src/detection.rs
@@ -98,24 +98,30 @@ impl Default for SurveyModel {
         // from the shared survey table.
         let limiting_mag = limiting_magnitude("DES").unwrap_or(23.8);
 
-        // Discovery-longitude windows. OSSOS observed a handful of blocks at
-        // specific ecliptic longitudes; combined with the other wide-field
-        // surveys that contributed large-a TNOs, the effective coverage is a
-        // few longitude blocks, NOT the full circle, and those blocks are
-        // *clumped* on the sky rather than evenly spaced (the deep large-a
-        // discoveries came from a limited set of nearby fields). That clumping
-        // — not the mere fact of incomplete coverage — is what manufactures a
-        // single dominant apparent-ϖ lobe out of an isotropic parent: evenly
-        // spaced blocks would seed several antipodal lobes and wash R̄ back
-        // toward zero. Centres mimic a clumped block layout around
-        // λ ≈ 0°–60° with one offset block, each ~20° half-width.
-        let windows = [0.0, 30.0, 60.0, 210.0]
-            .iter()
-            .map(|&c| LongitudeWindow {
-                center: c * DEG2RAD,
-                half_width: 20.0 * DEG2RAD,
-            })
-            .collect();
+        // Discovery-longitude windows: the PUBLISHED OSSOS block centres
+        // (Bannister et al. 2018, OSSOS VII, Table 1), by ecliptic
+        // longitude. The blocks form two clumps roughly opposite on the
+        // circle — the "B" blocks near λ ≈ 7–48° (13BL, 14BH, 15BS/BT,
+        // 15BC/BD) and the "A" blocks near λ ≈ 203–240° (13AE, 13AO, 15AP,
+        // 15AM) — NOT the single-side layout a previous version invented
+        // (centres [0°, 30°, 60°, 210°], chosen to "mimic" clumping). Each
+        // window is a block clump with a half-width covering its members.
+        // The two-clump reality still manufactures apparent-ϖ structure out
+        // of an isotropic parent (discovery at perihelion maps sky clumps
+        // onto ϖ clumps), but with a genuinely bimodal — not single-lobe —
+        // selection, which is what the debiased statistics must beat.
+        let windows = [
+            (13.0, 18.0),  // 13BL(13°) + 15BS(7°) + 15BT(8°) + 14BH(24°)
+            (47.0, 8.0),   // 15BC/15BD (46-49°)
+            (209.0, 12.0), // 15AP(203°) + 13AE(215°)
+            (237.0, 8.0),  // 15AM(234°) + 13AO(240°)
+        ]
+        .iter()
+        .map(|&(c, hw): &(f64, f64)| LongitudeWindow {
+            center: c * DEG2RAD,
+            half_width: hw * DEG2RAD,
+        })
+        .collect();
 
         Self {
             limiting_mag,


### PR DESCRIPTION
Fixes #230.

The discovery-longitude windows were invented — centres [0°, 30°, 60°, 210°] chosen (per the code's own comment) to 'mimic a clumped block layout', and the crate's headline bias-induced R̄ ∈ [0.3, 0.85] followed directly from that free geometry.

- Windows now encode the published OSSOS block centres (Bannister et al. 2018, OSSOS VII, Table 1): two clumps roughly opposite on the circle — 13BL/14BH/15BS/15BT at λ ≈ 7–24° with 15BC/BD at 46–49°, and 13AE/13AO/15AP/15AM at λ ≈ 203–240°.
- Honest outcome, re-pinned: the real bimodal layout produces bias-induced R̄ ≈ 0.29 from isotropy (opposite clumps partially cancel the resultant) — weaker than the invented single-side layout's 0.5–0.65, but still Rayleigh-significant at survey sample sizes: selection alone creates apparent ϖ structure, which is the crate's point.
- The window geometry entry added to REPRODUCTION_NOTES' tuned/assumed-parameters list (half-widths remain simplified block-clump extents).