### PR TITLE
Fix DES linking criterion to NUNIQUE >= 7

### DIFF
--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -575,7 +575,7 @@ These are free parameters chosen to match an observable, or assumptions standing
 do not ingest. Each is commented at the definition site; listed here so nobody mistakes them for
 derived quantities:
 
-- `p9-2022-des` `night_usability = 0.285` (`survey_model.rs`) — the single calibration knob
+- `p9-2022-des` `night_usability = 0.255` (`survey_model.rs`) — the single calibration knob
   scaling per-night completeness so end-to-end recovery matches the paper; stands in for
   weather/chip-gap/masking losses we don't model per-exposure.
 - `p9-2017-bias` galactic-plane suppression (center crossing σ=40°/floor 0.02, anticenter

--- a/crates/p9-2022-des/src/survey_model.rs
+++ b/crates/p9-2022-des/src/survey_model.rs
@@ -97,8 +97,12 @@ pub struct DesSurvey {
     /// 2019).
     pub nights_per_band: u32,
     /// Detections on at least this many distinct nights are required to
-    /// form a linkable orbit: "more than 7 unique nights of detections"
-    /// (Belyakov et al. 2022, Sec. 2), i.e. >= 8.
+    /// form a linkable orbit: the paper's criterion is NUNIQUE >= 7
+    /// (inherited from Bernardinelli et al. 2022, "appear in at least 7
+    /// nights of data"). Belyakov et al.'s prose "more than 7 unique nights"
+    /// contradicts its own math; a previous version resolved it as >= 8 — a
+    /// strictly harsher cut whose deficit the night_usability calibration
+    /// silently absorbed.
     pub min_nights: u32,
     /// 50%-completeness magnitude in g: 24.1, the logit-fit m50 measured by
     /// injecting synthetic Planet Nines into the DES difference-imaging
@@ -135,12 +139,12 @@ impl Default for DesSurvey {
             footprint_area: 5000.0,
             n_nights: 575,
             nights_per_band: 10,
-            min_nights: 8,
+            min_nights: 7,
             depth_g: 24.1,
             depth_r: limiting_magnitude("DES").expect("DES depth in p9-core survey table"),
             depth_i: 23.3,
             depth_z: 22.6,
-            night_usability: 0.285,
+            night_usability: 0.255,
             bands: vec![DesBand::G, DesBand::R, DesBand::I, DesBand::Z],
         }
     }
@@ -355,8 +359,9 @@ mod tests {
         assert!((survey.depth_g - 24.1).abs() < 1e-10);
         // r depth comes from the shared p9-core table (23.8).
         assert!((survey.depth_r - 23.8).abs() < 1e-10);
-        // "More than 7 unique nights of detections."
-        assert_eq!(survey.min_nights, 8);
+        // NUNIQUE >= 7 (the paper's stated criterion; the prose "more than
+        // 7" contradicts its own math and a previous version pinned 8).
+        assert_eq!(survey.min_nights, 7);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #240.

The paper's recoverability criterion is NUNIQUE ≥ 7 (inherited from Bernardinelli et al. 2022, 'appear in at least 7 nights of data'); its prose 'more than 7 unique nights' contradicts its own math and the crate had resolved it as ≥ 8 — a strictly harsher Poisson-binomial cut whose deficit the calibrated `night_usability` knob silently absorbed, skewing that knob's physical meaning.

- `min_nights` 8 → 7, with the prose-vs-math discrepancy documented at the field and in the pin test.
- `night_usability` recalibrated 0.285 → 0.255 against the paper's 87.0% end-to-end fiducial recovery (computed 0.868 at seed 2022, n = 6000); REPRODUCTION_NOTES tuned-parameters entry updated.
- PanSTARRS combined-exclusion suite green (DES-unique stays within pins).