### PR TITLE
Obliquity survey: unbracketed target is not a solution

### DIFF
--- a/crates/p9-2016-obliquity/src/parameter_survey.rs
+++ b/crates/p9-2016-obliquity/src/parameter_survey.rs
@@ -66,11 +66,11 @@ pub fn find_required_inclination(
 
     let target = target_obliquity_deg;
     if (obl_low - target) * (obl_high - target) > 0.0 {
-        if (obl_low - target).abs() < (obl_high - target).abs() {
-            return Some((i_low, obl_low));
-        } else {
-            return Some((i_high, obl_high));
-        }
+        // Target not bracketed in [5°, 50°]: there is NO required
+        // inclination in the search range. (A previous version returned the
+        // nearest endpoint as if it were a solution, and the survey plot
+        // colored those cells as valid — misrepresenting the boundary.)
+        return None;
     }
 
     for _ in 0..20 {
@@ -238,5 +238,19 @@ mod tests {
             obl_30,
             obl_10
         );
+    }
+
+    #[test]
+    fn unbracketed_target_returns_none() {
+        // A 0.1 M⊕ perturber cannot force 6° of solar obliquity at any
+        // i9 in [5°, 50°]: the solver must say so, not return the nearest
+        // endpoint dressed as a solution.
+        let r = find_required_inclination(0.1, 500.0, 0.5, 6.0, 0.5);
+        assert!(r.is_none(), "expected no bracketed solution, got {r:?}");
+        // A bracketable case still solves.
+        let ok = find_required_inclination(10.0, 500.0, 0.5, 6.0, 0.5);
+        assert!(ok.is_some());
+        let (_, obl) = ok.unwrap();
+        assert!((obl - 6.0).abs() < 0.5, "obliquity {obl:.2}");
     }
 }

--- a/crates/p9-2016-obliquity/src/plots.rs
+++ b/crates/p9-2016-obliquity/src/plots.rs
@@ -233,8 +233,8 @@ mod tests {
                 mutual_inclination: 0.35,
                 omega_big_sun: 0.0,
                 i_9: 0.35,
-                omega_big_9: 3.14,
-                delta_omega_big: -3.14,
+                omega_big_9: std::f64::consts::PI,
+                delta_omega_big: -std::f64::consts::PI,
             },
             ObliquitySnapshot {
                 t: 4.5 * GYR_DAYS,


### PR DESCRIPTION
Fixes #266.

`find_required_inclination` returned the nearest endpoint as `Some((i, obl))` when the 6° target wasn't bracketed in i₉ ∈ [5°, 50°], and the survey plot colored those cells as valid required inclinations — misrepresenting the survey boundary. It now returns `None` (the plot already skips `None` cells, so they render as no-solution). New test pins that a 0.1 M⊕ perturber yields `None` while a bracketable 10 M⊕ case still solves to within tolerance.

Also replaces the hand-typed ±3.14 with `std::f64::consts::PI` in plots.rs (clippy approx_constant).