### PR TITLE
Rubin watch: detailed design document directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,11 @@ Planet Nine is a hypothetical large planet in the far outer Solar System, propos
 - **Michael E. Brown** — Caltech
   - Website: https://mikebrown.caltech.edu/
   - ORCID: [0000-0002-8255-0545](https://orcid.org/0000-0002-8255-0545)
+
+## Live data watch
+
+- `paper_watch/` — arXiv literature watch ledger and findings.
+- `rubin_watch/` — design and (future) operations for hitching into
+  Rubin/LSST alerts and MPC publishing: discovery ingestion, coverage
+  tracking, and a slow-mover search. Start at
+  [rubin_watch/README.md](rubin_watch/README.md).

--- a/rubin_watch/README.md
+++ b/rubin_watch/README.md
@@ -1,0 +1,77 @@
+# Rubin Watch
+
+Hitching the planet9 workspace into the live Rubin/LSST data ecosystem: new
+distant-object discoveries flow into our statistical machinery, Rubin's
+accumulating sky coverage flows into the search-hull/viability maps, and the
+alert stream is mined for the ultra-slow movers (d ≳ 200 AU) that sit at the
+edge of Rubin's own linking pipeline — the regime where Planet Nine lives.
+
+This directory will hold the operational ledgers and run reports; the system
+is specified in `design/`. Nothing here runs yet — the design is the current
+deliverable.
+
+## Why now
+
+LSST survey operations began 2026-06-30. The April 2026 early-data release
+already put ~11,000 asteroids and ~380 TNOs through the MPC, including
+**2025 LS2** (a = 523 AU, e = 0.917, q = 43.2 AU, ϖ = 336°) — a bona-fide
+ETNO by our vetted-sample cuts whose longitude of perihelion lands ~76° off
+the ϖ ≈ 52° cluster mean. Every object like it moves the clustering, gap,
+and posterior statistics this workspace maintains. Our frozen tables go
+stale in months at Rubin's discovery rate; this system keeps them current
+and turns each discovery into a recomputed verdict.
+
+## Document map
+
+| Doc | Contents |
+|---|---|
+| [design/00-goals-and-requirements.md](design/00-goals-and-requirements.md) | Goals, non-goals, science requirements, success criteria |
+| [design/01-architecture.md](design/01-architecture.md) | System architecture, dataflow, language split, repo layout |
+| [design/02-layer1-mpc-watch.md](design/02-layer1-mpc-watch.md) | **Layer 1**: MPC/SBDB distant-object poller (Phase 1) |
+| [design/03-layer2-coverage.md](design/03-layer2-coverage.md) | **Layer 2**: LSST coverage-to-date → search hull (Phase 2) |
+| [design/04-layer3-broker-intake.md](design/04-layer3-broker-intake.md) | **Layer 3**: Fink/broker alert intake (Phase 3) |
+| [design/05-layer4-slow-mover-search.md](design/05-layer4-slow-mover-search.md) | **Layer 4**: distance-hypothesis slow-mover linking (Phase 4) |
+| [design/06-statistics-battery.md](design/06-statistics-battery.md) | What recomputes when a new object lands; delta reports |
+| [design/07-schemas.md](design/07-schemas.md) | Ledger / candidate / coverage / alert-subset schemas |
+| [design/08-operations.md](design/08-operations.md) | Runbooks, cadence, git/PR conventions, credentials, failure modes |
+| [design/09-risks-open-questions.md](design/09-risks-open-questions.md) | Risk register, open questions, decision log |
+
+## Phasing at a glance
+
+| Phase | Layer | Needs | Value |
+|---|---|---|---|
+| 1 | MPC watch | nothing (public, verified live 2026-07-16) | most of the science, ~5% of the effort |
+| 2 | Coverage map | Layer-1 plumbing | hull/viability stay honest as LSST eats the southern residual |
+| 3 | Broker intake | **Fink registration (user action)** | raw material for Layer 4; coverage cross-check |
+| 4 | Slow-mover search | Layers 2+3 | the one search nobody else is guaranteed to run |
+| 5 | Streaming/SNAPS | broker APIs maturing | latency reduction only; not on critical path |
+
+## Status
+
+- 2026-07-16 — design directory written; no implementation yet. External
+  endpoints verified: MPC `distant_extended.json.gz` (updates daily), JPL
+  `sbdb_query.api` constraint queries (82 objects with a > 150 AU, q > 30 AU
+  today), SBDB single-object lookups. Fink LSST registration not yet
+  requested.
+
+## Glossary
+
+- **DIA / DIASource** — difference-image analysis; one detection on one
+  visit's difference image. The atom of the alert stream.
+- **ssObjectId** — Rubin's identifier linking a DIASource to a known solar
+  system object; absence = "unassociated".
+- **SSP** — Rubin's nightly Solar System Processing (tracklet-less linking,
+  MPC submission, MPCORB/SSObject daily products).
+- **Broker** — community service receiving the full alert stream (Fink,
+  ALeRCE, ANTARES, Babamul, Lasair, Pitt-Google, AMPEL) or a filtered
+  downstream (SNAPS, POI).
+- **MPEC** — Minor Planet Electronic Circular; discovery/orbit announcements.
+- **Tracklet** — intra-night pair/triplet of detections of one mover; P9-class
+  objects move too little intra-night to form one (see design/05).
+- **Stationary point** — epoch where a distant object's apparent motion
+  crosses zero as Earth's reflex reverses; a linking hazard and a false-match
+  source (see design/05).
+- **ETNO** — extreme trans-Neptunian object; our vetted class is a ≥ 250 AU,
+  q ≥ 40 AU (see design/02 for the full class table).
+- **PPDB / RSP** — Prompt Products Database / Rubin Science Platform
+  (data-rights gated; deliberately not on our critical path).

--- a/rubin_watch/design/00-goals-and-requirements.md
+++ b/rubin_watch/design/00-goals-and-requirements.md
@@ -1,0 +1,89 @@
+# 00 — Goals and requirements
+
+## Problem statement
+
+The workspace's scientific claims rest on frozen observational inputs (the
+vetted ETNO table, the perihelion-gap sample, the survey-coverage hull) and
+on statistics computed from them (κ/R̄/Rayleigh clustering, gap p-values,
+posterior sky maps, exclusion fractions). Rubin/LSST began survey operations
+on 2026-06-30 and will roughly decuple the known TNO population, while its
+own coverage progressively converts our "residual un-searched probability"
+into either a detection or an exclusion. Without automation, every one of
+our headline numbers decays toward stale.
+
+Separately, Rubin's nightly Solar System Processing is optimized for the
+bulk population. A Planet-Nine-class body (d ≈ 300–1000 AU) moves
+3.4–11.2″/day at opposition and 0.08–0.26″ within a standard ~33-minute
+visit pair — it forms **no intra-night tracklet** and sits at the slow tail
+of SSP's linking sensitivity. It would, however, be a perfectly ordinary
+V ≈ 20.5–23 unassociated DIASource on every visit. Nobody's pipeline is
+guaranteed to connect those dots; ours can be.
+
+## Goals
+
+- **G1 — Statistical currency.** Any newly designated distant object
+  (class table in design/02) is ingested, classified, tiered, and reflected
+  in a recomputed statistics battery within **one week** of its MPC orbit
+  posting, with a written delta report and a tracking issue.
+- **G2 — Coverage currency.** The search-hull and viability products carry
+  an "LSST (to date)" survey entry rebuilt **monthly** from Rubin's actual
+  observed footprint and depth, so the residual-probability numbers quoted
+  anywhere in this repo are never more than a month behind the sky.
+- **G3 — Independent slow-mover search.** A distance-hypothesis linking
+  search over unassociated alerts in our priority footprint (the ~5,000 deg²
+  holding 80% of the ν-weighted residual; RA 0–120°, Dec −40..+25 core),
+  sensitive to d ∈ [300, 1000] AU and V ≤ 23.5, with a measured injection/
+  recovery efficiency — not an assumed one.
+- **G4 — Provenance and honesty.** Every ingested element set carries its
+  source, epoch, arc, and uncertainty; every statistic distinguishes
+  *provisional* from *vetted* inputs; every conditional prior stays labeled.
+  Same culture as REPRODUCTION_NOTES — the automation must not launder
+  1-opposition orbits into headline claims.
+
+## Non-goals
+
+- **Not** a re-implementation of Rubin SSP, heliolinc, or difference
+  imaging. We consume DIASources; we never touch pixels except candidate
+  cutouts.
+- **Not** a full-stream consumer. ~10M alerts/night is Fink's job; we take
+  filtered subsets (design/04 budgets ≤ ~10⁵ records/night worst case).
+- **Not** a transient/variable science system. Anything with a stellar/host
+  crossmatch or an ssObjectId is dropped at intake (Layer 4 keeps
+  unassociated-only).
+- **Not** an MPC submitter — not until the policy question (OQ-1,
+  design/09) about submitting astrometry derived from public alert packets
+  is resolved. Candidates stop at a vetted internal report.
+- **Not** dependent on Rubin data rights. The design runs entirely on
+  world-public products (alerts, MPC, SBDB). The RSP/PPDB path is an
+  optimization documented in design/09, never a dependency.
+
+## Science requirements
+
+| ID | Requirement | Driver |
+|---|---|---|
+| SR-1 | Track objects with a ≥ 150 AU or q ≥ 40 AU or (q > 30 AU and a ≥ 100 AU) or i ≥ 60° | superset of every sample any crate consumes (design/02 class table) |
+| SR-2 | Distinguish provisional (1-opposition) from vetted (multi-opposition) orbits; statistics run on both, reported separately | the a–e fit degeneracy documented in `p9_core::data::refresh`; Rubin's first-year orbits will swing |
+| SR-3 | Clustering deltas reported under all three labeled selection stand-ins (`p9_core::analysis::selection::VarpiSelection`) | the verdict is selection-model dependent (core verdict-sensitivity test) |
+| SR-4 | Slow-mover search covers apparent rates 2–14″/day near opposition and is ephemeris-aware through stationary points | d ∈ [300, 1000] AU ⇒ 3.4–11.2″/day at opposition, → 0 at stationary epochs |
+| SR-5 | Slow-mover search depth V ≤ 23.5 (single-visit), ≥ 3 nights in a 90-day window | posterior residual is V ≈ 20.5–23 at d 400–900 AU; 3 nights over-determines the 5-parameter fit |
+| SR-6 | Injection/recovery efficiency ≥ 90% for synthetic P9 draws with V ≤ 23 and ≥ 3 covered nights | claimed exclusions from non-detection must be backed by measured completeness |
+| SR-7 | Coverage map resolution ≤ 1 deg² (HEALPix nside 64), per band, with visit counts and depth | matches the hull's 3° grid without aliasing survey edges |
+| SR-8 | All tests offline (fixtures); every network touch behind an explicit binary/runbook invocation | repo-wide rule; the gate must never hit the network |
+
+## Success criteria (per phase)
+
+- **Phase 1** — first ingest reproduces the current SBDB census (82 objects
+  with a > 150 AU, q > 30 AU as of 2026-07-16), classifies 2025 LS2 into the
+  vetted-candidate class, and emits a delta report with the clustering
+  battery run with-and-without it. Second run on unchanged inputs is a
+  no-op (idempotence).
+- **Phase 2** — `search_hull.json` regenerates with an "LSST (to date)"
+  entry; the excluded fraction is monotonically non-decreasing across
+  monthly runs; a synthetic full-southern-coverage input reproduces the
+  hull's existing Rubin-forecast numbers within tolerance.
+- **Phase 3** — one night of Fink Data-Transfer output lands in the local
+  store with schema-validated records; volume within budget; known-object
+  contamination after filtering < 5% (spot-checked against SkyBoT).
+- **Phase 4** — SR-6 met on injections; false-candidate rate ≤ ~10 per
+  month reaching human review; zero known objects surviving the vetting
+  chain in a blind test month.

