### PR TITLE
Run the apsidal-clustering estimator on real ETNO data

### DIFF
--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -694,6 +694,19 @@ p9-core machinery rather than the constant against itself; the suppression-crite
 - Pinned: `crates/p9-2016-inclination-instability/src/growth.rs`
   (`efolding_time_in_the_published_order_unity_band`), `src/suppression.rs`.
 
+### 23d. p9-2026-apsidal-clustering — tuned synthetics demonstrate the mechanism; the real sample lands at σ ≈ 2.6
+
+The stable-21/25 synthetic samples are TUNED (their concentrations were solved from the
+published 2.7σ → 1.9σ outputs), so those headline values are reproduced by construction — they
+pin only the dilution mechanism. The genuine data test runs the same von Mises
+log-likelihood-ratio estimator on the vetted 10-object ϖ sample (`p9_core::data::etno`):
+κ ≈ 1.73, σ ≈ 2.64 — independently at the paper's ~2.7σ scale (pinned). The asymptotic Wilks
+p = exp(−Λ) is cross-checked against the small-n-corrected Rayleigh series from p9-core on the
+same sample (agreement within ~0.3σ; the Wilks form is the more optimistic). The paper's exact
+stable-21/25 element tables are not transcribed.
+- Pinned: `crates/p9-2026-apsidal-clustering/src/samples.rs`
+  (`real_etno_sample_is_significantly_clustered`).
+
 ### 24. p9-2025-stacking — analytic matched-filter / metric reproduction, not a pixel pipeline
 
 Geringer-Sameth et al. (2025) build a full image-stacking search with an orbit-

--- a/crates/p9-2026-apsidal-clustering/src/samples.rs
+++ b/crates/p9-2026-apsidal-clustering/src/samples.rs
@@ -9,12 +9,25 @@
 //! - [`stable_25`] — the same 21 objects plus 4 additional, less-aligned
 //!   stable objects (broader scatter, offset mean), yielding ≈1.9σ.
 //!
-//! The samples are NOT the answer: the significances are computed from them by
-//! the estimator. The point of the construction is that the SAME estimator on
-//! the larger, diluted sample returns a LOWER significance.
+//! These synthetic samples are TUNED (the concentrations were solved from
+//! the published 2.7σ/1.9σ outputs), so the headline values they reproduce
+//! are circular — they demonstrate only the dilution MECHANISM (same
+//! estimator, larger diluted sample ⇒ lower significance). The genuine data
+//! test is [`vetted_etno_varpi`]: the real 10-object ϖ sample run through
+//! the same estimator (pinned in the tests, and documented in
+//! REPRODUCTION_NOTES).
 //!
 //! Wrapped-normal draws are used (σ ↔ κ via R̄ = exp(−σ²/2)); the von Mises
 //! fit then recovers an effective κ from the realized sample.
+
+/// The REAL vetted ETNO ϖ sample from `p9_core::data::etno` (10 objects,
+/// Brown 2017 selection) — the workspace's actual data, previously never fed
+/// to the estimator (only tuned synthetics were). Not the paper's exact
+/// stable-21/25 tables (those element lists are not transcribed here), but a
+/// genuine, independent sample the estimator must find clustered.
+pub fn vetted_etno_varpi() -> Vec<f64> {
+    p9_core::data::etno::longitudes_of_perihelion()
+}
 
 use rand::rngs::StdRng;
 use rand::SeedableRng;
@@ -95,5 +108,34 @@ mod tests {
         for (a, b) in s21.iter().zip(s25.iter()) {
             assert_eq!(a, b);
         }
+    }
+
+    #[test]
+    fn real_etno_sample_is_significantly_clustered() {
+        // The genuine data test issue #248 asked for: the vetted 10-object
+        // ϖ sample (p9-core, Brown 2017 selection) through the SAME
+        // estimator gives κ ≈ 1.73 and σ ≈ 2.64 — independently landing at
+        // the paper's ~2.7σ scale with real data, unlike the tuned
+        // synthetics (which reproduce their targets by construction).
+        let v = vetted_etno_varpi();
+        assert_eq!(v.len(), 10);
+        let fit = crate::estimator::fit(&v);
+        let lam = crate::estimator::log_likelihood_ratio(&v, fit.mu, fit.kappa);
+        let sig = crate::significance::sigma(lam);
+        assert!((1.6..1.9).contains(&fit.kappa), "kappa = {:.3}", fit.kappa);
+        assert!((2.3..3.0).contains(&sig), "sigma = {sig:.3}");
+
+        // Small-sample cross-check: the asymptotic Wilks p = exp(−Λ) vs the
+        // small-n-corrected Rayleigh series from p9-core on the same sample.
+        // At n = 10 they agree to within ~0.3σ; the Wilks form is the more
+        // optimistic (uncorrected O(1/n) bias), documented here.
+        let p_wilks = crate::significance::lambda_to_p_value(lam);
+        let p_rayleigh = p9_core::analysis::circular::rayleigh_p_value(&v);
+        let s_wilks = crate::significance::p_value_to_sigma(p_wilks);
+        let s_rayleigh = crate::significance::p_value_to_sigma(p_rayleigh);
+        assert!(
+            (s_wilks - s_rayleigh).abs() < 0.5,
+            "Wilks {s_wilks:.2}σ vs small-n Rayleigh {s_rayleigh:.2}σ"
+        );
     }
 }


### PR DESCRIPTION
Fixes #248.

The headline 2.7σ → 1.9σ reproduction was circular: the synthetic samples' concentrations were tuned from the published outputs, and the repo's real ϖ data was never fed to the estimator.

- New `vetted_etno_varpi()` runs the same von Mises log-likelihood-ratio estimator on the genuine 10-object sample (p9-core, Brown 2017 selection): **κ ≈ 1.73, σ ≈ 2.64** — independently landing at the paper's ~2.7σ scale with real data. Pinned.
- The tuned synthetics stay, re-documented as mechanism demonstrations only (dilution direction), with the circularity stated at the module level and in the new REPRODUCTION_NOTES §23d.
- Secondary item from the issue: the asymptotic Wilks p = exp(−Λ) is now cross-checked against p9-core's small-n-corrected Rayleigh series on the same sample (within ~0.3σ at n = 10, the Wilks form more optimistic — documented).