### PR TITLE
Apply labeled V-to-r color before thresholding against r-band depths

### DIFF
--- a/crates/p9-2023-lsst-strategy/src/discoverable.rs
+++ b/crates/p9-2023-lsst-strategy/src/discoverable.rs
@@ -30,6 +30,7 @@ use p9_core::coords::sky::{ecliptic_vec_to_equatorial_deg, equatorial_to_galacti
 use p9_core::types::OrbitalElements;
 
 use crate::strategy::LsstStrategy;
+use p9_core::analysis::photometry::SOLAR_V_MINUS_R;
 
 /// One synthetic Planet Nine realization: its orbital elements (for the sky
 /// position) and its reflected-light apparent `V` magnitude at that position.
@@ -82,7 +83,13 @@ pub fn discovery_probability(strategy: &LsstStrategy, sample: &P9Sample) -> f64 
     if !footprint.accepts(dec_deg, gal_lat_deg) {
         return 0.0;
     }
-    footprint.coverage_fraction * strategy.linking_probability(sample.v_magnitude)
+    footprint.coverage_fraction * strategy.linking_probability(r_magnitude(sample))
+}
+
+/// r-band apparent magnitude of a sample: the population carries V, the
+/// LSST depths are r — convert with the labeled neutral-reflector color.
+fn r_magnitude(sample: &P9Sample) -> f64 {
+    sample.v_magnitude - SOLAR_V_MINUS_R
 }
 
 /// Discoverable fraction of `population` under `strategy`: the mean per-orbit
@@ -107,7 +114,7 @@ pub fn discoverable_fraction(
         let (dec_deg, gal_lat_deg) = dec_and_galactic_lat_deg(&s.elements);
         if footprint.accepts(dec_deg, gal_lat_deg) {
             in_fp += footprint.coverage_fraction;
-            expected += footprint.coverage_fraction * strategy.linking_probability(s.v_magnitude);
+            expected += footprint.coverage_fraction * strategy.linking_probability(r_magnitude(s));
         }
     }
     DiscoverableResult {

--- a/crates/p9-2025-ps1-holman/src/exclusion.rs
+++ b/crates/p9-2025-ps1-holman/src/exclusion.rs
@@ -20,6 +20,7 @@ use p9_core::types::OrbitalElements;
 use p9_core::units::{degrees, Angle};
 
 use crate::survey_model::Ps1StackSurvey;
+use p9_core::analysis::photometry::SOLAR_V_MINUS_R;
 
 /// A reference-population member reduced to the observables the survey model
 /// needs: an equatorial declination and an apparent r magnitude.
@@ -73,7 +74,9 @@ pub fn reference_targets(n: usize, seed: u64) -> Vec<DetectionTarget> {
             };
             DetectionTarget {
                 dec_deg: declination_deg(&elements),
-                r_magnitude: p.v_magnitude,
+                // The reference population carries V; the PS1 depth is r.
+                // Convert with the labeled neutral-reflector color.
+                r_magnitude: p.v_magnitude - SOLAR_V_MINUS_R,
             }
         })
         .collect()

--- a/crates/p9-core/src/analysis/photometry.rs
+++ b/crates/p9-core/src/analysis/photometry.rs
@@ -33,6 +33,14 @@ pub const NEPTUNE_MASS_EARTH: f64 = 17.147;
 /// Neptune's geometric albedo (V band).
 pub const ALBEDO_NEPTUNE: f64 = 0.41;
 
+/// Solar V − r color (AB, Willmer 2018): the color of a neutral (gray)
+/// reflector, used to convert the workspace's V-band population magnitudes
+/// onto r-band survey depths (m_r = m_V − 0.36). A Neptune-like body is
+/// somewhat BLUER in the red (CH₄ absorption pulls V − r toward ~0.2), so
+/// the neutral color slightly overstates the r-band brightness — a labeled
+/// systematic of a few tenths of a magnitude, not a hidden one.
+pub const SOLAR_V_MINUS_R: f64 = 0.36;
+
 /// Mass-radius relation for Neptunian (volatile-envelope) planets, anchored
 /// at Neptune:
 ///


### PR DESCRIPTION
Fixes #265.

Both flagged crates thresholded V-band population magnitudes directly against r-band survey depths. p9-core photometry gains `SOLAR_V_MINUS_R = 0.36` (AB, Willmer 2018) — the color of a neutral gray reflector — with docs noting a Neptune-like body's CH₄ blueness pulls V−r toward ~0.2, so the neutral color is a labeled few-tenths systematic rather than a hidden one.

- p9-2025-ps1-holman: `DetectionTarget.r_magnitude` is now `v_magnitude − SOLAR_V_MINUS_R` against the PS1 stacked r depth.
- p9-2023-lsst-strategy: `discovery_probability`/`discoverable_fraction` convert through a shared `r_magnitude()` helper before the linking-probability roll-off (the §26 footprint-binding conclusion is unchanged; the faint-tail tests still pass with the brighter r magnitudes).

All affected suites green.