--- a/rubin_watch/design/01-architecture.md
+++ b/rubin_watch/design/01-architecture.md
@@ -1,0 +1,105 @@
+# 01 — Architecture
+
+## System diagram
+
+```
+  EXTERNAL (all world-public unless noted)
+  ┌────────────────┐  ┌──────────────────┐  ┌───────────────────┐
+  │ MPC            │  │ JPL SBDB          │  │ Fink broker        │
+  │ distant_ext-   │  │ sbdb.api (single) │  │ Data Transfer +    │
+  │ ended.json.gz  │  │ sbdb_query.api    │  │ Kafka livestream   │
+  │ (daily) MPECs  │  │ (constraints)     │  │ (registration req) │
+  └───────┬────────┘  └────────┬──────────┘  └─────────┬─────────┘
+          │ weekly             │ per-object            │ nightly/monthly
+          ▼                    ▼                       ▼
+  ┌───────────────────────────────────┐   ┌───────────────────────────┐
+  │ LAYER 1: mpc-watch (Rust)         │   │ LAYER 3: broker intake     │
+  │ poll → diff → classify → tier     │   │ (Python: fink-client)      │
+  │ crates/p9-rubin-watch             │   │ scripts/rubin_watch/       │
+  └──────┬───────────────┬────────────┘   └──────┬──────────┬─────────┘
+         │               │                        │          │
+         ▼               │                        ▼          ▼
+  rubin_watch/           │              local alert store   LAYER 2:
+  etno_ledger.json       │              (parquet+DuckDB,    coverage map
+  (committed)            │               NOT committed)     rubin_watch/
+         │               │                        │         lsst_coverage.json
+         ▼               ▼                        ▼         (committed)
+  ┌──────────────────────────────┐   ┌──────────────────────────┐   │
+  │ STATISTICS BATTERY (Rust)    │   │ LAYER 4: slow-mover      │   │
+  │ clustering / gap / crossing  │   │ linker (Rust)            │   │
+  │ via existing paper crates    │   │ distance-hypothesis fit  │   │
+  └──────┬───────────────────────┘   └──────┬───────────────────┘   │
+         │                                  │                       │
+         ▼                                  ▼                       ▼
+  reports/rubin-watch/*.md          rubin_watch/candidates/   p9-search-hull /
+  + GitHub issue per delta          *.json + vetting chain    p9-viability regen
+```
+
+## Layering principle
+
+Each layer is independently useful and independently shippable, ordered by
+value-per-effort. Layer 1 needs no credentials and delivers most of the
+science (goal G1). Layer 2 keeps the maps honest (G2). Layers 3–4 are the
+custom search (G3) and are the only components with an external-credential
+dependency (Fink) or nontrivial storage.
+
+## Language and dependency split
+
+**Decision D-1**: Python owns broker I/O, Rust owns science.
+
+- **Rust** (`crates/p9-rubin-watch`, one binary, subcommands per layer):
+  polling MPC/SBDB (reuses `starfield::sbdb::SbdbClient` via
+  `p9_core::data::refresh`), ledger management, classification/tiering,
+  statistics battery orchestration (calls into the existing paper crates as
+  path dependencies), slow-mover linking (reuses `p9_core::coords::observer`
+  Earth ephemeris + `candidate_pair` machinery from the IRAS/AKARI work),
+  coverage-map ingestion for the hull.
+- **Python** (`scripts/rubin_watch/`): `fink-client` consumption (it is
+  Python-only), parquet writing, DuckDB spot queries, plotting. Mirrors the
+  existing `scripts/plot_*.py` convention: Python at the I/O and viz edges,
+  Rust for every number that ends up in a claim.
+
+Interchange format between the two: parquet (alert subsets) and JSON
+(everything else), schemas pinned in design/07. No Python computes a
+statistic that lands in a report.
+
+## Repo layout additions
+
+```
+crates/p9-rubin-watch/          # Rust binary: mpc-sync | coverage | link | battery
+scripts/rubin_watch/            # fink_pull.py, store.py, plot_candidates.py
+rubin_watch/                    # committed state (this dir)
+  README.md, design/            #   docs (this design)
+  etno_ledger.json              #   Layer-1 ledger        (committed)
+  lsst_coverage.json            #   Layer-2 map           (committed)
+  candidates/                   #   Layer-4 vetted output (committed)
+reports/rubin-watch/            # delta reports, one per run (committed)
+~/.cache/p9-rubin-watch/        # alert store, cutouts     (NOT committed)
+```
+
+Committed-vs-cache rule: anything a statistic depends on is committed
+(ledger, coverage, candidates); bulk intermediates (alert parquet, cutouts)
+are cache, reconstructible from the brokers, and capped (design/08).
+
+## Dataflow triggers
+
+| Event | Detected by | Triggers |
+|---|---|---|
+| New/changed distant object at MPC | Layer 1 weekly diff | classify → tier → statistics battery → delta report + issue |
+| Provisional object gains 2nd opposition | Layer 1 (arc/opposition fields) | tier promotion → battery re-run flagged "promotion" |
+| Month boundary | cron/manual | Layer 2 coverage rebuild → hull + viability regen → delta if excluded% moved ≥ 0.5 pt |
+| New Fink night pulled | Layer 3 | store append → Layer 4 incremental link over affected tiles |
+| Linker candidate survives auto-vetting | Layer 4 | candidate record + cutout fetch + human-review issue |
+| Frozen-table drift (existing sbdb-refresh guard) | Layer 1 piggyback | drift report appended to delta |
+
+## Design tenets (inherited from the workspace)
+
+1. Offline determinism: every test runs from fixtures; network only in
+   explicitly invoked binaries (SR-8).
+2. One source of truth: survey geometry/depths come from `p9_core::analysis::
+   surveys`; photometry from `p9_core::analysis::photometry`; no local copies.
+3. Honest tiers and labels: provisional vs vetted, conditional priors named
+   at every use (SR-2, SR-3).
+4. Append-only ledgers with full provenance; regeneration is always possible
+   from source APIs + git history.
+5. Everything lands via branch + PR + the standard full-suite gate.

