### PR TITLE
ACT-mm: reach offset pinned as residual, not agreement

### DIFF
--- a/REPRODUCTION_NOTES.md
+++ b/REPRODUCTION_NOTES.md
@@ -558,6 +558,17 @@ the initial mutual inclination i₀ ≈ i₉, and the test varies that.
 
 ---
 
+### p9-2021-act-mm — mm reach ~15–20% below the published 425–775 AU band
+
+The thermal model gives d_max(10 M⊕) ≈ 364 AU at 12 mJy and ≈ 631 AU at 4 mJy vs Naess et
+al.'s 425–775 AU — a uniform under-prediction from the Neptune-anchored mass–radius relation
+and the 40 K temperature floor, where the paper uses Fortney evolutionary radii/temperatures
+(larger and warmer at 10 M⊕). Survey constants (18,000 deg², 4–12 mJy, 98/150/229 GHz, 10
+candidates) verified correct. Untuned; the sub-band reaches are pinned tightly with the
+offset direction asserted.
+- Pinned: `crates/p9-2021-act-mm/src/detectability.rs`
+  (`mm_reach_band_offset_from_paper_is_pinned`).
+
 ## Agreements within tolerance (for completeness)
 
 | Quantity | Computed | Published | Pinned at |

--- a/crates/p9-2021-act-mm/src/detectability.rs
+++ b/crates/p9-2021-act-mm/src/detectability.rs
@@ -176,13 +176,34 @@ mod tests {
     }
 
     #[test]
-    fn mm_reach_is_hundreds_of_au_and_finite() {
-        let survey = ActSurvey::default();
-        let d = max_detectable_distance(&survey, 10.0);
-        assert!(d.is_finite());
-        // A 10 M⊕ cold P9 is detectable out to several hundred AU at 8 mJy,
-        // consistent with Naess et al.'s 425–775 AU (4–12 mJy) range for 10 M⊕.
-        assert!((300.0..900.0).contains(&d), "d_max(10 M⊕) = {d:.0} AU");
+    fn mm_reach_band_offset_from_paper_is_pinned() {
+        // Documented residual (REPRODUCTION_NOTES): this model reaches
+        // d_max(10 M⊕) ≈ 364 AU at 12 mJy and ≈ 631 AU at 4 mJy, a uniform
+        // ~15% under-prediction of Naess et al.'s 425–775 AU band — the
+        // Neptune-anchored mass-radius (and 40 K floor) versus the paper's
+        // Fortney evolutionary radius/temperature. NOT "consistent with the
+        // paper" at the band edges; the offset is the finding, so pin the
+        // computed values tightly and the offset direction explicitly.
+        let d_shallow = max_detectable_distance(&ActSurvey::shallowest(), 10.0);
+        let d_deep = max_detectable_distance(&ActSurvey::deepest(), 10.0);
+        assert!(
+            (355.0..375.0).contains(&d_shallow),
+            "d_max @ 12 mJy = {d_shallow:.0} AU"
+        );
+        assert!(
+            (620.0..645.0).contains(&d_deep),
+            "d_max @ 4 mJy = {d_deep:.0} AU"
+        );
+        // Uniform under-prediction of the published band, ~10-25% at both
+        // edges.
+        let (paper_lo, paper_hi) = (425.0, 775.0);
+        for (ours, paper) in [(d_shallow, paper_lo), (d_deep, paper_hi)] {
+            let frac = ours / paper;
+            assert!(
+                (0.75..0.95).contains(&frac),
+                "reach/paper = {frac:.3} (ours {ours:.0} vs paper {paper:.0})"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #269.

The reach test asserted only (300..900) AU with a comment calling the result "consistent with" Naess et al.'s 425–775 AU band, when the model actually under-predicts both band edges by ~15% (364 AU @ 12 mJy, 631 AU @ 4 mJy) — the Neptune-anchored mass–radius and 40 K floor vs the paper's Fortney radius/temperature.

Now: the computed sub-band reaches are pinned tightly (±3%), the reach/paper ratio is asserted in (0.75, 0.95) at both edges so the offset direction itself is the regression, and the residual is documented in REPRODUCTION_NOTES with its physical cause. Survey constants were verified correct in the review and are untouched.