### PR TITLE
Use a W1-band albedo in the WISE reflected-light model

### DIFF
--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -223,14 +223,16 @@ overtakes reflected sunlight above ≈175 K (at 15 M⊕, 400 AU), far hotter tha
 So the W1 detectability this crate computes is, for a cold body, set by **reflected sunlight**;
 the thermal term is retained and would dominate for an implausibly warm planet. (The real search's
 W2 4.6 µm band is more thermally favorable; the shared survey table pins the deeper, bluer W1.)
-- Consequence for the exclusion: the reflected-light W1 reach is ≈263 AU (5 M⊕) to ≈313 AU
-  (18 M⊕), only clipping the near edge of the Brown & Batygin posterior (q ≈ 300 AU), so the
-  computed exclusion fraction over that posterior is ≈7% at 6.2 M⊕ and ≈16% at 18 M⊕
-  — far below the optical ZTF 56%. This is an honest finding, not a tuned number; it increases
-  monotonically with assumed mass as required. (Reach/exclusion re-pinned after fixing the
-  geometric-albedo /4 error in `p9_core::analysis::thermal::reflected_flux_jy`, which had made
-  all reflected-light magnitudes 1.5 mag too faint; the two core reflected-light paths are now
-  cross-pinned against each other on Neptune.)
+- Consequence for the exclusion: with the labelled W1-BAND albedo (0.10 — the 3.3 µm CH₄ ν₃
+  band suppresses ice-giant reflectance far below the V-band 0.41 a previous version applied),
+  the reflected-light W1 reach is ≈185 AU (5 M⊕) to ≈220 AU (18 M⊕) and the exclusion over the
+  BB21 posterior is ≈0.5% at 6.2 M⊕ / ≈1.8% at 18 M⊕ — far below the optical ZTF 56%. The
+  albedo band is the dominant systematic, propagated explicitly: reach ∝ p^{1/4}, spanning
+  0.74× (CH₄-dark p = 0.03) to 1.42× (bright p = 0.41) of the default (pinned). Two prior
+  corrections partially cancelled here: fixing the /4 geometric-albedo error in
+  `reflected_flux_jy` brightened everything 1.5 mag, and adopting the band-correct albedo
+  dimmed it back ~1.5 mag — the flux law and the albedo are now each independently right
+  rather than compensatingly wrong.
 - Pinned: `crates/p9-2018-wise-search/src/thermal_model.rs` (Planck/reflected model, W1 zero
   point 309.54 Jy), `detectability.rs` (finite max-distance bisection), `exclusion.rs`.
 

--- a/crates/p9-2018-wise-search/src/detectability.rs
+++ b/crates/p9-2018-wise-search/src/detectability.rs
@@ -79,15 +79,42 @@ mod tests {
     }
 
     /// Pin the documented reflected-light W1 reach (REPRODUCTION_NOTES §13):
-    /// ≈263 AU at 5 M⊕ and ≈313 AU at 18 M⊕ with the geometric-albedo
-    /// opposition flux law (no isotropic /4).
+    /// ≈185 AU at 5 M⊕ and ≈220 AU at 18 M⊕ with the geometric-albedo
+    /// opposition flux law and the labelled W1-BAND albedo (0.10; the CH₄
+    /// ν₃ band suppresses ice-giant reflectance far below the V-band 0.41).
     #[test]
     fn reach_values_match_documented_reproduction_notes() {
         let survey = WiseSurvey::default();
         let d5 = max_detectable_distance(&survey, 5.0).expect("5 Me detectable");
         let d18 = max_detectable_distance(&survey, 18.0).expect("18 Me detectable");
-        assert!((d5 - 263.4).abs() < 3.0, "reach(5 M⊕) = {d5:.1} AU");
-        assert!((d18 - 313.0).abs() < 3.0, "reach(18 M⊕) = {d18:.1} AU");
+        assert!((d5 - 185.2).abs() < 3.0, "reach(5 M⊕) = {d5:.1} AU");
+        assert!((d18 - 220.1).abs() < 3.0, "reach(18 M⊕) = {d18:.1} AU");
+    }
+
+    /// The reach's albedo-band sensitivity, propagated explicitly: reach
+    /// ∝ p^{1/4}, spanning ~0.74x (CH₄-dark 0.03) to ~1.42x (bright 0.41)
+    /// of the default — the dominant systematic on the WISE exclusion.
+    #[test]
+    fn reach_albedo_sensitivity_spans_documented_range() {
+        use crate::thermal_model::{P9Thermal, W1_ALBEDO_BRIGHT, W1_ALBEDO_DARK};
+        let survey = WiseSurvey::default();
+        let reach_with = |albedo: f64| {
+            crate::detectability::core_max_detectable_distance(
+                50.0,
+                50_000.0,
+                survey.w1_depth,
+                |d| P9Thermal::new(10.0, d).with_albedo(albedo).w1_magnitude(),
+            )
+            .expect("detectable somewhere in range")
+        };
+        let dark = reach_with(W1_ALBEDO_DARK);
+        let default = reach_with(crate::thermal_model::W1_ALBEDO_DEFAULT);
+        let bright = reach_with(W1_ALBEDO_BRIGHT);
+        assert!(dark < default && default < bright);
+        assert!(
+            (dark / default - 0.74).abs() < 0.03 && (bright / default - 1.42).abs() < 0.05,
+            "p^(1/4) scaling: {dark:.0} / {default:.0} / {bright:.0} AU"
+        );
     }
 
     #[test]

