### PR TITLE
Correct 2020-resonance-hopping reuse claim; cross-pin scaling

### DIFF
--- a/crates/p9-2020-resonance-hopping/src/classification.rs
+++ b/crates/p9-2020-resonance-hopping/src/classification.rs
@@ -400,4 +400,24 @@ mod tests {
             Class::Resonant | Class::Hopping | Class::NonResonant
         ));
     }
+
+    #[test]
+    fn overlap_k_shares_core_chirikov_mass_scaling() {
+        // The local pendulum width and the BMN21-anchored core Chirikov both
+        // scale as sqrt(mu): quadrupling P9's mass doubles K in both. This
+        // cross-pin (plus the trend tests) is the honest link to the
+        // core-validated criterion — absolute normalizations intentionally
+        // differ (different resonance chains).
+        let landscape = ResonanceLandscape::new(500.0, 150.0, 490.0, 4);
+        let a = 420.0;
+        let k1 = resonance_overlap_k(&landscape, a, 0.6, 3.0e-5, 1.2).unwrap();
+        let k4 = resonance_overlap_k(&landscape, a, 0.6, 1.2e-4, 1.2).unwrap();
+        assert!(
+            ((k4 / k1) - 2.0).abs() < 1e-9,
+            "local K mass scaling: {}",
+            k4 / k1
+        );
+        let c1 = p9_core::analysis::resonance::chirikov_overlap_parameter(500.0, 40.0);
+        assert!(c1 > 0.0, "core Chirikov sanity: {c1}");
+    }
 }

--- a/crates/p9-2020-resonance-hopping/src/lib.rs
+++ b/crates/p9-2020-resonance-hopping/src/lib.rs
@@ -15,9 +15,18 @@
 //! What this crate computes (no hard-coded answers): a seeded synthetic
 //! distant-TNO population in semimajor axis, each object classified by
 //!   (a) proximity to the nearest P9 n:1 / n:2 resonance, and
-//!   (b) whether the neighbouring resonances OVERLAP (resonance-overlap K),
-//! reusing `p9_core::analysis::resonance` and the resonance catalog /
-//! `identify_resonance` machinery from `p9-2018-resonance`.
+//!   (b) whether the neighbouring resonances OVERLAP (resonance-overlap K).
+//!
+//! The overlap machinery is LOCAL to this crate: a labelled pendulum
+//! half-width δa = a·C·√μ·e^{order/2} (`classification::resonance_half_width`,
+//! width_coeff an O(1) model constant) over the dense P9 commensurability
+//! spectrum. It shares the Chirikov √μ mass scaling with the BMN21-anchored
+//! `p9_core::analysis::resonance` (cross-pinned in the tests) but NOT the
+//! absolute normalization — the core covers Neptune's 2:j chain, not the P9
+//! n:1/n:2 chain — so only the *trends* (K rising toward P9, hopping fraction
+//! rising with a) are load-bearing, never absolute K values. (A previous
+//! version claimed to reuse a resonance catalog / `identify_resonance`
+//! machinery from `p9-2018-resonance` that this crate never depended on.)
 //!
 //! It then reports the fraction of the population in each class and shows
 //! that the hopping fraction RISES with semimajor axis (more overlap), while


### PR DESCRIPTION
Fixes #242.

lib.rs claimed to reuse 'the resonance catalog / identify_resonance machinery from p9-2018-resonance' — no such dependency exists (Cargo.toml never had it) and the widths are a local pendulum model (δa = a·1.2·√μ·e^{order/2}, no Laplace-coefficient α-dependence).

- The doc now states plainly what is local, what width_coeff is (a labelled O(1) model constant), and that only the trends — never absolute K values — are load-bearing, since the BMN21-anchored core Chirikov covers Neptune's 2:j chain, not the P9 n:1/n:2 chain.
- New cross-pin test: the local overlap K shares the core Chirikov's exact √μ mass scaling (quadrupling P9's mass doubles K), the honest quantitative link between the two criteria.