### PR TITLE
Strengthen weak and tautological tests

### DIFF
--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -593,6 +593,10 @@ derived quantities:
 - `p9-2019-clustering` / `p9-2021-orbit` survey-bias null: longitude suppression near
   λ ≈ 95°/275° + δ > −30° coverage — same caveat.
 - `p9-2025-clustering` selection weighting w(ϖ) = 1 + 0.3cos(ϖ − 60°) in the bias-resampling MC.
+- `p9-2025-simons-forecast` SO flux limits (deep 4.4 mJy / shallow 14.2 mJy at 280 GHz) — reverse-
+  engineered from the paper's published 900/500 AU 5 M⊕ reaches under this thermal model (the
+  paper quotes reaches, not point-source limits); the SO reach test is therefore a round-trip
+  consistency pin, with the published ACT 8 mJy band as the independent anchor.
 - `p9-search-hull` TESS entry footprint (dec 0–90°, areal coverage 0.20) — a coarse stand-in for
   the Rice & Laughlin (2020) blind-search sectors 18–19 (~4,600 deg² of northern sky); the depth
   (V < 21) and the d ≤ 150 au validity cap are the paper's published values via

--- a/crates/p9-2016-commensurabilities/src/clustering.rs
+++ b/crates/p9-2016-commensurabilities/src/clustering.rs
@@ -162,10 +162,12 @@ mod tests {
                 obs.r_bar
             );
             // A single random control of the same size is, with high
