### PR TITLE
Document Sedna as an aphelion-proxy false positive

### DIFF
--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -294,8 +294,11 @@ at smaller a is not adjacent n:1 resonances literally touching; it is the highly
 (e ≈ 0.9) TNOs whose orbits **penetrate** the near-P9 overlap zone at aphelion during their
 secular cycles, sampling the chaotic web — which their full N-body integration captures and a
 static pendulum-width chain does not. The crate classifies an ETNO as a hopper when its aphelion
-Q = a(1+e) reaches a_hop; 2007 TG422, 2013 RF98 and Sedna all qualify, matching the paper's
-migrating class. No constant is tuned to a target a_hop — the strength `S = α·α/(1−α)·e` is the
+Q = a(1+e) reaches a_hop; 2007 TG422 and 2013 RF98 qualify, matching the paper's migrating
+class. Sedna also crosses the Q threshold but Becker et al. report it (with 2012 VP113) as
+NON-migrating — the aphelion proxy is necessary-not-sufficient and Sedna is its documented
+false positive (resonant phase protection, which only the paper's N-body captures, keeps it
+locked). No constant is tuned to a target a_hop — the strength `S = α·α/(1−α)·e` is the
 bare leading Laplace/eccentric scaling, and K ∝ √μ exactly.
 - Pinned: `crates/p9-2017-resonance-hopping/src/chain.rs`
   (`resonance_locations_match_kepler_relation` to 1e-9,

--- a/crates/p9-2017-resonance-hopping/src/tno.rs
+++ b/crates/p9-2017-resonance-hopping/src/tno.rs
@@ -99,9 +99,9 @@ mod tests {
 
     #[test]
     fn eccentric_distant_tnos_penetrate_overlap_zone() {
-        // Becker+'s migrating objects are high-e and distant; their aphelia
+        // Becker+'s MIGRATING objects are high-e and distant; their aphelia
         // reach into the overlap zone, so they are classified as hoppers.
-        for name in ["2007 TG422", "2013 RF98", "Sedna"] {
+        for name in ["2007 TG422", "2013 RF98"] {
             let o = obj(name);
             assert_eq!(
                 classify(o.a, o.e),
@@ -112,6 +112,27 @@ mod tests {
                 o.a * (1.0 + o.e)
             );
         }
+    }
+
+    #[test]
+    fn sedna_is_a_known_false_positive_of_the_aphelion_proxy() {
+        // Becker et al. report Sedna (with 2012 VP113) as an object that
+        // does NOT migrate — it "tends to stay in the same resonance" — yet
+        // its aphelion (Q ≈ 936 AU ≥ a_hop ≈ 590) reaches the overlap zone,
+        // so the Q-based proxy classifies it Hopping. The proxy is a
+        // NECESSARY-not-sufficient criterion: reaching the chaotic web at
+        // aphelion does not force migration when the secular phase keeps
+        // perihelion passages resonantly protected (the paper's N-body
+        // captures this; a static aphelion cut cannot). Documented as a
+        // known false positive rather than asserted as reproducing the
+        // paper's class.
+        let o = obj("Sedna");
+        assert_eq!(
+            classify(o.a, o.e),
+            HoppingState::Hopping,
+            "the proxy's false positive is itself pinned (Q = {:.0})",
+            o.a * (1.0 + o.e)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #235.

The test asserted Sedna is a hopper while the module doc quotes Becker et al. the other way: Sedna (with 2012 VP113) 'does not migrate significantly' and 'tends to stay in the same resonance'. The Q ≥ a_hop aphelion criterion is necessary-not-sufficient — reaching the chaotic web at aphelion doesn't force migration when resonant phase protection (which the paper's N-body captures and a static cut cannot) keeps perihelion passages locked.

- The migrating-class test now covers the paper's actual migrators (2007 TG422, 2013 RF98).
- Sedna moved to its own test pinning it explicitly as the proxy's documented false positive (still crossing the Q threshold — that behavior is itself pinned).
- REPRODUCTION_NOTES §16's 'matching the paper's migrating class' wording corrected.