### PR TITLE
Extend sbdb-refresh guard to all frozen element tables

### DIFF
--- a/crates/p9-2016-inclined-tnos/Cargo.toml
+++ b/crates/p9-2016-inclined-tnos/Cargo.toml
@@ -16,3 +16,6 @@ uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
+
+[features]
+sbdb-refresh = ["p9-core/sbdb-refresh"]

--- a/crates/p9-2016-inclined-tnos/src/known_objects.rs
+++ b/crates/p9-2016-inclined-tnos/src/known_objects.rs
@@ -83,6 +83,39 @@ pub fn extended_high_i_objects() -> Vec<KnownTno> {
     objects
 }
 
+/// The paper table as snapshot rows for `p9_core::data::refresh` (all five
+/// elements are carried).
+pub fn element_snapshots() -> Vec<p9_core::data::refresh::ElementSnapshot> {
+    paper_tnos()
+        .iter()
+        .map(|t| p9_core::data::refresh::ElementSnapshot {
+            name: t.name,
+            designation: t.designation,
+            a: Some(t.elements.a),
+            e: Some(t.elements.e),
+            i_deg: Some(t.elements.i / DEG2RAD),
+            omega_deg: Some(t.elements.omega / DEG2RAD),
+            omega_big_deg: Some(t.elements.omega_big / DEG2RAD),
+            h_mag: None,
+        })
+        .collect()
+}
+
+/// Diff the frozen table against the live JPL SBDB (network; see the
+/// `#[ignore]`d test in `tests/sbdb_refresh_live.rs`). The table was
+/// re-transcribed at full SBDB precision in July 2026, so the tight
+/// `full_precision` tolerances apply.
+#[cfg(feature = "sbdb-refresh")]
+pub fn refresh_from_sbdb(
+    client: &p9_core::data::refresh::SbdbClient,
+) -> Result<Vec<p9_core::data::refresh::EtnoDiff>, String> {
+    p9_core::data::refresh::refresh_table_from_sbdb(
+        client,
+        &element_snapshots(),
+        &p9_core::data::refresh::Tolerances::full_precision(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/p9-2016-inclined-tnos/tests/sbdb_refresh_live.rs
+++ b/crates/p9-2016-inclined-tnos/tests/sbdb_refresh_live.rs
@@ -1,0 +1,22 @@
+//! Live SBDB drift check for the frozen paper-TNO table.
+//!
+//! Network-gated: `cargo test -p p9-2016-inclined-tnos --features sbdb-refresh -- --ignored`
+#![cfg(feature = "sbdb-refresh")]
+
+use p9_2016_inclined_tnos::known_objects::refresh_from_sbdb;
+use p9_core::data::refresh::SbdbClient;
+
+#[test]
+#[ignore = "hits the live JPL SBDB API"]
+fn paper_tno_table_matches_live_sbdb() {
+    let client = SbdbClient::new().expect("HTTP client");
+    let diffs = refresh_from_sbdb(&client).expect("live SBDB refresh");
+    for d in &diffs {
+        eprintln!("paper-tno drift: {d}");
+    }
+    assert!(
+        diffs.is_empty(),
+        "{} element(s) of the paper TNO table drifted vs live SBDB (see stderr)",
+        diffs.len()
+    );
+}

--- a/crates/p9-2021-perihelion-gap/Cargo.toml
+++ b/crates/p9-2021-perihelion-gap/Cargo.toml
@@ -13,3 +13,6 @@ uom = "0.38.0"
 
 [dev-dependencies]
 approx = { workspace = true }
+
+[features]
+sbdb-refresh = ["p9-core/sbdb-refresh"]

--- a/crates/p9-2021-perihelion-gap/src/sample.rs
+++ b/crates/p9-2021-perihelion-gap/src/sample.rs
@@ -173,6 +173,39 @@ pub fn high_e_perihelia(e_floor: f64) -> Vec<f64> {
         .collect()
 }
 
+/// The extended table as snapshot rows for `p9_core::data::refresh` (only a
+/// and e are carried by this table; q is derived).
+pub fn element_snapshots() -> Vec<p9_core::data::refresh::ElementSnapshot> {
+    EXTENDED_DISTANT_TNOS
+        .iter()
+        .map(|t| p9_core::data::refresh::ElementSnapshot {
+            name: t.name,
+            designation: t.name,
+            a: Some(t.a),
+            e: Some(t.e),
+            i_deg: None,
+            omega_deg: None,
+            omega_big_deg: None,
+            h_mag: None,
+        })
+        .collect()
+}
+
+/// Diff the frozen extended table against the live JPL SBDB (network; see
+/// the `#[ignore]`d test in `tests/sbdb_refresh_live.rs`). SBDB serves ~3
+/// significant figures for the weakly-constrained members, and a/e drift
+/// with the fit degeneracy, so the coarse `brown2017` allowances apply.
+#[cfg(feature = "sbdb-refresh")]
+pub fn refresh_from_sbdb(
+    client: &p9_core::data::refresh::SbdbClient,
+) -> Result<Vec<p9_core::data::refresh::EtnoDiff>, String> {
+    p9_core::data::refresh::refresh_table_from_sbdb(
+        client,
+        &element_snapshots(),
+        &p9_core::data::refresh::Tolerances::brown2017(),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/p9-2021-perihelion-gap/tests/sbdb_refresh_live.rs
+++ b/crates/p9-2021-perihelion-gap/tests/sbdb_refresh_live.rs
@@ -1,0 +1,22 @@
+//! Live SBDB drift check for the frozen extended distant-TNO table.
+//!
+//! Network-gated: `cargo test -p p9-2021-perihelion-gap --features sbdb-refresh -- --ignored`
+#![cfg(feature = "sbdb-refresh")]
+
+use p9_2021_perihelion_gap::sample::refresh_from_sbdb;
+use p9_core::data::refresh::SbdbClient;
+
+#[test]
+#[ignore = "hits the live JPL SBDB API"]
+fn extended_table_matches_live_sbdb() {
+    let client = SbdbClient::new().expect("HTTP client");
+    let diffs = refresh_from_sbdb(&client).expect("live SBDB refresh");
+    for d in &diffs {
+        eprintln!("extended-table drift: {d}");
+    }
+    assert!(
+        diffs.is_empty(),
+        "{} element(s) of EXTENDED_DISTANT_TNOS drifted vs live SBDB (see stderr)",
+        diffs.len()
+    );
+}

--- a/crates/p9-core/src/data/refresh.rs
+++ b/crates/p9-core/src/data/refresh.rs
@@ -311,6 +311,26 @@ pub fn etno_snapshots() -> Vec<ElementSnapshot> {
         .collect()
 }
 
+/// The Batygin & Brown (2016) stable-KBO table as snapshot rows for the
+/// differ. The elements are epoch-~2016 SBDB osculating values (refreshed
+/// July 2026 after #223 found a mixed solution and systematic e offsets), so
+/// the coarse [`Tolerances::brown2017`] drift allowances apply.
+pub fn stable_kbo_snapshots() -> Vec<ElementSnapshot> {
+    crate::data::stable_kbos::stable_kbos()
+        .iter()
+        .map(|k| ElementSnapshot {
+            name: k.name,
+            designation: k.designation,
+            a: Some(k.elements.a),
+            e: Some(k.elements.e),
+            i_deg: Some(k.elements.i / DEG2RAD),
+            omega_deg: Some(k.elements.omega / DEG2RAD),
+            omega_big_deg: Some(k.elements.omega_big / DEG2RAD),
+            h_mag: None,
+        })
+        .collect()
+}
+
 /// Julian Date (UT) of a calendar date with fractional day (proleptic
 /// Gregorian; standard Meeus algorithm). `calendar_to_jd(2000, 1, 1.5)` is
 /// J2000.0 = 2451545.0.
@@ -421,10 +441,20 @@ mod live {
     pub fn refresh_etno_from_sbdb(client: &SbdbClient) -> Result<Vec<EtnoDiff>, String> {
         refresh_table_from_sbdb(client, &etno_snapshots(), &Tolerances::brown2017())
     }
+
+    /// Diff the frozen stable-KBO table against live SBDB with the
+    /// [`Tolerances::brown2017`] drift allowances. An empty result means the
+    /// frozen table still matches JPL.
+    pub fn refresh_stable_kbos_from_sbdb(client: &SbdbClient) -> Result<Vec<EtnoDiff>, String> {
+        refresh_table_from_sbdb(client, &stable_kbo_snapshots(), &Tolerances::brown2017())
+    }
 }
 
 #[cfg(feature = "sbdb-refresh")]
-pub use live::{fetch_live_elements, refresh_etno_from_sbdb, refresh_table_from_sbdb};
+pub use live::{
+    fetch_live_elements, refresh_etno_from_sbdb, refresh_stable_kbos_from_sbdb,
+    refresh_table_from_sbdb,
+};
 
 /// Re-export so downstream crates enabling `p9-core/sbdb-refresh` can build a
 /// client without depending on starfield directly.

--- a/crates/p9-core/tests/sbdb_refresh_live.rs
+++ b/crates/p9-core/tests/sbdb_refresh_live.rs
@@ -76,3 +76,43 @@ fn sbdb_lookup_returns_full_element_set_for_sedna() {
     assert!(live.mean_motion_deg_per_day.is_some());
     assert!(live.first_obs.is_some());
 }
+
+/// Solution drift documented at the 2026-07-15 live check: `stable_kbos`
+/// deliberately pins the paper-epoch (~2016) solutions (see the module
+/// docs), and JPL has since republished a/e along the fit degeneracy for
+/// the long-period members (live SBDB also serves only ~3 significant
+/// figures for these), plus a sub-degree ω update for the short-arc
+/// 2010 GB174. Anything outside this list is a transcription error or a
+/// new solution worth a human look.
+const STABLE_KBO_KNOWN_DRIFT: &[(&str, Element)] = &[
+    ("Sedna", Element::SemiMajorAxis),
+    ("Sedna", Element::Eccentricity),
+    ("2012 VP113", Element::SemiMajorAxis),
+    ("2012 VP113", Element::Eccentricity),
+    ("2004 VN112", Element::SemiMajorAxis),
+    ("2010 GB174", Element::SemiMajorAxis),
+    ("2010 GB174", Element::ArgPerihelion),
+    ("2010 VZ98", Element::SemiMajorAxis),
+];
+
+#[test]
+#[ignore = "hits the live JPL SBDB API"]
+fn stable_kbo_table_matches_live_sbdb_modulo_documented_drift() {
+    use p9_core::data::refresh::refresh_stable_kbos_from_sbdb;
+    let client = SbdbClient::new().expect("HTTP client");
+    let diffs = refresh_stable_kbos_from_sbdb(&client).expect("live SBDB refresh");
+    let mut unexpected = 0;
+    for d in &diffs {
+        let known = STABLE_KBO_KNOWN_DRIFT
+            .iter()
+            .any(|(obj, el)| *obj == d.object && *el == d.element);
+        eprintln!("{}: {d}", if known { "known drift" } else { "UNEXPECTED" });
+        if !known {
+            unexpected += 1;
+        }
+    }
+    assert_eq!(
+        unexpected, 0,
+        "{unexpected} element(s) of stable_kbos drifted out of tolerance vs live SBDB          beyond the drift documented 2026-07-15 (transcription error or new          orbit-solution update; see stderr)"
+    );
+}


### PR DESCRIPTION
Fixes #258. The three tables where the review found wrong/fabricated elements are now mechanically guarded like the ETNO and Neptune-crossing samples:

- **`p9_core::data::stable_kbos`** — `stable_kbo_snapshots()` + `refresh_stable_kbos_from_sbdb` (brown2017 tolerances; the table pins paper-epoch ~2016 solutions). The live check was run today: 8 diffs, all the documented a/e fit-degeneracy drift on the long-period members (plus GB174's sub-degree ω update), recorded as a `STABLE_KBO_KNOWN_DRIFT` list exactly like the ETNO test — anything new fails.
- **`p9-2021-perihelion-gap::sample::EXTENDED_DISTANT_TNOS`** — `element_snapshots()` (a, e; the only columns the table carries) + gated `refresh_from_sbdb` + `#[ignore]`d live test. Ran clean today (the #200 re-transcription holds).
- **`p9-2016-inclined-tnos::known_objects`** — full five-element snapshots + gated refresh at `full_precision` tolerances + live test. Ran clean today (the #204 re-transcription holds).

Both paper crates gain the `sbdb-refresh = ["p9-core/sbdb-refresh"]` feature; default builds and tests stay offline. All three live tests were executed against JPL before this PR.