### PR TITLE
p9-core numerics hardening

### DIFF
--- a/crates/p9-2021-stability/src/nbody_validation.rs
+++ b/crates/p9-2021-stability/src/nbody_validation.rs
@@ -30,8 +30,6 @@ pub fn neptune_circular() -> MassiveBody {
             Vector3::new(0.0, v, 0.0),
         ),
         radius_au: 1.655e-4,
-        j2: None,
-        j4: None,
     }
 }
 

--- a/crates/p9-2022-des/src/survey_model.rs
+++ b/crates/p9-2022-des/src/survey_model.rs
@@ -32,15 +32,6 @@ pub enum DesBand {
     Y,
 }
 
-fn ra_in_range(ra: f64, start: f64, end: f64) -> bool {
-    let ra = ra.rem_euclid(360.0);
-    if start <= end {
-        (start..end).contains(&ra)
-    } else {
-        ra >= start || ra < end
-    }
-}
-
 /// DES survey model parameters for Planet Nine detection.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DesSurvey {

--- a/crates/p9-core/src/analysis/circular.rs
+++ b/crates/p9-core/src/analysis/circular.rs
@@ -157,8 +157,26 @@ pub fn bessel_i0(x: f64) -> f64 {
     }
 }
 
+/// ln I₀(x): overflow-safe log of the modified Bessel function. `bessel_i0`
+/// itself overflows to +inf for x ≳ 709 (exp(x) leaves f64), while von Mises
+/// log-likelihood consumers only ever need the log — for large |x| this uses
+/// the asymptotic ln I₀(x) = |x| − ln√(2π|x|) + ln(1 + 1/(8|x|) + …).
+pub fn ln_bessel_i0(x: f64) -> f64 {
+    let ax = x.abs();
+    if ax < 700.0 {
+        bessel_i0(x).ln()
+    } else {
+        // Asymptotic series: I0(x) ~ e^x/sqrt(2 pi x) (1 + 1/(8x) + 9/(128x^2)).
+        let corr = 1.0 + 1.0 / (8.0 * ax) + 9.0 / (128.0 * ax * ax);
+        ax - 0.5 * (2.0 * std::f64::consts::PI * ax).ln() + corr.ln()
+    }
+}
+
 /// Maximum-likelihood κ from the mean resultant length R̄