--- a/rubin_watch/design/02-layer1-mpc-watch.md
+++ b/rubin_watch/design/02-layer1-mpc-watch.md
@@ -1,0 +1,119 @@
+# 02 — Layer 1: MPC watch (Phase 1)
+
+The highest-value, zero-credential layer: a weekly poller that discovers
+newly designated distant objects, classifies them into the sample classes
+our analyses consume, tiers them by orbit quality, and hands deltas to the
+statistics battery (design/06).
+
+## Sources (all verified live 2026-07-16)
+
+| Priority | Source | Endpoint | Role |
+|---|---|---|---|
+| Primary | MPC distant-object extended file | `https://www.minorplanetcenter.net/Extended_Files/distant_extended.json.gz` (Last-Modified updates daily; few-MB gzip, ~5–6k Centaurs/TNOs) | discovery diff: the census of designated distant objects |
+| Secondary | JPL SBDB constraint query | `https://ssd-api.jpl.nasa.gov/sbdb_query.api` with `sb-cdata={"AND":["a\|GT\|150","q\|GT\|30"]}` etc. | cross-check census (JPL syncs from MPC within days); 82 objects match a>150∧q>30 today |
+| Per-object | JPL SBDB single lookup | `https://ssd-api.jpl.nasa.gov/sbdb.api?sstr=<desig>` (already integrated via `starfield::SbdbClient`) | full-precision elements, uncertainties, arc, opposition count, orbit-solution id |
+| Tertiary | MPC Orbits API | `https://data.minorplanetcenter.net/api/get-orb` (single designation only) | element cross-check in `mpc_orb` format when SBDB and MPC file disagree |
+| Announce | Distant-object MPECs | MPC MPEC index | earlier-than-file discovery notice; parse opportunistically, never required |
+
+Caveats to encode: SBDB serves ~3 significant figures for weakly constrained
+TNOs (documented in `p9_core::data::refresh`); the MPC file and SBDB can
+disagree during the days after designation — the ledger stores both when they
+differ beyond the refresh-guard tolerances and flags the row.
+
+## Class table (SR-1)
+
+An object can carry multiple tags. Cuts follow the crates that consume them.
+
+| Tag | Cut | Consuming analyses |
+|---|---|---|
+| `etno_vetted_class` | a ≥ 250 AU ∧ q ≥ 40 AU | apsidal clustering (p9-2026), 2021-orbit R̄, hull sample vetting |
+| `etno_napier_class` | a ≥ 230 AU ∧ 30 < q < 40 AU | napier-critique debiasing sample |
+| `gap_band` | 50 ≤ q ≤ 75 AU | perihelion-gap statistic (p9-2021-perihelion-gap) |
+| `gap_context` | q ≥ 40 AU ∧ 100 ≤ a < 250 AU | gap-population context table |
+| `high_inclination` | i ≥ 60° | inclined-TNO analyses (p9-2016-inclined-tnos) |
+| `retrograde` | i > 90° | Drac-class comparisons |
+| `neptune_crossing_class` | a > 100 AU ∧ i < 40° ∧ q < 30 AU | p9-2024-neptune-crossing sample rules |
+| `sedna_like` | q ≥ 60 AU | IWG/Sedna-population notes |
+| `watch_only` | a ≥ 150 AU, none of the above | census tracking |
+
+## Tier rules (SR-2)
+
+| Tier | Criteria (all required) | Statistics treatment |
+|---|---|---|
+| `provisional` | designated, but: 1 opposition, or arc < 400 d, or SBDB condition code ≥ 6, or e ≥ 1 solution | battery runs *with and without*; never enters a frozen table; delta report shows both |
+| `vetted` | ≥ 2 oppositions ∧ arc ≥ 400 d ∧ condition code ≤ 5 | eligible for frozen-table adoption via a human-reviewed PR (never auto-committed into `p9_core::data::*`) |
+| `retired` | designation superseded/merged, or object dropped below all class cuts after orbit revision | kept in ledger with pointer to successor; excluded from battery |
+
+Rationale: Rubin's first-year orbits ride the a–e fit degeneracy hard
+(the same drift our sbdb-refresh guard documents on multi-decade objects —
+worse at 1 opposition). Example to encode as a fixture: 2025 LS2 is
+`provisional` today (arc 350 d, soln 2) despite its spectacular a = 523 AU.
+
+## Poller algorithm
+
+```
+mpc-sync [--dry-run] [--ledger rubin_watch/etno_ledger.json]
+
+1. fetch distant_extended.json.gz  → parse → filter by SR-1 superset cut
+2. fetch sbdb_query census (same cuts) → union of designations
+3. diff against ledger designations (aliases resolved first — see below)
+4. for each NEW designation:
+     a. SBDB single lookup → full elements, epoch, arc, n_opp, condition code
+     b. classify (class table) ; tier (tier rules)
+     c. append ledger record (schema design/07), provenance = {mpc_file_date,
+        sbdb_soln, fetched_at}
+5. for each KNOWN designation:
+     a. refresh elements if MPC file Last-Modified newer than ledger record
+     b. detect tier transitions (promotion/demotion) and class changes
+        (orbit revisions move objects across cuts — record as history event)
+6. piggyback: run the existing sbdb-refresh drift check across all frozen
+   tables; append any drift to the run report
+7. emit delta = {new[], promoted[], reclassified[], drifted[]}
+8. if delta nonempty and not --dry-run:
+     run statistics battery (design/06) → write reports/rubin-watch/
+     YYYY-MM-DD-mpc.md → open issue "rubin-watch: <n> new / <m> promoted"
+9. exit code 0 = clean/no-op, 1 = delta emitted, 2 = source failure
+```
+
+**Alias handling.** Provisional designations get replaced by numbered ones
+(e.g. 2004 VN112 → (474640) Alicanto). The ledger keys on a stable internal
+id; `aliases[]` accumulates every MPC/SBDB spelling; the differ resolves
+through aliases before declaring anything "new". Mis-resolution here is the
+main dedup risk — the fixture suite must include a rename.
+
+**Idempotence.** Running twice against unchanged sources must produce no
+ledger change and no report (byte-identical ledger, exit 0). This is the
+first acceptance test.
+
+## Failure handling
+
+| Failure | Behavior |
+|---|---|
+| MPC file unreachable / malformed | fall back to SBDB census alone; mark run `degraded:mpc` in report header |
+| SBDB unreachable | ledger diff against MPC file only, elements refresh skipped; `degraded:sbdb` |
+| Both unreachable | exit 2; no ledger mutation; issue only if 3 consecutive failures (ops, design/08) |
+| Element disagreement MPC↔SBDB beyond refresh tolerances | ledger stores both under `elements` and `elements_alt`; row flagged `discrepant`; battery uses SBDB (full precision) and the report notes the flag |
+| MPC format change | parser is fixture-tested; unknown fields ignored, missing required fields → exit 2 with the raw record logged |
+
+## Acceptance tests (offline, fixtures)
+
+1. **Seed reproduction**: fixture census (frozen copy of the 2026-07-16
+   SBDB query) → ledger with expected counts per class tag.
+2. **Idempotence**: second run, unchanged fixtures → no-op.
+3. **New-object path**: inject synthetic a=400/q=45 object → classified
+   `etno_vetted_class`, tiered `provisional` (1 opp), delta report contains
+   with/without clustering numbers.
+4. **2025 LS2 record**: fixture of its SBDB response → a=523, e=0.917,
+   q=43.2, ϖ=336.0°, tier `provisional`, tags {etno_vetted_class}.
+5. **Rename**: fixture rename event → no duplicate, alias appended, no delta.
+6. **Demotion**: orbit-revision fixture moving q 41→38 → class change
+   etno_vetted → napier, history event recorded, battery re-run flagged.
+
+## First live run (Phase-1 exit)
+
+Seed the ledger from the real census, ingest the ~380-TNO Rubin batch as it
+appears in the distant file, and produce the inaugural delta report: the
+vetted-clustering battery with the post-Rubin sample, explicitly including
+the 2025 LS2 with/without comparison (ϖ = 336° vs cluster mean ≈ 52°,
+circular separation ≈ 76° ≈ 2.2 circular-σ — expected to *reduce* R̄ and κ;
+quantify in the report, not here).

