### PR TITLE
ZTF depth: V-band label and explicit 7-detection completeness model

### DIFF
--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -38,18 +38,21 @@ arithmetic (0.564 + 0.050 + 0.171 = 0.785) is preserved exactly via the shared
 - Pinned: `crates/p9-2024-panstarrs/src/combined_exclusion.rs:227-252` (table identity to 1e-10;
   population-based values within stated tolerances).
 
-### 3. p9-2021-ztf — exclusion fraction: computed 0.477 vs published 0.564
+### 3. p9-2021-ztf — exclusion fraction: computed 0.528 vs published 0.564
 
-Our per-orbit model (sky position from elements, δ > −30° footprint, logistic
-magnitude efficiency, linking factor), fed by the BB21-faithful reference population
-(r₉ = (m₉/3)R⊕, per-object albedo U(0.2, 0.75)), under-excludes by ~9 points. The dominant
-remaining model difference is the depth semantics: we treat V = 20.5 as a 50% logistic
-midpoint, while BB21 define it as the 95%-completeness depth for ≥7 detections — an
-effectively deeper survey (issue #255). (Before the population fix the model computed 0.609:
-a reference population ~0.6 mag brighter than BB21's stated assumptions more than compensated
-for the shallow efficiency reading.) Untuned — no free parameter was adjusted to close the gap.
-- Pinned: `crates/p9-2021-ztf/src/exclusion.rs` (asserted within 0.12 of 0.564, fed by the
-  seeded BB21-faithful reference population).
+Our per-orbit model (sky position from elements, δ > −30° footprint, object-level
+completeness, linking factor), fed by the BB21-faithful reference population
+(r₉ = (m₉/3)R⊕, per-object albedo U(0.2, 0.75)), under-excludes by ~3.6 points. The depth is
+now modeled with BB21's own semantics: completeness = P(≥7 single-epoch detections over
+N = 22 effective epochs), per-epoch logistic centered at the DES paper's independent
+single-epoch reading (m50 = 20.75 g ≈ 20.48 V), with N the one calibrated quantity (smallest
+N whose completeness at V = 20.5 reaches the defined 95%). Under the earlier misreading of
+20.5 as a 50% logistic midpoint the model computed 0.477; before the population fix it
+computed 0.609 (a reference population ~0.6 mag brighter than BB21's stated assumptions
+more than compensated for the shallow efficiency reading). The remaining gap is per-field
+cadence/weather structure we don't model.
+- Pinned: `crates/p9-2021-ztf/src/exclusion.rs` (asserted within 0.05 of 0.564, fed by the
+  seeded BB21-faithful reference population); `survey_model.rs` pins the 95% point at 20.5.
 
 ### 4. p9-2021-orbit — clustering confidence: computed ≈0.989 vs published 0.996
 

