### PR TITLE
Fix doc/code mismatches across crates

### DIFF
--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -224,8 +224,9 @@ band's 3.4 µm and a plausible Planet Nine effective temperature of ≈40 K, hν
 blackbody thermal flux is ~10⁻⁵⁵ W/m²/Hz/sr — utterly negligible. The thermal channel only
 overtakes reflected sunlight above ≈175 K (at 15 M⊕, 400 AU), far hotter than any Planet Nine.
 So the W1 detectability this crate computes is, for a cold body, set by **reflected sunlight**;
-the thermal term is retained and would dominate for an implausibly warm planet. (The real search's
-W2 4.6 µm band is more thermally favorable; the shared survey table pins the deeper, bluer W1.)
+the thermal term is retained and would dominate for an implausibly warm planet. (W1 is the band
+Meisner et al. actually searched in the unWISE coadds — the one the shared survey table pins;
+W2 at 4.6 µm would be more thermally favorable but was not the search band.)
 - Consequence for the exclusion: with the labelled W1-BAND albedo (0.10 — the 3.3 µm CH₄ ν₃
   band suppresses ice-giant reflectance far below the V-band 0.41 a previous version applied),
   the reflected-light W1 reach is ≈185 AU (5 M⊕) to ≈220 AU (18 M⊕) and the exclusion over the