--- a/rubin_watch/design/03-layer2-coverage.md
+++ b/rubin_watch/design/03-layer2-coverage.md
@@ -1,0 +1,84 @@
+# 03 — Layer 2: LSST coverage-to-date → search hull (Phase 2)
+
+Purpose: keep goal G2 — the hull/viability numbers quoted anywhere in this
+repo reflect what Rubin has *actually* observed, updated monthly. Today the
+hull treats Rubin as a forecast; within a year LSST will have converted a
+large share of the southern residual, and our maps must track that
+conversion at the cadence it happens.
+
+## Source options, ranked
+
+| Rank | Source | Access | Notes |
+|---|---|---|---|
+| 1 | Alert-stream-derived coverage | world-public via Fink Data Transfer per-night pulls (Layer 3) | every processed visit emits alerts; (night, band, pointing) is reconstructible from alert metadata. Zero new dependencies once Layer 3 exists; blind to visits whose alert production failed (rare, acceptable) |
+| 2 | Published completed-visit metadata (scheduler/`schedview`-style nightly summaries) | public web, format to be confirmed at implementation | cleaner than (1) if a stable machine-readable feed exists; treat as an upgrade, verify during Phase 2 |
+| 3 | RSP ConsDB/visit tables | data-rights gated | deliberately not a dependency (non-goal); revisit only if (1) and (2) both prove inadequate |
+
+Decision D-5: build against (1), spike (2) for one afternoon during
+implementation, ignore (3).
+
+## Map specification (SR-7)
+
+`rubin_watch/lsst_coverage.json` (schema in design/07):
+
+- HEALPix, **nside 64** (49,152 pixels, ~0.84 deg² each), ring ordering.
+- Per band in {u, g, r, i, z, y}, but the hull consumes r (and g as a
+  cross-check): `n_visits[pix]`, `last_visit_mjd[pix]`,
+  `depth_single_median[pix]` (5σ PSF from alert metadata where available,
+  else the band's fiducial: r ≈ 24.3 single visit).
+- Derived, computed in Rust at hull-integration time (never stored, so the
+  model can improve without re-ingesting):
+  - `depth_catalog(pix)` — single-visit depth (a bright mover is caught on
+    any one visit; this is the conservative reachability depth),
+  - `depth_linked(pix, N)` — the magnitude at which the probability of ≥ N
+    detections over the pixel's visit history reaches 95%, via the existing
+    `p9-2023-lsst-strategy` P(≥N of M) machinery (`poisson_binomial_tail` +
+    per-visit logistic efficiency). N = 3 matches SSP-like linkability and
+    our own linker's requirement (SR-5).
+
+## Hull and viability integration
+
+- `p9-search-hull` gains an optional input: if `rubin_watch/
+  lsst_coverage.json` exists, add a `RealSurvey`-like entry **"LSST (to
+  date)"** whose acceptance is per-pixel membership (n_visits ≥ 3 in r)
+  rather than an analytic footprint. Implementation: extend the hull's
+  survey layer with a pixel-mask variant alongside `Footprint` — the
+  `max_distance_au` cap machinery (from the TESS fix) already generalizes
+  the struct; this adds a `PixelMask(HealpixMask)` footprint variant.
+  Depth per cell = `depth_linked(pix, 3)` for exclusion (an object must be
+  *linkable* to be excluded by non-detection), and the map keeps the
+  existing Rubin *forecast* entry separately so "now" vs "10-year" remain
+  distinct products.
+- `p9-viability` swaps the static "Rubin/LSST (visit)" row's sky fraction
+  for the observed fraction (pixels with ≥ 3 r visits / 4π).
+- Regeneration cadence: monthly, or immediately after any Layer-1 delta
+  that changes the posterior sample (design/06 decision rules).
+
+## Depth model honesty
+
+Two labeled systematics, both documented in the artifact header:
+
+1. Alert-derived depth is the *difference-image* point-source depth; for a
+   moving point source on a clean template it is the right number, but
+   year-2+ template self-subtraction (design/05 §hazards) degrades the
+   effective depth for ultra-slow movers. The coverage artifact therefore
+   records `template_epoch_flag` per pixel once templates begin including
+   survey-year data — consumers decide the penalty.
+2. Near-plane pixels: DIA crowding losses are not modeled; pixels with
+   |b| < 10° carry `crowding_flag = true` and the hull continues to treat
+   them conservatively (the same deliberate-fidelity choice as the ZTF
+   plane treatment, documented at the survey entry).
+
+## Acceptance tests
+
+1. **Synthetic full coverage**: a fixture map with every southern pixel at
+   200 visits reproduces the hull's existing Rubin-forecast exclusion
+   numbers within 1 point (consistency between "to date" machinery and the
+   forecast entry).
+2. **Monotonicity**: for fixture months M1 ⊂ M2 (visit sets), excluded% is
+   non-decreasing and residual% non-increasing.
+3. **Empty map**: absent/empty coverage file → hull output byte-identical
+   to today's (the entry is strictly additive).
+4. **Depth-linked sanity**: a pixel with exactly 3 visits at r=24.3 yields
+   depth_linked(3) < depth_single (needing 3 hits is harder than 1), and
+   depth_linked grows with visit count toward the logistic ceiling.

--- a/rubin_watch/design/04-layer3-broker-intake.md
+++ b/rubin_watch/design/04-layer3-broker-intake.md
@@ -1,0 +1,99 @@
+# 04 — Layer 3: broker alert intake (Phase 3)
+
+Purpose: land a filtered, schema-stable subset of Rubin alerts on local disk
+so Layer 4 can link across nights and Layer 2 can derive coverage. Alerts
+are world-public with no proprietary period; the practical tap is a broker.
+
+## Broker selection
+
+| Broker | Role here | Basis |
+|---|---|---|
+| **Fink** (primary) | Data Transfer (batch, by-night, server-side filtered) + later Kafka livestream | most SSO-developed full-stream broker; LSST API/portal gained SSO support 2026; registration = username via email, PLAINTEXT Kafka, `fink-client` pip package |
+| **ALeRCE** (secondary) | per-object API cross-checks (ssObjectId, stamp-classifier movers) | working SSO notebooks; independent classifier for candidate sanity checks |
+| **SNAPS** (watch) | future: dedicated SSO enrichment/outlier alerts | the one solar-system downstream broker; public-access paper Apr 2026, API "coming soon" — integrate when it ships (design/09 OQ-4) |
+| Lasair | none | explicitly does not handle solar-system alerts |
+| Pitt-Google/AMPEL/ANTARES/Babamul | none for now | no SSO advantage over Fink for our use |
+
+**Registration (user action, blocks this phase):** request Fink Data
+Transfer + livestream credentials with an exclosure address; store via
+1Password (`op inject` pattern, design/08). Everything below assumes it.
+
+## Intake modes
+
+### Batch (primary, Phase 3)
+
+Nightly-or-weekly pulls via Fink Data Transfer:
+
+- **Selection A — SSO-tagged**: the `b_is_solar_system` block (Fink's
+  SSO-associated alerts) over the full sky. Cheap, small, powers coverage
+  cross-checks and keeps a local record of every *known*-object detection
+  in our footprint (useful for injection-calibration and for the
+  known-object veto in Layer 4).
+- **Selection B — unassociated residue in the priority footprint**: alerts
+  with no ssObjectId, no Fink stellar/variable crossmatch, reliability high,
+  19.5 ≤ mag ≤ 24.0, inside the **priority footprint** = the hull's
+  80%-of-ν-weighted-residual region (~4,900 deg²; RA 0–120° ∪ 330–360°,
+  Dec −40..+25 core, exported from `search_hull.json` as a polygon set —
+  regenerated whenever the hull regenerates) **plus** the DES-hole cells.
+- Exact server-side filter capability is Fink's moving target; anything not
+  expressible server-side is applied client-side in `fink_pull.py` before
+  writing (the record budget below is post-filter).
+
+### Streaming (Phase 5, explicitly deferred)
+
+`fink-client` Kafka consumption of the same selections once Fink's LSST
+real-time SSO filters stabilize. Buys latency we do not need: a 300–1000 AU
+mover is findable a week later. Not on the critical path; revisit when
+SNAPS/Fink announce stable SSO topics.
+
+## Volume budget
+
+Order-of-magnitude, to be re-measured in the first week of operation:
+~10M alerts/night over ~9,600 deg² visited ⇒ ~10³/deg²/night raw. Fink's
+non-SSO, non-variable, high-reliability residue historically prunes 1–2
+orders of magnitude; our footprint intersects a fraction of any night's
+visits. Budget: **≤ 10⁵ selection-B records/night worst case, ~10⁴
+typical** (≈ 5–50 MB/night as parquet). Alarm (design/08) if a night
+exceeds 3× budget — that signals a filter regression, not science.
+
+## Record schema (subset — full spec in design/07)
+
+Keep exactly what linking and vetting need; drop cutouts (fetch on demand
+for candidates only):
+
+`alert_id, dia_source_id, dia_object_id, ss_object_id?, mjd, ra, dec,
+ra_err, dec_err, band, psf_mag, psf_mag_err, reliability, visit, detector,
+fink_class?, ingested_at`
+
+## Storage
+
+- **Format**: parquet, partitioned `night=YYYYMMDD/tile=<healpix-nside8>/`
+  (nside 8 ⇒ ~53 deg² tiles — matches linker work units).
+- **Store root**: `~/.cache/p9-rubin-watch/alerts/` — *never committed*;
+  reconstructible from Fink by night.
+- **Query layer**: DuckDB directly over the parquet tree (no server, no
+  schema migration machinery). Python writes, Rust reads (arrow/parquet
+  crate) — interchange pinned by the schema doc.
+- **Retention**: 120-day hot window (linker needs ≤ 90-day windows + slack);
+  older partitions archived to a tarball or dropped (re-pullable).
+
+## Known-object veto data
+
+Layer 4 needs "is this position a known object?" beyond ssObjectId:
+maintain a weekly ephemeris cache of all MPC distant + local-region objects
+(SkyBoT cone queries via astroquery for candidate positions, plus
+`astcheck` against the MPCORB file for bulk pre-filtering). Both are
+existing, community-standard tools; wrapping them is `scripts/rubin_watch/`
+territory, and every veto is recorded on the candidate (design/07).
+
+## Acceptance tests
+
+1. One pulled night lands schema-valid (validated against design/07) with
+   volume in budget; DuckDB count == record count.
+2. Selection-B contamination: SkyBoT spot-check of 200 random records →
+   < 5% known objects (measures the ssObjectId+crossmatch veto quality).
+3. Rust reader round-trip: parquet written by Python is read by the linker
+   with identical values (bit-exact for f64 columns).
+4. Replay: deleting a night's partition and re-pulling reproduces identical
+   record counts (broker-side determinism check; if it fails, document —
+   brokers may reprocess — and key the store on alert_id dedup instead).