-            // probability, less grouped than the observed sample.
+            // probability, less grouped than the observed sample. (This
+            // previously OR'd in `p_mc < 0.2`, already asserted above, so
+            // the comparison could never fire.)
             let random_r = uniform_control_r_bar(n, 9999);
             assert!(
-                obs.r_bar > random_r - 0.05 || p_mc < 0.2,
+                obs.r_bar > random_r - 0.05,
                 "{:?}: obs R̄ {:.3} vs random {:.3}",
                 angle,
                 obs.r_bar,

--- a/crates/p9-2016-holman-payne/src/sky.rs
+++ b/crates/p9-2016-holman-payne/src/sky.rs
@@ -161,10 +161,12 @@ mod tests {
         let p = brown_batygin_orbit();
         let sky = favored_sky_position(&p, 1440);
         let sep = sky.separation_deg(published::PREFERRED_RA_DEG, published::PREFERRED_DEC_DEG);
-        // Honest bound: the computed direction lands within ~one orbit-quadrant
-        // of the published region. (See REPRODUCTION_NOTES for the offset.)
+        // Recorded offset: the computed direction lands at (RA ≈ 47°,
+        // Dec ≈ −12°), 7.5° from the published region center — comfortably
+        // inside its ~20° half-extent. (A previous bound of 120° — one
+        // orbit-quadrant — could not fail.)
         assert!(
-            sep < 120.0,
+            sep < 15.0,
             "favored sky point (RA {:.0}°, Dec {:.0}°) is {sep:.0}° from published \
              (RA {:.0}°, Dec {:.0}°)",
             sky.ra_deg,

--- a/crates/p9-2017-bias/src/bias_function.rs
+++ b/crates/p9-2017-bias/src/bias_function.rs
@@ -207,7 +207,9 @@ pub fn perihelion_bias(
     brightness * angular_bias(varpi, omega, i, params)
 }
 
-/// Compute bias weights for a grid of (ϖ, Ω) values.
+/// Compute bias weights for a grid of (ϖ, Ω) values — a DIAGNOSTIC map of
+/// the selection model (the Monte-Carlo sampler does not consume it; it
+/// rejection-samples against the exact bound 1.0, valid because B ∈ [0, 1]).
 ///
 /// Returns a 2D array of bias values for each (ϖ, Ω) combination,
 /// with inclination marginalized over a sin(i) prior restricted to the
@@ -251,8 +253,9 @@ pub fn bias_grid(
     grid
 }
 
-/// Maximum of the raw bias over (ϖ, Ω) for a given (a, e, H, i): the true
-/// envelope needed for un-clamped rejection sampling.
+/// Maximum of the raw bias over (ϖ, Ω) for a given (a, e, H, i) — a
+/// DIAGNOSTIC of the selection contrast, not a sampler input (the sampler
+/// rejects against 1.0, the exact envelope since B ∈ [0, 1]).
 pub fn bias_max(a: f64, e: f64, h_mag: f64, i: f64, params: &BiasParams) -> f64 {
     let n = 72;
     let mut max = 0.0_f64;

--- a/crates/p9-2019-review/src/parameter_survey.rs
+++ b/crates/p9-2019-review/src/parameter_survey.rs
@@ -267,9 +267,10 @@ mod tests {
         let grid = ParameterGrid::paper_grid();
         let viable = grid.count_viable();
         // Paper reports ~1,134 viable simulations
-        assert!(
-            viable > 500 && viable < 2000,
-            "Expected ~1134 viable, got {}",
+        // The grid reproduces the paper's count exactly; pin it.
+        assert_eq!(
+            viable, 1134,
+            "Expected the paper's 1134 viable, got {}",
             viable
         );
     }

--- a/crates/p9-2022-des/src/recovery_analysis.rs
+++ b/crates/p9-2022-des/src/recovery_analysis.rs
@@ -283,10 +283,13 @@ mod tests {
         // Coarse per-model regression against Table 1 (the single
         // calibrated night-usability parameter is shared across models, so
         // inter-model differences are genuinely computed from colors).
+        // Tolerance ±0.04: tighter than the full Table-1 inter-model
+        // spread (0.113), so a column shift between models (the #212 bug,
+        // which a 0.12 tolerance let through) cannot pass.
         for model in color_models::all_models() {
             let r = compute_recovery_for_model(&model, 3000, 11).recovery_frac;
             assert!(
-                (r - model.paper_recovery).abs() < 0.12,
+                (r - model.paper_recovery).abs() < 0.04,
                 "{}: computed {r:.3} vs Table 1 {:.3}",
                 model.name,
                 model.paper_recovery

--- a/crates/p9-2025-planet-y/src/lib.rs
+++ b/crates/p9-2025-planet-y/src/lib.rs
@@ -11,8 +11,10 @@
 //!   `p9_core::forces::j2_secular`) and Planet Y's exterior ring torque
 //!   (∝ m_Y), and measures the warp amplitude.
 //! - [`mean_plane`] expresses the forced plane as an observable mean-plane pole
-//!   (reusing p9-core pole geometry) and applies a first-order debiasing of an
-//!   inclination-limited sample.
+//!   (reusing p9-core pole geometry). (A previous "debiasing" here was an
+//!   x·s/s identity around a free efficiency-slope knob — deleted rather
+//!   than dressed up; a real ε(i) would have to be derived over the
+//!   librating population.)
 
 pub mod laplace_plane;
 pub mod mean_plane;

--- a/crates/p9-2025-planet-y/src/mean_plane.rs
+++ b/crates/p9-2025-planet-y/src/mean_plane.rs
@@ -44,30 +44,6 @@ pub fn mean_plane_tilt_deg(a_au: f64, planet_y: &PlanetY) -> f64 {
     angular_distance(&forced_pole(a_au, planet_y), &reference_pole()) / DEG2RAD
 }
 
-/// First-order debiasing of a measured mean-plane tilt.
-///
-/// An inclination-limited sample (detection efficiency ∝ a smooth, decreasing
-/// function of ecliptic inclination) under-weights high-inclination members,
-/// pulling the *measured* pole toward the ecliptic. To leading order the
-/// measured tilt is suppressed by a factor `efficiency_slope ∈ (0, 1]`
-/// relative to the true forced tilt; debiasing divides it back out.
-///
-/// `measured_tilt_deg`: the raw mean-plane tilt from the (biased) sample.
-/// `efficiency_slope`: the fractional suppression (1.0 = unbiased).
-pub fn debias_tilt_deg(measured_tilt_deg: f64, efficiency_slope: f64) -> f64 {
-    assert!(
-        efficiency_slope > 0.0 && efficiency_slope <= 1.0,
-        "efficiency_slope must be in (0, 1]"
-    );
-    measured_tilt_deg / efficiency_slope
-}
-
-/// Forward model of a *biased* measurement: apply the inclination suppression
-/// to the true forced tilt. Used to verify that debiasing inverts the bias.
-pub fn biased_tilt_deg(a_au: f64, planet_y: &PlanetY, efficiency_slope: f64) -> f64 {
-    mean_plane_tilt_deg(a_au, planet_y) * efficiency_slope
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -91,25 +67,6 @@ mod tests {
         let tilt = mean_plane_tilt_deg(72.0, &py);
         let i_f = forced_inclination(72.0, &py) / DEG2RAD;
         assert_relative_eq!(tilt, i_f, max_relative = 1e-9);
-    }
-
-    #[test]
-    fn test_debias_inverts_bias() {
-        let py = nominal();
-        let slope = 0.7;
-        let true_tilt = mean_plane_tilt_deg(75.0, &py);
-        let measured = biased_tilt_deg(75.0, &py, slope);
-        let recovered = debias_tilt_deg(measured, slope);
-        assert_relative_eq!(recovered, true_tilt, max_relative = 1e-12);
-    }
-
-    #[test]
-    fn test_bias_pulls_toward_ecliptic() {
-        // A biased measurement is always closer to flat than the truth.
-        let py = nominal();
-        let true_tilt = mean_plane_tilt_deg(78.0, &py);
-        let measured = biased_tilt_deg(78.0, &py, 0.6);
-        assert!(measured < true_tilt && measured > 0.0);
     }
 
     #[test]

--- a/crates/p9-2025-russell-albedo/src/photometry.rs
+++ b/crates/p9-2025-russell-albedo/src/photometry.rs
@@ -20,7 +20,8 @@ use crate::composition::Composition;
 /// Most-likely current heliocentric distance of Planet Nine from the Reference
 /// Population 3.0 orbit (AU).
 ///
-/// Solved so that the two composition endpoints' apparent magnitudes straddle
+/// BACK-SOLVED, not sourced: the paper publishes H and m but not this
+/// distance. Solved so that the two composition endpoints' apparent magnitudes straddle
 /// the published m = +21.9..+22.7 band: at this distance the bright (H = −6.1)
 /// endpoint sits at m ≈ 21.8 and the faint (H = −5.2) endpoint at m ≈ 22.7.
 /// This lands in the few-hundred-AU regime expected near the most-likely
@@ -73,9 +74,16 @@ mod tests {
 
     #[test]
     fn apparent_v_brackets_published_band() {
+        // NOT an independent reproduction of the published +21.9..+22.7
+        // band: MOST_LIKELY_DISTANCE_AU (625 AU) is back-solved from that
+        // very band (the paper does not publish the distance), so this test
+        // certifies only the CONSISTENCY of the (H, distance, m) triangle —
+        // that the genuine H = −6.1/−5.2 pins, propagated through the
+        // shared distance law, land on the published magnitudes at one
+        // common distance. The independent physics pins are the H test
+        // above and the distance-scaling test below.
         let m_bright = apparent_v_most_likely(&LARGE_COLD);
         let m_faint = apparent_v_most_likely(&SMALL_WARM);
-        // Published apparent-magnitude band is +21.9..+22.7.
         assert!((m_bright - 21.9).abs() < 0.3, "m(bright) = {m_bright:.3}");
         assert!((m_faint - 22.7).abs() < 0.3, "m(faint) = {m_faint:.3}");
         // Brighter absolute magnitude ⇒ brighter (smaller) apparent magnitude.

--- a/crates/p9-2025-simons-forecast/src/forecast.rs
+++ b/crates/p9-2025-simons-forecast/src/forecast.rs
@@ -194,6 +194,11 @@ mod tests {
 
     #[test]
     fn so_reach_matches_published_5me_band() {
+        // ROUND-TRIP of the tuned limits, not an independent check: the SO
+        // flux limits are reverse-engineered from these very reaches (see
+        // `bands`), so this pins only that the inversion stays consistent.
+        // The independent computed pins are the ACT band test above (ACT's
+        // 8 mJy is a published limit) and the scaling tests below.
         // SO forecast: 5 M⊕ detectable from 500 AU (shallow) to 900 AU (deep).
         let deep = (max_detectable_distance(5.0, &SO_SENSITIVITY) / au(1.0)).value;
         let shallow = (max_detectable_distance(5.0, &SO_SENSITIVITY_SHALLOW) / au(1.0)).value;

--- a/crates/p9-2025-stellar-flybys/tests/headline.rs
+++ b/crates/p9-2025-stellar-flybys/tests/headline.rs
@@ -14,11 +14,20 @@ use p9_2025_stellar_flybys::{
 };
 
 #[test]
-fn combined_probability_is_at_most_five_percent() {
+fn combined_probability_pins_the_computed_band() {
+    // The component bands guarantee p <= 5%, so that alone certifies
+    // nothing. The computed value is ~0.42% — an order of magnitude below
+    // the paper's ≲5% CEILING (the paper quotes an upper bound, not a
+    // point estimate; our factorized F_SUCCESS x geometry x close-encounter
+    // product sits well inside it). Pin the computed band.
     let p = total_probability();
     assert!(
-        p > 0.0 && p <= PUBLISHED_MAX_PROBABILITY,
-        "P_total = {p:.4} should be in (0, {PUBLISHED_MAX_PROBABILITY}] (published ≲5%)"
+        (0.003..0.006).contains(&p),
+        "P_total = {p:.4} drifted out of the computed 0.3-0.6% band"
+    );
+    assert!(
+        p <= PUBLISHED_MAX_PROBABILITY,
+        "P_total = {p:.4} must respect the published ≲{PUBLISHED_MAX_PROBABILITY} ceiling"
     );
 }
 

--- a/crates/p9-2026-iorio-precession/src/lib.rs
+++ b/crates/p9-2026-iorio-precession/src/lib.rs
@@ -489,7 +489,19 @@ mod tests {
             saturn_perihelion_precession_arcsec_per_cy(&px),
             SATURN_PRECESSION_BOUND_ARCSEC_PER_CY
         );
-        // These two are recorded as computed facts (whichever way they fall):
-        let _ = (is_excluded(&p9), is_excluded(&py));
+        // The other two verdicts are computed facts — assert them, don't
+        // discard them: the ~6 M⊕/460 AU Planet Nine precesses Saturn at
+        // ~0.5 mas/cy, inside the 1 mas/cy bound (allowed); the close warp
+        // Planet Y at ~1.3 mas/cy is excluded.
+        assert!(
+            !is_excluded(&p9),
+            "Planet Nine ({:.3e} as/cy) should sit inside the bound",
+            saturn_perihelion_precession_arcsec_per_cy(&p9)
+        );
+        assert!(
+            is_excluded(&py),
+            "warp Planet Y ({:.3e} as/cy) should exceed the bound",
+            saturn_perihelion_precession_arcsec_per_cy(&py)
+        );
     }
 }


### PR DESCRIPTION
Fixes #260. All ten checklist items:

1. holman-payne sky test: the computed favored direction is actually only **7.5°** from the published (RA 40°, Dec −15°) center — the unfalsifiable 120° bound is now 15°, with the offset recorded inline (the phantom REPRODUCTION_NOTES reference removed).
2. 2019-review grid: `assert_eq!(viable, 1134)` — the code reproduces the paper's count exactly.
3. p9-2022-des per-model recovery tolerance 0.12 → **0.04**, tighter than the Table-1 inter-model spread (0.113) that let the #212 column-shift bug through. Passes.
4. commensurabilities: the R̄-vs-control comparison no longer ORs in the already-asserted `p_mc < 0.2`, so it can actually fire.
5. iorio-precession: the discarded P9/Planet-Y verdicts are asserted — P9 (~0.5 mas/cy) inside the 1 mas/cy Saturn bound, warp Planet Y (~1.3 mas/cy) excluded.
6. stellar-flybys headline: pins the computed 0.3–0.6% band (measured 0.42%) and documents that the paper's ≲5% is a ceiling the component bands guarantee — the old `p ≤ 0.05` could not fail.
7. russell-albedo: the 625 AU distance is now labeled BACK-SOLVED (the paper publishes H and m, not the distance), and the apparent-magnitude test documents it certifies consistency of the (H, d, m) triangle, not an independent reproduction; the genuine H = −5.2/−6.1 pins stand.
8. simons-forecast: the SO reach test is labeled a round-trip of the reverse-engineered flux limits, with the published ACT band as the independent anchor; tuning recorded in the REPRODUCTION_NOTES tuned-parameters list.
9. planet-y: the x·s/s "debiasing" identity (free efficiency-slope knob, no pipeline consumer) deleted outright per the no-dead-code rule; the lib doc says what a real ε(i) would require.
10. p9-2017-bias: `bias_grid`/`bias_max` docs no longer claim a rejection-sampler role — they are labeled diagnostics; the sampler correctly rejects against the exact envelope 1.0 (B ∈ [0, 1]).