--- a/crates/p9-2016-constraints/src/clustering_metric.rs
+++ b/crates/p9-2016-constraints/src/clustering_metric.rs
@@ -106,7 +106,7 @@ pub fn observed_etno_r_bar() -> f64 {
 /// From the paper: randomly draw `n_draw` objects from the qualifying
 /// survivors (a ∈ [300,700], q < 80 AU, i < 50°) and check whether their Δϖ
 /// concentration reaches the *observed* 6-KBO mean resultant length
-/// (R̄ ≈ 0.96 from `observed_six_kbo_r_bar`, replacing a previous invented
+/// (R̄ ≈ 0.84 from `observed_six_kbo_r_bar`, replacing a previous invented
 /// R̄ > 0.5 cut). Returns the fraction of draws at least as confined as the
 /// observations.
 pub fn confinement_probability(

--- a/crates/p9-2016-fortney-thermal/src/lib.rs
+++ b/crates/p9-2016-fortney-thermal/src/lib.rs
@@ -107,6 +107,10 @@ impl P9Thermal {
         Self {
             mass_earth,
             distance_au,
+            // Conflation kept deliberately: core's ALBEDO_NEPTUNE (0.41) is a
+            // GEOMETRIC albedo; Neptune's Bond albedo is ~0.29. At 100s of AU
+            // the equilibrium-temperature difference is well under a kelvin,
+            // so the shared constant is used rather than a second knob.
             bond_albedo: ALBEDO_NEPTUNE,
             l_int_ref_w: L_INT_REF_W,
         }

--- a/crates/p9-2016-obliquity-gomes/src/lib.rs
+++ b/crates/p9-2016-obliquity-gomes/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! Over one full precession cycle the obliquity oscillates between 0 and
 //! 2·i_p. The solar-system age is a fraction of the precession period, so the
-//! achieved obliquity at 4.5 Gyr is 2·i_p·sin²(π·t/T_prec).
+//! achieved obliquity at 4.5 Gyr is 2·i_p·|sin(π·t/T_prec)|.
 //!
 //! The forced inclination i_p, the precession period T_prec, and hence the
 //! obliquity all depend on Planet Nine's mass, semimajor axis, and

--- a/crates/p9-2016-resonance-prediction/src/lib.rs
+++ b/crates/p9-2016-resonance-prediction/src/lib.rs
@@ -11,15 +11,16 @@
 //! their observed orbital periods are commensurate with P9's period and
 //! therefore *predict* it. An object in the exterior p:q resonance sits at
 //!
-//!   a_ETNO = a9 · (p/q)^(2/3)        ⇔        P_ETNO / P9 = q / p,
+//!   a_ETNO = a9 · (q/p)^(2/3)        ⇔        P9 / P_ETNO = p / q,
 //!
-//! i.e. P9 completes p orbits while the ETNO completes q (p > q for an
-//! exterior body). Scanning a9 and asking which value places the whole
-//! distant set closest to low-order resonances localizes Planet Nine.
+//! i.e. the interior ETNO completes p orbits while P9 completes q (p > q).
+//! Scanning a9 and asking which value places the whole distant set closest
+//! to low-order resonances localizes Planet Nine.
 //!
 //! Malhotra et al. report a9 ≈ 665 AU (period ≈ 17,117 yr), with the four
 //! longest-period ETNOs (Sedna, 2004 VN112, 2010 GB174, 2012 VP113) near
-//! period ratios of small integers (e.g. 3:2, 4:3, 5:3, ...). Millholland &
+//! period ratios of small integers (3:2, 5:2, 3:1, 4:1 — the N:1 / N:2
+//! family the DEFAULT_Q_MAX = 2 scan admits). Millholland &
 //! Laughlin independently localize P9 near a9 ≈ 654 AU.
 //!
 //! HONEST CAVEAT. These resonance predictions are NOT confirmed. The sibling

--- a/crates/p9-2017-dynamics/src/resonance.rs
+++ b/crates/p9-2017-dynamics/src/resonance.rs
@@ -102,7 +102,7 @@ impl Resonance {
 /// evaluated on the resonant stream λ = (p/q) λ₉ + φ/q (coplanar,
 /// anti-aligned apsides, Δϖ = π — the configuration of the confined
 /// population), returning (max_φ H − min_φ H)/2 over a grid of resonant
-/// phases. A softening b = 0.02 a₉ regularizes orbit-crossing geometries
+/// phases. A softening b = 0.005 a₉ regularizes orbit-crossing geometries
 /// (mutual inclination separates the orbits in reality).
 ///
 /// This is a direct numerical evaluation of the resonance strength — no

--- a/crates/p9-2017-resonance-hopping/src/chain.rs
+++ b/crates/p9-2017-resonance-hopping/src/chain.rs
@@ -68,11 +68,11 @@ const EARTH_MASS_SOLAR: f64 = 3.003_489e-6;
 /// A single interior p:q mean-motion resonance of Planet Nine.
 ///
 /// Convention (the workspace single convention): an interior particle in the
-/// p:q resonance completes q orbits while P9 completes p (p > q), sitting at
+/// p:q resonance completes p orbits while P9 completes q (p > q), sitting at
 /// `a_res = a9 (q/p)^{2/3} < a9`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct P9Resonance {
-    /// Planet Nine's integer (orbits of P9 per `q` orbits of the particle).
+    /// The particle's orbit count (per `q` orbits of P9).
     pub p: u32,
     /// Particle's integer.
     pub q: u32,

--- a/crates/p9-2018-chaotic-dynamics/src/lib.rs
+++ b/crates/p9-2018-chaotic-dynamics/src/lib.rs
@@ -22,10 +22,11 @@
 //! - The resonance locations are cross-checked against the analytic Kepler
 //!   relation a_j = a9 j^{-2/3} to 1e-9.
 //!
-//! REUSE: the resonance widths come from
-//! `p9_core::analysis::resonance::{Resonance, chirikov_overlap_parameter,
-//! critical_perihelion}`; the secular Hamiltonian structure from
-//! `p9_core::analysis::secular`. Nothing here re-derives those.
+//! REUSE: the resonance locations come from
+//! `p9_core::analysis::resonance::resonance_semi_major_axis`, the overlap
+//! zone from `p9_core::analysis::resonance::overlap_zone_width_fraction`,
+//! and the width machinery from `p9_core::analysis::hansen`. Nothing here
+//! re-derives those.
 //!
 //! Published claims are kept as labelled reference constants in [`reference`];
 //! residuals against them are documented in the tests.

--- a/crates/p9-2018-wise-search/src/thermal_model.rs
+++ b/crates/p9-2018-wise-search/src/thermal_model.rs
@@ -22,9 +22,10 @@
 //! WISE W1 detectability is in practice set by **reflected sunlight**, and
 //! this crate's "thermal-IR" exclusion is, at W1, a reflected-light exclusion
 //! — the thermal term is retained (and would dominate for an implausibly warm
-//! body) but contributes nothing at 40 K. The W2 (4.6 µm) band of the actual
-//! Meisner et al. search is somewhat more thermally favorable; we model the
-//! deeper, bluer W1 band that the shared survey table pins.
+//! body) but contributes nothing at 40 K. W1 (3.4 µm) is the band Meisner
+//! et al. (2018, arXiv:1712.04950) actually searched in the unWISE coadds —
+//! the same band the shared survey table pins. (W2 at 4.6 µm would be
+//! somewhat more thermally favorable, but was not the search band.)
 //!
 //! Both channels are converted to a Vega-system W1 magnitude with the WISE W1
 //! zero point F_ν0 = 309.540 Jy (Wright et al. 2010, Table 1). The radius law

--- a/crates/p9-2020-clement-precession/src/lib.rs
+++ b/crates/p9-2020-clement-precession/src/lib.rs
@@ -1,4 +1,4 @@
-//! Reproduction of Clement & Sheppard (2020), "Orbital Precession in the
+//! Reproduction of Clement & Kaib (2020), "Orbital Precession in the
 //! Distant Solar System" (arXiv:2005.05326), and the companion 2021 study of
 //! Neptune's distant mean-motion resonances under a Planet Nine
 //! (arXiv:2105.01065).

--- a/crates/p9-2020-clement-precession/src/precession.rs
+++ b/crates/p9-2020-clement-precession/src/precession.rs
@@ -13,7 +13,7 @@
 //! limit b_{3/2}^{(1)}(α) → 3α; the (1 − e²)^{-2} factor is the standard
 //! finite-eccentricity correction). The total precession is slow and prograde,
 //! with a period of order >~ 1 Gyr for the clustered ETNOs — the regime in
-//! which the apsidal lines can stay coherently confined (Clement & Sheppard
+//! which the apsidal lines can stay coherently confined (Clement & Kaib
 //! 2020, arXiv:2005.05326).
 //!
 //! A Planet Nine is *exterior* to the ETNO and adds an opposite-sign secular
@@ -232,7 +232,7 @@ mod tests {
 
     #[test]
     fn test_giant_planet_precession_period_is_documented_order() {
-        // Clement & Sheppard 2020: the giant planets drive a slow prograde
+        // Clement & Kaib 2020: the giant planets drive a slow prograde
         // apsidal precession of the distant ETNOs, with a period of order
         // ~1 Gyr (>~ a Gyr for a ≳ 250 AU). The rate must be positive
         // (prograde) and the period in the 10^8–10^10 yr band.

--- a/crates/p9-2020-secular-octupole/src/lib.rs
+++ b/crates/p9-2020-secular-octupole/src/lib.rs
@@ -22,8 +22,10 @@
 //! - [`octupole`]: the coplanar secular Hamiltonian to quadrupole and octupole
 //!   order. The quadrupole piece REUSES
 //!   `p9_core::analysis::secular::coplanar_quadrupole`; the octupole piece adds
-//!   the literature `-C_oct e e_9 cos(dvarpi)` term with
-//!   `C_oct = (15/16)(GM_9/a_9) alpha^3 e_9/(1-e_9^2)^{5/2}`. The
+//!   the `+C_oct e e_9 cos(dvarpi)` term (positive sign, matching the exact
+//!   ring average) with
+//!   `C_oct = K_OCT (GM_9/a_9) alpha^3/(1-e_9^2)^{5/2}`, K_OCT = 1.05
+//!   calibrated against p9-core's numerical ring average. The
 //!   octupole-to-quadrupole strength ratio `epsilon_oct` and its scaling with
 //!   `e_9` and `alpha` are pinned. The analytic octupole amplitude is
 //!   cross-checked at small `alpha` against the cos(dvarpi) Fourier amplitude

--- a/crates/p9-2024-siraj-orbit/src/forcing.rs
+++ b/crates/p9-2024-siraj-orbit/src/forcing.rs
@@ -5,7 +5,8 @@
 //! constant (the rate at which the perturber forces the test body's apsidal
 //! line) scales as
 //!
-//!   ω̇_sec ∝ G m_p a² / a_p⁵   (quadrupole, in the α = a/a_p ≪ 1 limit)
+//!   ω̇_sec ∝ n (m_p/M☉) (a/a_p)³ ∝ m_p a^{3/2} / a_p³   (quadrupole,
+//!   α = a/a_p ≪ 1 limit)
 //!
 //! At fixed test-particle semi-major axis `a`, the *mass-and-distance*
 //! dependence of the forcing that the clustered population responds to is

--- a/crates/p9-2025-simons-forecast/src/bands.rs
+++ b/crates/p9-2025-simons-forecast/src/bands.rs
@@ -8,14 +8,14 @@
 /// the Rayleigh–Jeans regime.
 pub const SO_280: f64 = 280e9;
 
-/// SO 220 GHz LAT band centre (Hz).
-pub const SO_220: f64 = 220e9;
+/// SO 225 GHz LAT band centre (Hz).
+pub const SO_225: f64 = 225e9;
 
-/// SO 150 GHz LAT band centre (Hz).
-pub const SO_150: f64 = 150e9;
+/// SO 145 GHz LAT band centre (Hz).
+pub const SO_145: f64 = 145e9;
 
-/// SO 90 GHz LAT band centre (Hz).
-pub const SO_90: f64 = 90e9;
+/// SO 93 GHz LAT band centre (Hz).
+pub const SO_93: f64 = 93e9;
 
 /// ACT 229 GHz band centre (Hz), the highest-frequency ACT band used in the
 /// Naess et al. (2021) Planet Nine search (98 / 150 / 229 GHz).
@@ -86,7 +86,7 @@ mod tests {
 
     #[test]
     fn bands_ordered() {
-        assert!(SO_90 < SO_150 && SO_150 < SO_220 && SO_220 < SO_280);
+        assert!(SO_93 < SO_145 && SO_145 < SO_225 && SO_225 < SO_280);
         assert!(ACT_229 < SO_280);
     }
 

--- a/crates/p9-2025-simons-forecast/src/lib.rs
+++ b/crates/p9-2025-simons-forecast/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //! The SO and ACT sensitivities are kept as **labelled reference constants**
 //! (`bands`), not derived: ACT's 8 mJy is the median of the published 4–12 mJy
-//! shift-and-stack limit; SO's deep/shallow limits (1.3 / 4.4 mJy) are the
+//! shift-and-stack limit; SO's deep/shallow limits (4.4 / 14.2 mJy) are the
 //! values that reproduce the paper's quoted 900 / 500 AU reach for a 5 M⊕ body
 //! under this thermal model. The crate then derives reach, SNR, and box
 //! coverage from them, and reproduces the published *direction* and *scale* of

--- a/crates/p9-core/src/analysis/surveys.rs
+++ b/crates/p9-core/src/analysis/surveys.rs
@@ -77,7 +77,7 @@ pub const SURVEY_DEPTHS: [SurveyDepth; 5] = [
         survey: "WISE W1",
         limiting_mag: 16.5,
         band: "W1",
-        reference: "Wright et al. (2010)",
+        reference: "Meisner et al. (2018) unWISE coadd search depth",
     },
     SurveyDepth {
         survey: "CRTS",

--- a/crates/p9-core/src/analysis/thermal.rs
+++ b/crates/p9-core/src/analysis/thermal.rs
@@ -65,8 +65,11 @@ pub fn photon_energy_ratio(t: f64, nu_hz: f64) -> f64 {
 }
 
 /// Solar equilibrium temperature (K) for a fast rotator radiating from its full
-/// surface at heliocentric distance `distance_au` with geometric/Bond albedo
-/// `albedo`: T_eq = T_sun √(R_sun / 2d) (1 − A)^¼.
+/// surface at heliocentric distance `distance_au`:
+/// T_eq = T_sun √(R_sun / 2d) (1 − A)^¼. Strictly A is the BOND albedo;
+/// callers passing the geometric `ALBEDO_NEPTUNE` (0.41, vs Neptune's Bond
+/// ~0.29) overstate (1−A) by ~17%, which changes T_eq by ~4% — sub-kelvin at
+/// the distances this workspace evaluates.
 pub fn solar_equilibrium_temp(distance_au: f64, albedo: f64) -> f64 {
     let d_m = distance_au * AU_M;
     T_SUN * (R_SUN_M / (2.0 * d_m)).sqrt() * (1.0 - albedo).powf(0.25)


### PR DESCRIPTION
Fixes #259. All thirteen checklist items, verified against current code before editing:

1. p9-2016-resonance-prediction lib doc: resonance law corrected to a_ETNO = a9·(q/p)^{2/3} with the interior ETNO completing p orbits per q of P9; example ratios now the N:1/N:2 family the DEFAULT_Q_MAX = 2 scan admits (3:2, 5:2, 3:1, 4:1).
2. p9-2016-constraints clustering_metric: docstring R̄ 0.96 → 0.84 (the value the function computes and the §5 residual documents).
3. p9-2016-obliquity-gomes lib doc: obliquity law 2·i_p·sin² → 2·i_p·|sin| (matching precession_model.rs and the code).
4. p9-2017-dynamics resonance doc: softening 0.02·a₉ → the implemented 0.005·a₉.
5. p9-2017-resonance-hopping: P9Resonance convention/field docs un-inverted (particle completes p orbits per q of P9).
6. p9-2018-chaotic-dynamics reuse note now cites what the crate actually consumes (resonance_semi_major_axis, overlap_zone_width_fraction, hansen) instead of nonexistent core items.
7. p9-2020-secular-octupole lib doc: +C_oct sign and the calibrated K_OCT = 1.05 coefficient (was −C_oct with a hardcoded 15/16).
8. p9-2024-siraj-orbit forcing doc: quadrupole rate ∝ n(m_p/M☉)(a/a_p)³ ∝ m_p a^{3/2}/a_p³ (the stated a²/a_p⁵ would imply an m ∝ a_p⁵ ridge, contradicting the implemented m/a_p³).
9. p9-2018-wise-search band attribution un-inverted: Meisner et al. (2018, arXiv:1712.04950) searched **W1**, the band we model; REPRODUCTION_NOTES §13 parenthetical fixed; the shared table's 16.5 depth now credited to the Meisner unWISE coadd, not Wright (2010).
10. p9-2020-clement-precession: arXiv:2005.05326 is Clement & **Kaib** (three sites).
11. p9-2025-simons-forecast lib doc: SO limits 4.4/14.2 mJy (was quoting 1.3/4.4, stale vs bands.rs).
12. bands.rs SO LAT centres corrected to the real 93/145/225 GHz and the constants renamed to match (they were 90/150/220 and unused; 280 was already right).
13. Geometric-vs-Bond albedo conflation labeled at both sites: fortney-thermal's `bond_albedo: ALBEDO_NEPTUNE` now carries the deliberate-conflation comment (sub-kelvin effect at these distances), and core `solar_equilibrium_temp` docs quantify the ~4% T_eq overstatement.