--- a/rubin_watch/design/05-layer4-slow-mover-search.md
+++ b/rubin_watch/design/05-layer4-slow-mover-search.md
@@ -1,0 +1,139 @@
+# 05 — Layer 4: slow-mover search (Phase 4)
+
+The custom science layer: link unassociated DIA sources across nights into
+candidates moving like a body at d ∈ [300, 1000] AU. This is the regime
+where Rubin's own tracklet-based expectations break down and where the
+corrected search hull says the surviving Planet Nine probability lives
+(V ≈ 20.5–23 at 400–900 AU).
+
+## Target kinematics
+
+Apparent motion of a distant body is dominated by Earth's reflex:
+
+| d (AU) | rate at opposition | motion in a 33-min visit pair | own orbital motion |
+|---|---|---|---|
+| 300 | 11.2″/day | 0.26″ | ~0.7″/day |
+| 600 | 5.7″/day | 0.13″ | ~0.24″/day |
+| 1000 | 3.4″/day | 0.08″ | ~0.11″/day |
+
+Consequences that shape everything below:
+
+1. **No intra-night tracklet.** 0.08–0.26″ over a visit pair is within the
+   astrometric scatter — a P9-class object is a *stationary transient*
+   within a night. Any pipeline requiring measurable intra-night motion is
+   blind to it by construction; ours must link *nights*, not exposures.
+2. **Rate windows are epoch-dependent.** The reflex rate sweeps from the
+   opposition maximum through **zero at the stationary points** (twice per
+   year) — near which the object is indistinguishable from a static
+   transient for days–weeks, and *closer* objects (a 100-AU body near its
+   own stationary point) sweep *through* our 2–14″/day window. Rate cuts
+   alone therefore neither guarantee completeness nor purity: the linker
+   must fit the full parallactic model, not a linear rate (SR-4).
+3. **Brightness is not the hard part.** Single-visit r ≈ 24.3 covers the
+   whole residual band with margin; SR-5's V ≤ 23.5 requirement is set by
+   vetting robustness, not detectability.
+
+## Algorithm: distance-hypothesis linking
+
+Heliolinc-style transform, reusing the workspace's ephemeris machinery
+(`p9_core::coords::observer::EarthProvider`, `apparent_position*`,
+`candidate_pair` — built for the IRAS↔AKARI epoch pairing, which is the
+same physics at a 20-year baseline):
+
+```
+for each tile (healpix nside 8, ~53 deg²) and 90-day window W:
+  D ← unassociated records in tile±border(0.5°) over W        (design/04)
+  for each hypothesis 1/d on the grid (below):
+    for each detection: invert topocentric→heliocentric direction
+      assuming distance d (Earth state from EarthProvider at each mjd)
+    cluster in (λ, β) with tolerance θ_link, allowing a linear drift
+      (dλ/dt, dβ/dt) ≤ the max heliocentric rate at d      [5-param model:
+      λ0, β0, 1/d, dλ/dt, dβ/dt]
+    clusters with ≥ 3 distinct nights → least-squares refit of the 5
+      parameters over the raw (ra, dec, mjd); keep χ²/dof ≤ 3
+  merge candidates found under adjacent hypotheses (same members ⇒ one
+  candidate; record the 1/d interval that links it)
+```
+
+**Hypothesis grid.** A wrong 1/d displaces the transformed positions by
+≈ B⊥·Δ(1/d) (B⊥ = Earth's projected baseline over the window, ≤ 2 AU for
+90 days). Requiring < 2″ (≈ 9.7 µrad) residual:
+
+- 90-day window: Δ(1/d) ≤ 4.8×10⁻⁶ AU⁻¹ over the range 1/1000–1/300 =
+  2.33×10⁻³ AU⁻¹ ⇒ **≈ 480 hypotheses**.
+- 14-day window (B⊥ ≲ 0.5 AU): ⇒ ≈ 120 hypotheses.
+
+Per (tile, hypothesis), clustering ~10³–10⁴ points is a sort + neighbor
+scan — the full footprint per month is minutes of CPU, embarrassingly
+parallel over tiles. No performance heroics needed; correctness and
+bookkeeping dominate.
+
+**Window/cadence choice.** Primary: rolling 90-day windows stepped monthly,
+centered away from each tile's stationary epochs (computed from the tile's
+ecliptic longitude); secondary short windows (14 d) near opposition for the
+highest-rate close-in tail. Windows spanning a stationary point get a
+purity flag: static contaminants fit d→∞ there.
+
+## Candidate scoring and auto-vetting chain
+
+Score = f(nights, χ², arc length, magnitude consistency). A candidate must
+survive, in order:
+
+1. **Static veto**: the 5-param fit must beat (Δχ² ≥ 25) a static-source
+   fit; kills variables/dipoles near stationary epochs.
+2. **Known-object veto**: ssObjectId (already absent by selection), then
+   astcheck against current MPCORB, then SkyBoT cone at each epoch (all
+   recorded on the candidate record).
+3. **Photometric consistency**: band-corrected magnitudes consistent with
+   one reflected-light source at the fitted d over the arc
+   (`p9_core::analysis::photometry`; the fitted d and the mass–albedo band
+   must overlap the physical envelope — a labeled plausibility cut, wide).
+4. **Cutout inspection set**: fetch stamps from the broker for every member
+   (the only pixel-level step), auto-reject obvious artifacts (edge,
+   saturation flags), package the rest for human review.
+5. **Archival precovery**: predicted positions at PS1/DES/ZTF/DECaLS epochs
+   using the fitted elements; a bright-enough predicted precovery that is
+   *absent* in a clean archival image is strong evidence against; a
+   *present* one is a discovery-grade confirmation. Depths come from the
+   shared `SURVEY_DEPTHS` table.
+
+Human review budget: ≤ ~10 candidates/month (SR from design/00); if the
+chain leaks more, tighten score thresholds before loosening anything else.
+
+**No MPC submission** in this phase (non-goal; OQ-1 in design/09). Output
+is `rubin_watch/candidates/<id>.json` + review issue.
+
+## Injection / recovery calibration (SR-6)
+
+Truth in advertising for any exclusion claim we ever make from this search:
+
+- Draw synthetic P9s from the ensemble posterior (`p9-search-hull`'s
+  `Draws` machinery — same clouds as the hull).
+- Generate synthetic DIA records using the *real* per-tile visit history
+  from the Layer-2 coverage map (mjd, band, depth) + astrometric noise +
+  the per-visit logistic detection efficiency.
+- Inject into real tiles (so contamination and window structure are real),
+  run the full linker + auto-vetting, measure recovery vs (V, d, nights,
+  elongation).
+- Gate: ≥ 90% recovery for V ≤ 23 with ≥ 3 covered nights in-window;
+  publish the full efficiency surface with the monthly report.
+
+## Hazards (each carries a mitigation, none is waved off)
+
+| Hazard | Effect | Mitigation |
+|---|---|---|
+| Template self-subtraction (year 2+): the mover enters the coadd template, each visit then shows a positive/negative **dipole** | flux underestimated; naive linking sees two sources | year-1 data is clean by construction; from template-era onward, extend intake to keep negative-flux DIA sources and teach the static veto the dipole signature (positive+negative pair offset consistent with fitted motion × template epoch span); coverage map's `template_epoch_flag` (design/03) marks affected pixels |
+| Stationary points | P9 static for weeks (missed links); static transients fit as d→∞ movers (false links) | window placement by tile ecliptic longitude; purity flag; static-veto Δχ² |
+| Closer objects sweeping the rate window near their stationary points | false candidates at wrong d | full 5-param fit separates them (their parallax curvature fits small d, outside grid) — verify with injected 80–150 AU decoys in the calibration suite |
+| Astrometric systematics per detector/band | fake curvature | fit includes per-band zero-point nuisance only if residuals demand it; start without |
+| Broker reprocessing / alert revisions | duplicate or shifted records | store dedup on alert_id; linker consumes latest per dia_source_id |
+| SSP already found it | wasted review | the known-object veto includes *Rubin's own* MPC submissions (weekly MPCORB refresh) — by construction we only surface what SSP hasn't designated |
+
+## Honest scope statement
+
+Rubin SSP + the community will link essentially everything at d ≲ 100–200
+AU. This layer's *unique* contribution is the 300–1000 AU, no-tracklet,
+near-stationary regime over our priority footprint — plus a measured
+completeness there, which converts "we didn't find it" into a defensible
+exclusion layer for the hull. That statement, with the efficiency surface,
+is the deliverable even if no candidate ever survives vetting.