-/// (Mardia & Jupp 2000 piecewise approximation of A⁻¹).
+/// (Mardia & Jupp 2000 piecewise approximation of A⁻¹). Clamped at 500 —
+/// far beyond any physical concentration in this workspace and safely below
+/// the x ≈ 709 overflow of `bessel_i0`, so downstream `bessel_i0(κ).ln()`
+/// stays finite (use `ln_bessel_i0` for arbitrary κ).
 pub fn kappa_from_r_bar(r_bar: f64) -> f64 {
     let kappa = if r_bar < 0.53 {
         2.0 * r_bar + r_bar.powi(3) + 5.0 * r_bar.powi(5) / 6.0
@@ -167,12 +185,12 @@ pub fn kappa_from_r_bar(r_bar: f64) -> f64 {
     } else {
         let denom = r_bar.powi(3) - 4.0 * r_bar.powi(2) + 3.0 * r_bar;
         if denom.abs() < 1e-10 {
-            1000.0 // Very concentrated distribution
+            500.0 // Very concentrated distribution
         } else {
             1.0 / denom
         }
     };
-    kappa.clamp(0.0, 1000.0)
+    kappa.clamp(0.0, 500.0)
 }
 
 #[cfg(test)]
@@ -279,5 +297,32 @@ mod tests {
         assert!(kappa_from_r_bar(0.2) < kappa_from_r_bar(0.6));
         assert!(kappa_from_r_bar(0.6) < kappa_from_r_bar(0.9));
         assert!(kappa_from_r_bar(0.0) < 1e-9);
+    }
+
+    #[test]
+    fn ln_bessel_stays_finite_where_bessel_overflows() {
+        // Continuity across the asymptotic switch and finiteness far beyond
+        // the exp overflow.
+        let a = ln_bessel_i0(699.0);
+        let b = ln_bessel_i0(701.0);
+        assert!(
+            (b - a - 2.0).abs() < 0.01,
+            "slope ~1 near switch: {}",
+            b - a
+        );
+        assert!(bessel_i0(800.0).is_infinite());
+        let big = ln_bessel_i0(800.0);
+        assert!(big.is_finite() && (big - 796.0).abs() < 1.0, "{big}");
+        // Small-x agreement with the direct log.
+        for &x in &[0.1, 1.0, 10.0, 100.0] {
+            assert!((ln_bessel_i0(x) - bessel_i0(x).ln()).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn kappa_clamp_is_below_bessel_overflow() {
+        let k = kappa_from_r_bar(0.999_999);
+        assert!(k <= 500.0);
+        assert!(bessel_i0(k).is_finite());
     }
 }

--- a/crates/p9-core/src/analysis/hansen.rs
+++ b/crates/p9-core/src/analysis/hansen.rs
@@ -29,7 +29,10 @@ const MAX_POINTS: usize = 1 << 18;
 pub fn hansen_coefficient(j: i64, n: i32, m: i32, e: f64, tol: f64) -> f64 {
     assert!((0.0..1.0).contains(&e), "eccentricity out of range: {e}");
 
-    let mut n_points = 64usize;
+    // Start above the aliasing floor: the integrand oscillates ~j times per
+    // period, so fewer than ~8j nodes can alias and make one 64→128
+    // doubling false-converge for large j.
+    let mut n_points = 64usize.max(8 * j.unsigned_abs() as usize);
     let mut prev = hansen_fixed(j, n, m, e, n_points);
     while n_points < MAX_POINTS {
         n_points *= 2;

--- a/crates/p9-core/src/analysis/photometry.rs
+++ b/crates/p9-core/src/analysis/photometry.rs
@@ -243,8 +243,9 @@ mod tests {
 
     #[test]
     fn test_phase_integral_standard_values() {
-        // q(G) = 0.290 + 0.684 G: q(0.15) = 0.3926.
-        assert!((phase_integral(0.15) - 0.3926).abs() < 1e-12);
+        // q(G) = 0.290 + 0.684 G evaluated at G = 0.15 (coincidentally near
+        // π/8; computed from the linear law, not a circle constant).
+        assert!((phase_integral(0.15) - (0.290 + 0.684 * 0.15)).abs() < 1e-12);
         assert!((phase_integral(0.0) - 0.290).abs() < 1e-12);
     }
 

--- a/crates/p9-core/src/initial_conditions/planets.rs
+++ b/crates/p9-core/src/initial_conditions/planets.rs
@@ -42,43 +42,17 @@ use crate::types::{MassiveBody, StateVector};
 /// 1550–2650; DE421 (also used by `coords::observer`) covers 1900–2050.
 pub const PLANET_EPHEMERIS_FILES: [&str; 2] = ["de440.bsp", "de421.bsp"];
 
-/// Attach p9-core's physical parameters (system GM/mass, radius, J2/J4) to
-/// a giant-planet state. Single source for both the hard-coded J2000 states
+/// Attach p9-core's physical parameters (system GM/mass, radius) to a
+/// giant-planet state. Single source for both the hard-coded J2000 states
 /// and the ephemeris path, so the two can never disagree on masses.
+/// (Planetary J2/J4 enter the dynamics only through the solar-quadrupole
+/// proxy in `crate::forces::j2_secular`, not per-body fields.)
 fn giant_body(body: Body, state: StateVector) -> MassiveBody {
-    let (name, gm, mass, radius_au, j2, j4) = match body {
-        Body::Jupiter => (
-            "Jupiter",
-            GM_JUPITER,
-            MASS_JUPITER_SOLAR,
-            RADIUS_JUPITER_AU,
-            J2_JUPITER,
-            J4_JUPITER,
-        ),
-        Body::Saturn => (
-            "Saturn",
-            GM_SATURN,
-            MASS_SATURN_SOLAR,
-            RADIUS_SATURN_AU,
-            J2_SATURN,
-            J4_SATURN,
-        ),
-        Body::Uranus => (
-            "Uranus",
-            GM_URANUS,
-            MASS_URANUS_SOLAR,
-            RADIUS_URANUS_AU,
-            J2_URANUS,
-            J4_URANUS,
-        ),
-        Body::Neptune => (
-            "Neptune",
-            GM_NEPTUNE,
-            MASS_NEPTUNE_SOLAR,
-            RADIUS_NEPTUNE_AU,
-            J2_NEPTUNE,
-            J4_NEPTUNE,
-        ),
+    let (name, gm, mass, radius_au) = match body {
+        Body::Jupiter => ("Jupiter", GM_JUPITER, MASS_JUPITER_SOLAR, RADIUS_JUPITER_AU),
+        Body::Saturn => ("Saturn", GM_SATURN, MASS_SATURN_SOLAR, RADIUS_SATURN_AU),
+        Body::Uranus => ("Uranus", GM_URANUS, MASS_URANUS_SOLAR, RADIUS_URANUS_AU),
+        Body::Neptune => ("Neptune", GM_NEPTUNE, MASS_NEPTUNE_SOLAR, RADIUS_NEPTUNE_AU),
         other => panic!("{} is not a giant planet", other.name()),
     };
     MassiveBody {
@@ -87,8 +61,6 @@ fn giant_body(body: Body, state: StateVector) -> MassiveBody {
         mass,
         state,
         radius_au,
-        j2: Some(j2),
-        j4: Some(j4),
     }
 }
 

--- a/crates/p9-core/src/integrator/bulirsch_stoer.rs
+++ b/crates/p9-core/src/integrator/bulirsch_stoer.rs
@@ -321,8 +321,6 @@ mod tests {
             mass: gm_jup / GM_SUN,
             state: StateVector::new(Vector3::new(a_jup, 0.0, 0.0), Vector3::new(0.0, v_jup, 0.0)),
             radius_au: 4.78e-4,
-            j2: None,
-            j4: None,
         };
 
         let a_p = 8.0;

--- a/crates/p9-core/src/integrator/hybrid.rs
+++ b/crates/p9-core/src/integrator/hybrid.rs
@@ -142,6 +142,16 @@ pub fn hybrid_step(
     hybrid_step_with_forces(bodies, particles, active, dt, config, &[])
 }
 
+/// Timestep sanity for the WHM stage, enforced in ALL build profiles (the
+/// WHM-internal check is debug-only): a caller stepping Jupiter directly at
+/// dt = 300 d would otherwise get quietly wrong secular evolution in
+/// release builds.
+fn assert_timestep_resolves_orbits(bodies: &[MassiveBody], dt: f64) {
+    if let Err(msg) = crate::integrator::whm::validate_timestep(bodies, dt) {
+        panic!("hybrid_step: {msg}");
+    }
+}
+
 /// [`hybrid_step`] with extra kick-stage accelerations (e.g.
 /// [`ExtraForce::J2Jsu`], the averaged J+S+U quadrupole), applied to bodies
 /// and non-encounter particles in both dt/2 kicks exactly as
@@ -157,6 +167,7 @@ pub fn hybrid_step_with_forces(
     config: &SimConfig,
     extra_forces: &[ExtraForce],
 ) -> usize {
+    assert_timestep_resolves_orbits(bodies, dt);
     let half_dt = 0.5 * dt;
 
     let apply_extra =
@@ -262,8 +273,6 @@ mod tests {
             mass: gm / GM_SUN,
             state: StateVector::new(Vector3::new(a, 0.0, 0.0), Vector3::new(0.0, v, 0.0)),
             radius_au: 4.78e-4,
-            j2: None,
-            j4: None,
         }
     }
 
@@ -338,5 +347,17 @@ mod tests {
         assert!(active[0], "particle should survive");
         let r = particles[0].pos.norm();
         assert!(r.is_finite() && r > 0.1 && r < 1e4, "r = {r}");
+    }
+
+    #[test]
+    #[should_panic(expected = "hybrid_step")]
+    fn hybrid_step_rejects_unresolvable_timestep() {
+        // Jupiter direct at dt = 300 d (needs <~ 215 d) must panic in every
+        // build profile, not silently corrupt the secular evolution.
+        let mut bodies = vec![crate::initial_conditions::planets::jupiter_j2000()];
+        let mut particles: Vec<StateVector> = vec![];
+        let mut active: Vec<bool> = vec![];
+        let config = test_config(300.0);
+        hybrid_step(&mut bodies, &mut particles, &mut active, 300.0, &config);
     }
 }

--- a/crates/p9-core/src/integrator/kick.rs
+++ b/crates/p9-core/src/integrator/kick.rs
@@ -8,7 +8,9 @@
 //! - Planet-planet gravitational interactions
 //! - Planet-particle gravitational interactions
 //! - Indirect term (barycentric correction)
-//! - Optionally: J2/J4 oblateness
+//! - J2/J4 oblateness helpers ([`j2_acceleration`]), applied through
+//!   `crate::forces::ExtraForce` (e.g. the J2Jsu solar-quadrupole proxy) —
+//!   NOT read from per-body fields
 
 use nalgebra::Vector3;
 

--- a/crates/p9-core/src/integrator/whm.rs
+++ b/crates/p9-core/src/integrator/whm.rs
@@ -390,8 +390,6 @@ mod tests {
             mass: gm_planet / GM_SUN,
             state: StateVector::new(Vector3::new(a, 0.0, 0.0), Vector3::new(0.0, v, 0.0)),
             radius_au: 4.78e-4,
-            j2: None,
-            j4: None,
         }
     }
 
@@ -405,8 +403,6 @@ mod tests {
             mass: gm_planet / GM_SUN,
             state: StateVector::new(Vector3::new(0.0, a, 0.0), Vector3::new(-v, 0.0, 0.0)),
             radius_au: 4.03e-4,
-            j2: None,
-            j4: None,
         }
     }
 

--- a/crates/p9-core/src/types.rs
+++ b/crates/p9-core/src/types.rs
@@ -117,10 +117,6 @@ pub struct MassiveBody {
     pub state: StateVector,
     /// Equatorial radius in AU (for Hill sphere computation)
     pub radius_au: f64,
-    /// J2 oblateness (optional)
-    pub j2: Option<f64>,
-    /// J4 oblateness (optional)
-    pub j4: Option<f64>,
 }
 
 impl MassiveBody {
@@ -274,8 +270,6 @@ impl P9Params {
             mass: self.mass_solar(),
             state,
             radius_au,
-            j2: None,
-            j4: None,
         }
     }
 }


### PR DESCRIPTION
Fixes #261. All five items:

- **Hybrid dt validation**: `hybrid_step_with_forces` now calls WHM's `validate_timestep` in every build profile and panics with the diagnostic on failure — a caller stepping Jupiter directly at dt = 300 d can no longer get quietly wrong secular evolution in release builds. Pinned by a should_panic test.
- **Bessel overflow**: new `ln_bessel_i0` with the asymptotic ln I₀(x) = x − ln√(2πx) + ln(1 + 1/8x + 9/128x²) branch above x = 700 (continuity across the switch tested); `kappa_from_r_bar`'s clamp lowered 1000 → 500, safely below the exp overflow at x ≈ 709, so downstream `bessel_i0(κ).ln()` (the apsidal-clustering von Mises likelihood) stays finite by construction.
- **Hansen aliasing**: quadrature now starts at max(64, 8·|j|) nodes, so a single 64→128 doubling cannot false-converge by aliasing when j approaches the node count (current callers, j ≤ 40, unchanged).
- **Dead J2/J4 fields**: `MassiveBody.j2/j4` were populated on every giant but never read by any integrator path; deleted (six construction sites), the kick.rs module doc now says oblateness enters via `ExtraForce` (the J2Jsu solar-quadrupole proxy), and `giant_body` docs no longer claim per-body oblateness. The J2_*/J4_* constants stay in `constants` (uranus-tilt consumes J2_URANUS).
- **Clippy approx_constant**: the photometry test computes q(0.15) from the linear law 0.290 + 0.684·G instead of the hand-typed 0.3926 ≈ π/8.

Also removes a dead `ra_in_range` helper left in p9-2022-des by the #257 refactor (was warning). Workspace builds with zero warnings; core suite 214 passing.