--- a/crates/p9-2021-ztf/src/exclusion.rs
+++ b/crates/p9-2021-ztf/src/exclusion.rs
@@ -96,14 +96,15 @@ mod tests {
         let result = compute_exclusion(&survey, &population);
 
         let published = EXCLUSION_FRACTIONS[0].unique_fraction; // ZTF: 0.564
-                                                                // Computed 0.477 with the BB21-faithful reference population
-                                                                // ((m/3)R⊕ radius, U(0.2, 0.75) per-object albedo). The undershoot vs
-                                                                // the published 0.564 reflects reading the V = 20.5 limit as a 50%
-                                                                // logistic midpoint where BB21 define it as the 95% completeness
-                                                                // depth (issue #255); the old +0.045 overshoot came from a reference
-                                                                // population ~0.6 mag brighter than BB21's stated assumptions.
+                                                                // Computed 0.528 with the BB21-faithful reference population
+                                                                // ((m/3)R⊕ radius, U(0.2, 0.75) per-object albedo) and the
+                                                                // object-level P(>= 7 detections) completeness whose 95% point is
+                                                                // pinned at V = 20.5 as BB21 define it (was 0.477 when 20.5 was
+                                                                // misread as a 50% logistic midpoint). The remaining -0.036 is the
+                                                                // documented residual: per-field cadence/weather structure we don't
+                                                                // model.
         assert!(
-            (result.fraction_excluded - published).abs() < 0.12,
+            (result.fraction_excluded - published).abs() < 0.05,
             "exclusion {:.3} vs published {published}",
             result.fraction_excluded
         );

--- a/crates/p9-2021-ztf/src/survey_model.rs
+++ b/crates/p9-2021-ztf/src/survey_model.rs
@@ -12,12 +12,27 @@ use serde::{Deserialize, Serialize};
 /// ZTF survey model parameters for Planet Nine detection.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ZtfSurvey {
-    /// 50%-efficiency magnitude of the recovery pipeline (~20.5, ZTF r-band)
+    /// V-band 95% object-completeness depth: BB21 define V = 20.5 as the
+    /// magnitude to which the survey recovers >= [`Self::min_detections`]
+    /// epochs for 95% of objects — NOT a 50% logistic midpoint (the earlier
+    /// reading here, which under-detected near the limit).
     pub depth_limit: f64,
-    /// Logistic steepness of the efficiency roll-off near the depth limit
-    /// (mag⁻¹); calibrated against known-asteroid recoveries in the paper,
-    /// which show a sharp (few-tenths of a magnitude) transition.
+    /// Single-epoch 50%-efficiency magnitude (V): the DES paper's
+    /// independent reading of ZTF, m50 = 20.75 g ~ 20.48 V. Per-epoch
+    /// efficiency is a logistic centered here.
+    pub single_epoch_m50: f64,
+    /// Logistic steepness of the per-epoch efficiency roll-off (mag⁻¹);
+    /// calibrated against known-asteroid recoveries in the paper, which show
+    /// a sharp (few-tenths of a magnitude) transition.
     pub efficiency_steepness: f64,
+    /// Detections required for the tracklet linker to consider an object
+    /// found (BB21 require >= 7).
+    pub min_detections: u32,
+    /// Effective number of independent epochs a sky position gets over the
+    /// survey — the one calibrated quantity, chosen as the smallest N whose
+    /// object-level completeness at [`Self::depth_limit`] reaches the
+    /// defined 95% (N = 22 gives 96.0%).
+    pub effective_epochs: u32,
     /// Southern declination limit of the footprint (degrees); ZTF observes
     /// from Palomar and covers δ > −30°.
     pub dec_limit_deg: f64,
@@ -27,18 +42,41 @@ impl Default for ZtfSurvey {
     fn default() -> Self {
         Self {
             depth_limit: limiting_magnitude("ZTF").expect("ZTF in shared survey table"),
+            single_epoch_m50: 20.48,
             efficiency_steepness: 4.0,
+            min_detections: 7,
+            effective_epochs: 22,
             dec_limit_deg: NORTHERN_SURVEY_DEC_LIMIT_DEG,
         }
     }
 }
 
 impl ZtfSurvey {
-    /// Magnitude-dependent single-epoch detection efficiency: a logistic
-    /// roll-off centered on the depth limit (the self-calibration curve from
-    /// known-asteroid injections), replacing the previous hard step at 20.5.
+    /// Single-epoch detection efficiency: a logistic roll-off centered on
+    /// [`Self::single_epoch_m50`] (the self-calibration curve from
+    /// known-asteroid injections).
+    pub fn single_epoch_efficiency(&self, apparent_magnitude: f64) -> f64 {
+        1.0 / (1.0
+            + ((apparent_magnitude - self.single_epoch_m50) * self.efficiency_steepness).exp())
+    }
+
+    /// Object-level detection efficiency: the probability of accumulating at
+    /// least [`Self::min_detections`] single-epoch detections over
+    /// [`Self::effective_epochs`] independent epochs — the quantity BB21's
+    /// V = 20.5 / 95% completeness statement is about. Binomial survival:
+    /// P(X >= 7), X ~ Bin(N, ε(m)).
     pub fn detection_efficiency(&self, apparent_magnitude: f64) -> f64 {
-        1.0 / (1.0 + ((apparent_magnitude - self.depth_limit) * self.efficiency_steepness).exp())
+        let eps = self.single_epoch_efficiency(apparent_magnitude);
+        let n = self.effective_epochs;
+        let mut p_lt = 0.0_f64; // P(X < min_detections)
+        let mut coeff = 1.0_f64; // C(n, k)
+        for k in 0..self.min_detections {
+            if k > 0 {
+                coeff *= (n - k + 1) as f64 / k as f64;
+            }
+            p_lt += coeff * eps.powi(k as i32) * (1.0 - eps).powi((n - k) as i32);
+        }
+        (1.0 - p_lt).clamp(0.0, 1.0)
     }
 
     /// Whether a sky position falls in the ZTF footprint (declination cut).
@@ -85,15 +123,28 @@ mod tests {
     }
 
     #[test]
-    fn efficiency_is_logistic_not_step() {
+    fn object_completeness_matches_bb21_definition() {
         let survey = ZtfSurvey::default();
-        // Near unity well above the limit, ~0.5 at the limit, ~0 below.
-        assert!(survey.detection_efficiency(18.0) > 0.99);
-        assert!((survey.detection_efficiency(20.5) - 0.5).abs() < 1e-10);
-        assert!(survey.detection_efficiency(23.0) < 0.01);
-        // Smooth: intermediate efficiency just past the limit.
-        let e = survey.detection_efficiency(20.8);
-        assert!(e > 0.05 && e < 0.5, "ε(20.8) = {e:.3}");
+        // The defining property: 95% object-level completeness (>= 7
+        // detections) at the published V = 20.5 depth.
+        let p95 = survey.detection_efficiency(survey.depth_limit);
+        assert!((0.95..0.98).contains(&p95), "P(20.5) = {p95:.4}");
+        // Saturated bright, dead faint, sharp few-tenths-mag transition
+        // (the BB21 self-calibration behavior).
+        assert!(survey.detection_efficiency(18.0) > 0.999);
+        assert!(survey.detection_efficiency(21.0) < 0.05);
+        assert!(survey.detection_efficiency(23.0) < 1e-6);
+        // Monotone non-increasing with magnitude.
+        let mut last = 1.0;
+        for k in 0..=60 {
+            let m = 18.0 + 0.1 * k as f64;
+            let e = survey.detection_efficiency(m);
+            assert!(e <= last + 1e-12, "non-monotone at m = {m}");
+            last = e;
+        }
+        // Per-epoch curve still sits where the DES reading puts it.
+        let e50 = survey.single_epoch_efficiency(survey.single_epoch_m50);
+        assert!((e50 - 0.5).abs() < 1e-10);
     }
 
     #[test]

--- a/crates/p9-core/src/analysis/surveys.rs
+++ b/crates/p9-core/src/analysis/surveys.rs
@@ -83,8 +83,11 @@ pub const SURVEY_DEPTHS: [SurveyDepth; 5] = [
     SurveyDepth {
         survey: "ZTF",
         limiting_mag: 20.5,
-        band: "r",
-        reference: "Brown & Batygin (2022)",
+        band: "V",
+        reference: "Brown & Batygin (2022): V = 20.5 is the 95% completeness \
+                    depth for >= 7 detections (their population magnitudes \
+                    are V); the DES paper's independent reading is a \
+                    single-epoch m50 = 20.75 g ~ 20.48 V",
     },
     SurveyDepth {
         survey: "PS1 3pi",


### PR DESCRIPTION
Fixes #255.

**Band label.** The shared table listed ZTF 20.5 as r-band; BB21 define V = 20.5 (their population magnitudes are V). Relabelled, with the reference documenting both published readings (BB21 95%-completeness definition; DES paper's independent single-epoch m50 = 20.75 g ≈ 20.48 V).

**Completeness semantics.** `ZtfSurvey::detection_efficiency` treated 20.5 as a 50% logistic midpoint, under-detecting near the limit relative to the paper's own definition. It now models P(≥ 7 single-epoch detections) explicitly: per-epoch logistic centered at the DES single-epoch reading (20.48 V, steepness 4/mag), binomial survival over N = 22 effective epochs — N being the one calibrated quantity, the smallest value whose object-level completeness at V = 20.5 reaches the defined 95% (gives 96.0%). Both published readings are consistent under this model rather than competing interpretations of one number.

**Effect.** The §3 documented residual halves: ZTF exclusion fraction 0.477 → 0.528 vs published 0.564 (tolerance tightened 0.12 → 0.05); the remaining gap is per-field cadence/weather structure we don't model. Tests pin the 95% point, the sharp few-tenths-mag transition, monotonicity, and the per-epoch m50.