--- a/rubin_watch/design/06-statistics-battery.md
+++ b/rubin_watch/design/06-statistics-battery.md
@@ -1,0 +1,76 @@
+# 06 — Statistics battery
+
+What actually recomputes when Layer 1 reports a delta, how results are
+reported, and which downstream artifacts regenerate. The battery reuses the
+paper crates as libraries — no statistic is reimplemented in the watcher.
+
+## Battery table
+
+Run order is fixed; each row states its input sample rule and the crate
+function(s) invoked. Every clustering statistic is computed twice — vetted
+tier only, and vetted+provisional — and reported side by side (SR-2).
+
+| # | Statistic | Sample rule | Machinery |
+|---|---|---|---|
+| B1 | ϖ mean-resultant R̄, von Mises κ, Gaussian-equivalent σ | `etno_vetted_class` | `p9-2026-apsidal-clustering` estimator pipeline (`kappa_from_r_bar`, `p_value_to_sigma` via core stats) |
+| B2 | Rayleigh + Kuiper p on ϖ, Ω, ω | same | `p9_core::analysis::circular` |
+| B3 | Selection-conditioned clustering p under all three labeled stand-ins | same | `p9_core::analysis::selection::VarpiSelection` MC (the verdict-sensitivity machinery); report the spread, never a single number (SR-3) |
+| B4 | Perihelion-gap continuous-null p, paper-epoch and current-epoch samples | `gap_band` + `gap_context` per p9-2021-perihelion-gap rules | `continuous_null_dip_p_value` |
+| B5 | Neptune-crossing sample delta | `neptune_crossing_class` | membership check against `p9-2024-neptune-crossing::observed_tnos`; if changed, re-run ζ/KS headline |
+| B6 | High-i / retrograde census delta | `high_inclination`, `retrograde` | table diff vs `p9-2016-inclined-tnos::known_objects` |
+| B7 | Frozen-table drift | all | existing sbdb-refresh guard, all five guarded tables |
+| B8 | Orbit-posterior staleness check | `etno_vetted_class` | rule-based flag, not a re-fit (below) |
+
+**B8 rule.** The published orbit solutions (`p9_survey::studies`) were fit
+to specific samples; we do not re-run anyone's MCMC automatically. Flag
+`posterior_stale` when the vetted sample differs from `BROWN_2017_SAMPLE`
+by ≥ 3 objects (added or removed) — the delta report then recommends
+opening a re-derivation issue, and the hull's ensemble caveat is quoted in
+any hull regeneration until resolved.
+
+## Delta report
+
+`reports/rubin-watch/YYYY-MM-DD-<layer>.md`, frontmatter per design/07.
+Body structure (fixed, diffable):
+
+1. **Trigger** — new/promoted/reclassified objects with elements, tier,
+   tags, provenance.
+2. **Battery results** — one table per B-row: previous value → new value
+   (vetted) and (vetted+provisional), with the with/without-new-object
+   column when the trigger is a single object.
+3. **Interpretation guardrails** — auto-inserted boilerplate: selection
+   spread (B3) restated; provisional-tier caveat; a–e degeneracy note for
+   any 1-opposition object.
+4. **Actions** — artifacts regenerated (below), issues opened, frozen-table
+   adoption recommendations (human PR required).
+
+## Regeneration decision rules
+
+| Condition | Action |
+|---|---|
+| Any B1–B4 change ≥ 0.1σ equivalent (vetted tier) | regenerate `figures/search_hull.json` + `figures/viability.json`; note headline movement in report |
+| `posterior_stale` flag newly set | issue: "re-derive orbit-solution inputs"; hull regen proceeds with caveat quoted |
+| Coverage-map monthly rebuild moves excluded% ≥ 0.5 pt | hull + viability regen; report |
+| Any frozen-table drift (B7) | drift section in report; fix-forward PR per the sbdb-refresh conventions |
+| review-article scope counters change (paper crate count/year span) | nothing — `p9-review-article` derives them at build time |
+
+## Worked example (to be executed as the Phase-1 inaugural report)
+
+Trigger: 2025 LS2 (a = 523 AU, e = 0.917, q = 43.2 AU, i = 12.6°,
+Ω = 144.0°, ω = 192.0°, ϖ = 336.0°; arc 350 d, soln 2 ⇒ tier
+`provisional`, tag `etno_vetted_class`).
+
+- B1/B2 expectation (qualitative, to be quantified by the run): ϖ = 336°
+  sits ≈ 76° from the cluster mean ≈ 52° (≈ 2.2 circular-σ given σ ≈ 34°);
+  including it in the provisional column lowers R̄ and κ and raises the
+  Rayleigh p. The vetted column is unchanged (1 opposition).
+- B3: the movement will differ by stand-in — under the cluster-aligned lobe
+  an off-cluster object is *expected* (selection suppresses nothing at
+  336°... report the actual three numbers); this is exactly the case the
+  spread-reporting rule exists for.
+- B4: q = 43.2 is below the 50–75 AU gap band → `gap_context` only; gap p
+  unchanged.
+- B8: |Δsample| = 1 → no staleness flag.
+
+The point of the worked example in this document is the *shape* of the
+report; the numbers come from the battery, never from prose.