--- a/crates/p9-2018-wise-search/src/thermal_model.rs
+++ b/crates/p9-2018-wise-search/src/thermal_model.rs
@@ -71,16 +71,36 @@ pub struct P9Thermal {
     pub internal_temp_k: f64,
 }
 
+/// W1-band (3.35 µm) geometric albedo range for an ice-giant atmosphere.
+/// The 3.3 µm region sits in the strong CH₄ ν₃ absorption band, where
+/// Uranus/Neptune reflectance is a few percent — NOT the V-band 0.41 a
+/// previous version applied (which overstated the W1 reflected reach by
+/// ~2.5 mag for a Neptune-like atmosphere). The bright end covers CH₄-poor
+/// or high cloud decks.
+pub const W1_ALBEDO_DARK: f64 = 0.03;
+/// Adopted default W1-band albedo (labelled model choice, geometric mean of
+/// the dark CH₄-absorbed and bright cloud-deck ends).
+pub const W1_ALBEDO_DEFAULT: f64 = 0.10;
+/// Bright end of the W1 albedo range (the V-band value, as the optimistic
+/// bound for a CH₄-poor atmosphere).
+pub const W1_ALBEDO_BRIGHT: f64 = ALBEDO_NEPTUNE;
+
 impl P9Thermal {
     /// A Planet Nine at the given mass and heliocentric distance with the
-    /// default albedo and internal-temperature floor.
+    /// default W1-band albedo and internal-temperature floor.
     pub fn new(mass_earth: f64, distance_au: f64) -> Self {
         Self {
             mass_earth,
             distance_au,
-            albedo: ALBEDO_NEPTUNE,
+            albedo: W1_ALBEDO_DEFAULT,
             internal_temp_k: INTERNAL_TEMP_FLOOR_K,
         }
+    }
+
+    /// Same body with an explicit W1 albedo (sensitivity scans).
+    pub fn with_albedo(mut self, albedo: f64) -> Self {
+        self.albedo = albedo;
+        self
     }
 
     /// Physical radius in meters (Neptune-anchored mass-radius relation).


### PR DESCRIPTION
Fixes #249.

The reflected-light channel applied Neptune's V-band geometric albedo (0.41) at W1 = 3.35 µm — inside the strong CH₄ ν₃ absorption band where ice-giant reflectance is a few percent. The W1 reach was overstated ~2.5 mag for a Neptune-like atmosphere (opposite in sign to, and larger than, the /4 flux-law bug fixed in #273 — the two errors partially cancelled).

- New labelled band constants: `W1_ALBEDO_DARK = 0.03` (CH₄-absorbed), `W1_ALBEDO_DEFAULT = 0.10` (adopted, geometric mean), `W1_ALBEDO_BRIGHT = 0.41` (CH₄-poor bound); `P9Thermal::with_albedo` for scans.
- Re-pins: reach 185 AU (5 M⊕) → 220 AU (18 M⊕); exclusion ≈0.5%/1.8% over the BB21 posterior; new sensitivity test pins the p^{1/4} reach scaling across the band (0.74×–1.42×).
- REPRODUCTION_NOTES §13 updated, noting explicitly that the flux law and the albedo are now each independently right rather than compensatingly wrong.