--- a/rubin_watch/design/07-schemas.md
+++ b/rubin_watch/design/07-schemas.md
@@ -1,0 +1,154 @@
+# 07 — Schemas
+
+All committed artifacts are JSON with a top-level `schema_version` (integer)
+and `generated_utc`. Consumers reject versions they don't know (fail loud,
+never guess). Bulk alert data is parquet with the column table below.
+Migration rule: bumping `schema_version` requires a migration note in this
+file and a fixture for the old version in the parser tests.
+
+## `rubin_watch/etno_ledger.json` (Layer 1)
+
+```jsonc
+{
+  "schema_version": 1,
+  "generated_utc": "2026-07-23T04:00:00Z",
+  "source_stamps": {                       // provenance of the last sync
+    "mpc_distant_last_modified": "…",
+    "sbdb_query_fetched": "…"
+  },
+  "objects": [
+    {
+      "id": "rw-0001",                     // stable internal key (never reused)
+      "primary_desig": "2025 LS2",
+      "aliases": ["2025 LS2"],             // grows on numbering/renames
+      "tier": "provisional",               // provisional | vetted | retired
+      "class_tags": ["etno_vetted_class"], // design/02 class table
+      "discovery": { "date": "2025-06-…", "source": "rubin_ssp|other|unknown" },
+      "elements": {                        // best current (SBDB full precision)
+        "epoch_jd": 0.0, "a_au": 523.0, "e": 0.917, "q_au": 43.2,
+        "i_deg": 12.6, "omega_deg": 192.0, "omega_big_deg": 144.0,
+        "varpi_deg": 336.0,
+        "source": "sbdb", "solution_id": "2", "fetched_utc": "…"
+      },
+      "elements_alt": null,                // populated when MPC↔SBDB discrepant
+      "quality": { "arc_days": 350, "n_oppositions": 1,
+                    "condition_code": null, "n_obs": null },
+      "flags": [],                         // e.g. "discrepant"
+      "history": [                         // append-only event log
+        { "utc": "…", "event": "ingested", "detail": "mpc_distant 2026-07-16" }
+        // "refreshed" | "promoted" | "demoted" | "reclassified" | "renamed" | "retired"
+      ]
+    }
+  ]
+}
+```
+
+Ledger invariants (tested): ids unique and stable; every alias maps to
+exactly one id; `history` append-only; serialization is canonical (sorted
+keys, fixed float formatting) so no-op runs are byte-identical.
+
+## `rubin_watch/lsst_coverage.json` (Layer 2)
+
+```jsonc
+{
+  "schema_version": 1,
+  "generated_utc": "…",
+  "healpix": { "nside": 64, "ordering": "ring" },
+  "window": { "first_night": "2026-06-30", "last_night": "2026-07-31" },
+  "source": "fink_alert_metadata",         // + optional visit-feed cross-check
+  "bands": {
+    "r": {
+      "n_visits":            [ /* 49152 × u16 */ ],
+      "last_visit_mjd":      [ /* 49152 × f32, 0 = never */ ],
+      "depth_single_median": [ /* 49152 × f32, 0 = never */ ]
+    }
+    // g, i as available
+  },
+  "flags": {
+    "template_epoch": [ /* 49152 × bool */ ],   // design/03 systematic 1
+    "crowding":       [ /* 49152 × bool */ ]    // |b| < 10°
+  }
+}
+```
+
+Derived quantities (`depth_linked(pix, N)` etc.) are computed by consumers,
+never stored (design/03).
+
+## Alert-subset parquet (Layer 3, NOT committed)
+
+Partitioning `night=YYYYMMDD/tile=<nside8 pixel>/part-*.parquet`:
+
+| column | type | notes |
+|---|---|---|
+| `alert_id` | u64 | dedup key |
+| `dia_source_id` | u64 | latest-wins on broker reprocess |
+| `dia_object_id` | u64 | |
+| `ss_object_id` | u64 nullable | null ⇒ unassociated (selection B) |
+| `mjd` | f64 | midpoint TAI as served |
+| `ra`, `dec` | f64 | degrees, ICRS |
+| `ra_err`, `dec_err` | f32 | arcsec |
+| `band` | utf8 (1 char) | |
+| `psf_mag`, `psf_mag_err` | f32 | |
+| `reliability` | f32 | broker/DIA real-bogus |
+| `visit`, `detector` | u64, u16 | coverage derivation |
+| `fink_class` | utf8 nullable | crossmatch label at intake time |
+| `selection` | utf8 | "A" (sso-tagged) or "B" (unassociated) |
+| `ingested_at` | timestamp | |
+
+## `rubin_watch/candidates/<id>.json` (Layer 4)
+
+```jsonc
+{
+  "schema_version": 1,
+  "candidate_id": "cand-2026-08-0001",
+  "status": "auto_vetted",   // linked → auto_vetted → human_review → rejected|confirmed
+  "fit": {                    // the 5-parameter parallactic solution
+    "lambda0_deg": 0.0, "beta0_deg": 0.0, "inv_d_au": 0.00167,
+    "dlam_dt_deg_day": 0.0, "dbeta_dt_deg_day": 0.0,
+    "d_au": 600.0, "d_au_interval": [560, 640],
+    "chi2": 0.0, "dof": 0, "arc_days": 0.0, "n_nights": 0
+  },
+  "members": [ { "alert_id": 0, "mjd": 0.0, "ra": 0.0, "dec": 0.0,
+                 "band": "r", "psf_mag": 0.0 } ],
+  "vetting": {                // every stage recorded, pass or fail
+    "static_veto_delta_chi2": 0.0,
+    "astcheck": { "run_utc": "…", "matches": [] },
+    "skybot":   { "run_utc": "…", "matches": [] },
+    "photometric_consistency": { "pass": true, "note": "…" },
+    "cutouts": { "fetched": 0, "artifact_rejects": 0 },
+    "precovery": [ { "survey": "DES", "mjd": 0.0, "predicted_mag": 0.0,
+                     "depth": 23.8, "found": null } ]
+  },
+  "score": 0.0,
+  "window": { "tile": 0, "mjd_start": 0.0, "mjd_end": 0.0,
+              "stationary_flag": false },
+  "history": [ { "utc": "…", "event": "linked" } ]
+}
+```
+
+## Delta-report frontmatter (`reports/rubin-watch/*.md`)
+
+```yaml
+---
+schema_version: 1
+run_utc: …
+layer: mpc | coverage | broker | linker
+trigger: [ "new:2025 LS2", "promoted:…", "monthly" ]
+degraded: []           # e.g. ["sbdb"] per design/02 failure table
+battery: { B1: {...}, … }   # machine-readable copy of every table in the body
+artifacts_regenerated: [ "figures/search_hull.json" ]
+issues_opened: [ 402 ]
+---
+```
+
+The frontmatter duplicates the body's numbers so downstream tooling never
+parses prose.
+
+## Priority-footprint polygon export
+
+`rubin_watch/priority_footprint.json` — polygon set (RA/Dec vertex lists)
+exported by `p9-search-hull` alongside `search_hull.json`, marking the
+80%-of-ν-weighted-residual region + DES-hole cells. `schema_version`,
+`derived_from` (hull git hash), vertex arrays. Layer 3's selection B and
+Layer 4's tile list both consume this file, so the footprint updates
+automatically whenever the hull moves.

--- a/rubin_watch/design/08-operations.md
+++ b/rubin_watch/design/08-operations.md
@@ -1,0 +1,87 @@
+# 08 — Operations
+
+## Cadence
+
+| Task | Cadence | Runtime | Command (target CLI) |
+|---|---|---|---|
+| MPC sync + battery | weekly (Mon) | ~1 min + battery | `cargo run -p p9-rubin-watch -- mpc-sync` |
+| Frozen-table drift (piggybacked) | with mpc-sync | ~30 s | (included) |
+| Fink batch pull | weekly → nightly once stable | ~min, network-bound | `python scripts/rubin_watch/fink_pull.py --nights …` |
+| Coverage rebuild + hull/viability regen | monthly (1st) | ~5 min | `cargo run -p p9-rubin-watch -- coverage && cargo run --release -p p9-search-hull && cargo run --release -p p9-viability` |
+| Slow-mover link + vetting | monthly, after coverage | ~10 min CPU | `cargo run --release -p p9-rubin-watch -- link --window 90d` |
+| Injection/recovery calibration | monthly, with link | ~30 min | `… -- link --calibrate` |
+
+Manual-first: every task is a runbook command producing a branch + PR, in
+the paper-watch style. Cron only after ≥ 3 clean manual cycles per task,
+and cron still opens PRs — nothing lands on main without the gate.
+
+## Git and PR conventions
+
+- Branch per run: `meawoppl/rubin-watch-YYYY-MM-DD[-layer]`.
+- One PR per run; body carries the delta-report summary; `Fixes #N` only
+  when a run closes a tracked issue.
+- Ledger merge policy: the ledger is regenerated, not hand-merged — on
+  conflict, re-run the sync on a fresh branch (append-only history +
+  canonical serialization make this safe and cheap).
+- Gate: the standard full-suite worktree gate applies to every PR,
+  including docs/ledger-only runs (fixture tests exercise the parsers, so
+  a format drift is caught by the gate, not by the next live run).
+- Reports and committed artifacts follow the repo attribution rule: no
+  AI attribution anywhere.
+
+## Credentials
+
+- Fink username/group (PLAINTEXT Kafka — treat as low-sensitivity but do
+  not commit): stored in 1Password, injected via `op inject` into env
+  (`FINK_USERNAME`, `FINK_GROUP`) per the global CLAUDE.md pattern. If the
+  1Password app connection fails, the runbook says: open the 1Password app
+  first.
+- No other layer holds credentials (MPC, SBDB, SkyBoT are anonymous).
+
+## Storage budget
+
+| Store | Location | Budget | Enforcement |
+|---|---|---|---|
+| Ledger + coverage + candidates + reports | repo (committed) | ≤ ~5 MB total; coverage arrays dominate (~1 MB) | review at PR |
+| Alert parquet | `~/.cache/p9-rubin-watch/alerts/` | ≤ 10 GB (120-night hot window × ≤ 50 MB) | `fink_pull.py --prune` drops partitions beyond retention |
+| Cutouts | `~/.cache/p9-rubin-watch/cutouts/` | ≤ 1 GB | fetched per-candidate only; pruned with candidate resolution |
+
+## Failure and alerting policy
+
+- Any task exiting `2` (source failure, design/02) retries next scheduled
+  run; **3 consecutive** failures of the same task ⇒ open an ops issue
+  labeled `rubin-watch-ops`.
+- Volume alarm: a Fink pull > 3× the nightly budget aborts before write
+  and opens an ops issue (filter regression, not data).
+- Schema alarm: any `schema_version` mismatch or parquet column drift
+  aborts loudly; never coerce.
+- Degraded runs (`degraded:` nonempty) are allowed to land but the report
+  header says so; two consecutive degraded runs from the same source ⇒
+  ops issue.
+- The linker never blocks the MPC layer: layers fail independently.
+
+## External-service etiquette
+
+- MPC file: one conditional GET (If-Modified-Since) per run.
+- SBDB: ≤ 1 request/s (existing SbdbClient behavior), single-object
+  lookups only for new/refresh-due objects.
+- SkyBoT: batch cone queries, ≤ 1/s, only for linker candidates (tens per
+  month) — never bulk sweeps (astcheck against the local MPCORB handles
+  bulk).
+- Fink: use Data Transfer batch jobs as designed; livestream group-id
+  registered once; respect their published limits when they publish them.
+- Attribution: reports and any publication acknowledge Rubin/LSST alerts,
+  Fink, MPC, IMCCE SkyBoT per each service's citation policy (tracked in
+  the report template).
+
+## Runbook index (to be written with each phase's implementation)
+
+- `RUNBOOK-mpc.md` — weekly sync: command, expected output, how to read
+  the delta report, frozen-table adoption procedure (human PR).
+- `RUNBOOK-coverage.md` — monthly rebuild + hull/viability regen +
+  headline-number update procedure.
+- `RUNBOOK-fink.md` — registration, credential injection, pull, prune,
+  volume checks.
+- `RUNBOOK-linker.md` — monthly run, calibration read-out, candidate
+  review checklist (what a human checks before `human_review` →
+  `confirmed`), escalation path (OQ-1 before any external report).

--- a/rubin_watch/design/09-risks-open-questions.md
+++ b/rubin_watch/design/09-risks-open-questions.md
@@ -1,0 +1,49 @@
+# 09 — Risks, open questions, decisions
+
+## Risk register
+
+| ID | Risk | L×I | Mitigation |
+|---|---|---|---|
+| R-1 | Fink LSST SSO filtering less capable than advertised (server-side filters immature in 2026) | M×M | selection filters degrade gracefully to client-side in `fink_pull.py`; volume budget assumes worst case; ALeRCE as secondary tap |
+| R-2 | MPC file format drift breaks the parser | M×L | fixture-tested parser; unknown fields ignored; exit-2 + ops issue on required-field loss; SBDB census is an independent path |
+| R-3 | 1-opposition Rubin orbits swing (a–e degeneracy) and churn class tags | H×M | tier system is the design answer: provisional never enters frozen tables; class-change history events make churn visible instead of silent |
+| R-4 | Template self-subtraction blinds the linker from year 2 | H×M | dipole-aware static veto + negative-flux intake (design/05); `template_epoch_flag` in coverage; year-1 window is clean and is where the calibration baseline gets built |
+| R-5 | Stationary-point false links / missed links | M×M | ephemeris-aware windows, purity flags, Δχ² static veto, decoy injections (80–150 AU) in calibration |
+| R-6 | Broker outage or alert-schema version bump | M×L | store is re-pullable by night; schema alarms fail loud; 120-day retention gives slack to re-pull |
+| R-7 | Volume surprise (footprint intersects deep-drilling fields; DDF cadence ~10× normal) | M×L | 3× volume alarm; DDF field list excluded from selection B if they dominate (they are ~5 pointings, negligible P9 prior weight) |
+| R-8 | Our exclusion claims outrun measured completeness | L×H | SR-6 hard-gates any exclusion statement on the injection surface; hull integration uses `depth_linked`, not single-visit depth |
+| R-9 | Scope creep toward re-implementing SSP | M×M | non-goals list; the linker's domain statement (design/05 §honest scope) is the fence |
+| R-10 | Statistical churn: weekly deltas re-litigate headline numbers noisily | M×M | regeneration thresholds (design/06) — 0.1σ / 0.5 pt gates; reports show movement without regenerating below threshold |
+
+## Open questions
+
+| ID | Question | Blocking | Next step / owner |
+|---|---|---|---|
+| OQ-1 | Policy on deriving astrometry from public alert packets and submitting discoveries to the MPC (attribution, duplicate-submission etiquette vs Rubin SSP) | Layer 4 external reporting only | ask on the Rubin community forum + MPC helpdesk *before* any candidate leaves the repo; until answered, candidates stop at internal reports |
+| OQ-2 | Does the user hold Rubin data rights (US astronomer)? | nothing (design avoids RSP) | if yes, ConsDB visit tables upgrade Layer 2 (option 3 → option 1); check at leisure |
+| OQ-3 | Exact Fink LSST server-side filter surface (which of our selection-B cuts run broker-side) | Phase-3 efficiency, not correctness | resolve during registration; measured in the first pull |
+| OQ-4 | SNAPS API availability (public-access paper Apr 2026, API "coming soon") | Phase 5 only | quarterly check; adopt for SSO enrichment when live |
+| OQ-5 | Published machine-readable completed-visit feed (schedview/almanac) as Layer-2 source 2 | quality upgrade only | one-afternoon spike during Phase 2 |
+| OQ-6 | Negative-flux DIA sources: does Fink transfer carry them with usable reliability scores? | R-4 mitigation from year 2 | test in Phase 3 with a known slow mover (e.g. Sedna: d ≈ 80 AU, in template, dipole signature expected) |
+| OQ-7 | Alert astrometric error model (per-band, per-airmass) sufficiency for the 5-param fit χ² | Phase-4 thresholds | measure empirically from selection-A residuals of known TNOs — a free calibration set |
+
+## Decision log
+
+| ID | Decision | Rationale | Revisit if |
+|---|---|---|---|
+| D-1 | Python for broker I/O, Rust for all science | fink-client is Python-only; repo culture computes claims in Rust | a maintained Rust Kafka/Avro path for Fink appears |
+| D-2 | MPC-first phasing (Layer 1 before any broker work) | most science value, zero credentials, feeds existing machinery | never — it's already the cheapest path |
+| D-3 | No MPC submissions pending OQ-1 | policy unknown; reputational risk asymmetric | OQ-1 answered |
+| D-4 | Parquet + DuckDB store, no database server | single-operator repo, reconstructible cache, SQL when needed | multi-user or >100 GB scale |
+| D-5 | Coverage from alert metadata (+ visit-feed spike) | no data-rights dependency | OQ-2 yes AND OQ-5 inadequate |
+| D-6 | HEALPix nside 64 coverage / nside 8 linker tiles | 0.84 deg² resolves survey edges below the hull's 3° grid; 53 deg² tiles bound linker memory | hull grid changes |
+| D-7 | 90-day primary linking window, monthly step | B⊥ ≤ 2 AU keeps hypothesis grid ~480 steps; ≥3 nights realistic per WFD cadence | measured cadence in priority footprint differs materially |
+| D-8 | Committed ledgers, cached bulk | reproducibility of claims vs repo bloat | ledger approaches ~10 MB (then split by year) |
+| D-9 | Priority footprint auto-derived from the hull (polygon export) | single source of truth; footprint follows the science | never |
+
+## Explicit dependencies on user action
+
+1. **Fink registration** with an exclosure email (Phase 3 gate) — design/04.
+2. OQ-2 data-rights check (optional upgrade).
+3. Frozen-table adoptions and candidate confirmations are human-reviewed
+   PRs by design — the automation proposes, the human disposes.


### PR DESCRIPTION
Design for hitching the workspace into the live Rubin/LSST ecosystem, per the search-space follow-on work. Eleven documents under `rubin_watch/design/` (index at `rubin_watch/README.md`):

- **Goals/requirements** — statistical currency (new ETNOs → recomputed verdicts ≤ 1 week), coverage currency (hull tracks LSST-observed sky monthly), an independent 300–1000 AU slow-mover search with *measured* completeness, and hard non-goals (no SSP re-implementation, no full-stream consumption, no data-rights dependency, no MPC submissions pending policy).
- **Architecture** — four layers ordered by value-per-effort: MPC watch (zero credentials, most of the science), coverage→hull, Fink broker intake, distance-hypothesis slow-mover linker. Python owns broker I/O (fink-client), Rust owns every number that lands in a claim.
- **Layer specs** — poller algorithm with class/tier tables (provisional vs vetted encodes the a–e degeneracy honestly), HEALPix coverage map feeding a `PixelMask` hull survey entry with P(≥3 detections) linked-depth, alert-subset intake with volume budgets, and the 5-parameter parallactic linker with the hypothesis-grid math (~480 steps of 1/d for 90-day windows), stationary-point and template-dipole hazards, and an injection/recovery gate (≥90% at V ≤ 23).
- **Statistics battery** — exactly which existing crates re-run on a delta, dual-tier reporting, selection-stand-in spread always shown, regeneration thresholds, and a worked 2025 LS2 example (a = 523 AU ETNO from Rubin's April batch, ϖ 76° off the cluster mean — verified live against SBDB).
- **Schemas / operations / risks** — versioned JSON schemas for ledger, coverage, candidates and reports; cadences, git/gate conventions, credential handling, storage budgets, service etiquette; risk register, open questions (MPC submission policy, Fink filter surface), and a decision log.

External endpoints named in the spec were verified live on 2026-07-16 (MPC `distant_extended.json.gz` updating daily; SBDB constraint queries returning the 82-object a>150/q>30 census). Docs only — no code changes.