### PR TITLE
Rubin watch: Fink broker access verified end-to-end

### DIFF
--- a/reports/rubin-watch/2026-07-17-fink-spike.md
+++ b/reports/rubin-watch/2026-07-17-fink-spike.md
@@ -1,0 +1,54 @@
+---
+schema_version: 1
+run_utc: "2026-07-18T01:14:00Z"
+layer: broker
+trigger: ["fink-registration"]
+degraded: []
+---
+
+# Rubin watch — Fink connectivity spike (Phase 3 opening)
+
+Credentials arrived 2026-07-17 (username `matthew`, group
+`matthew_cosmicfrontier`; LSST server `kafka-lsst.fink-broker.org:24499`,
+ZTF `kafka-ztf.fink-broker.org:24499`; fink-client ≥ 11 required — design/04
+said ≥ 10, amended).
+
+## What was verified live
+
+1. **Registration**: `fink_client_register` for both surveys; configs in
+   `~/.finkclient/` (not committed).
+2. **Topic inventory via Kafka metadata** — LSST broker: 2,320 topics, of
+   which 11 curated livestream topics (SN/extragalactic oriented,
+   `fink_uniform_sample_lsst`, `fink_hostless_candidate_lsst`) and the rest
+   `ftransfer_lsst_*` Data-Transfer job topics. **No LSST SSO livestream
+   topic exists yet** — confirming design/09 OQ-3/R-1: the LSST
+   solar-system path today is Data Transfer, exactly the mode Layer 3 was
+   designed around. ZTF broker: `fink_sso_ztf_candidates_ztf` and
+   `fink_sso_fink_candidates_ztf` are live.
+3. **Livestream consumption, both surveys**:
+   - ZTF SSO candidates delivered (e.g. ZTF26abgssgf, mag 18.06, emitted
+     2026-07-13, consumed 2026-07-18 — inside the ~7-day queue).
+   - LSST alerts delivered (`fink_hostless_candidate_lsst`, diaObjectId
+     170591519677875016 et al.).
+
+## Implications for the design
+
+- Selection A/B batch pulls proceed via portal-created Data Transfer jobs
+  (browser step) + `fink_datatransfer` consumption (scripted). The
+  ~7-day topic lifetime means pulls must be consumed promptly once created.
+- `fink_hostless_candidate_lsst` overlaps our selection-B concept (no host
+  crossmatch): worth a standing subscription as a low-volume real-time
+  side channel — a P9-class stationary transient would land there.
+- The ZTF SSO topics give us a permanent live testbed for consumer/parquet
+  code before LSST SSO volumes exist.
+
+## Next actions
+
+1. Create the first Data Transfer job in the portal (one night,
+   `b_is_solar_system`, Light-SSO packets) → run the design/04 acceptance
+   tests: volume vs budget, schema round-trip into Rust, contamination
+   spot-check. (Browser step — user or supervised session.)
+2. Implement the consumption/re-partition loop in
+   `scripts/rubin_watch/fink_pull.py` against the ZTF SSO testbed first.
+3. Store the credentials email in 1Password (working copies are local
+   YAML only).

--- a/rubin_watch/README.md
+++ b/rubin_watch/README.md
@@ -48,6 +48,14 @@ and turns each discovery into a recomputed verdict.
 
 ## Status
 
+- 2026-07-17 — **Fink access live** (Phase 3 opened). Registered both
+  surveys with fink-client 11.0; topic inventories pulled via Kafka
+  metadata; real alerts consumed from `fink_hostless_candidate_lsst`
+  (LSST) and `fink_sso_ztf_candidates_ztf` (ZTF). Key fact: no LSST SSO
+  livestream topic exists yet — Data Transfer is the LSST SSO path, as
+  designed. See `RUNBOOK-fink.md` and
+  `reports/rubin-watch/2026-07-17-fink-spike.md`. Next: first portal
+  Data Transfer job (browser step) → volume spike.
 - 2026-07-16 (later) — **Phase 1 implemented and seeded.**
   `crates/p9-rubin-watch` (`mpc-sync` subcommand) + `RUNBOOK-mpc.md`;
   ledger seeded with the live census (370 minor planets: 358 SBDB

--- a/rubin_watch/RUNBOOK-fink.md
+++ b/rubin_watch/RUNBOOK-fink.md
@@ -1,0 +1,82 @@
+# Runbook — Fink broker access (Layer 3)
+
+Registration is done (2026-07-17, fink-client 11.0). Credentials are
+low-sensitivity (PLAINTEXT Kafka, no password) but keep the email in
+1Password; the working copies live in `~/.finkclient/{lsst,ztf}_credentials.yml`
+and are NOT in the repo.
+
+## Environment
+
+```bash
+uv venv ~/.venvs/fink && uv pip install --python ~/.venvs/fink/bin/python "fink-client>=11"
+```
+
+(System python is PEP-668 managed and `python3 -m venv` lacks ensurepip on
+this box — use uv.)
+
+## Re-registering / changing topics
+
+```bash
+~/.venvs/fink/bin/fink_client_register -survey lsst \
+  -username matthew -group_id matthew_cosmicfrontier \
+  -servers kafka-lsst.fink-broker.org:24499 \
+  -mytopics fink_uniform_sample_lsst fink_hostless_candidate_lsst -maxtimeout 30
+# same for -survey ztf with kafka-ztf.fink-broker.org:24499
+```
+
+Topic choices can change any time (re-register). Discover what exists with
+Kafka metadata (no docs needed):
+
+```bash
+~/.venvs/fink/bin/python -c "
+from confluent_kafka import Consumer
+c = Consumer({'bootstrap.servers': 'kafka-lsst.fink-broker.org:24499',
+              'group.id': 'matthew_cosmicfrontier'})
+print(sorted(t for t in c.list_topics(timeout=15).topics
+             if t.startswith('fink_')))"
+```
+
+## Topic map (as verified 2026-07-17)
+
+- **LSST curated (11 topics)**: extragalactic/SN oriented plus
+  `fink_uniform_sample_lsst` and `fink_hostless_candidate_lsst`.
+  **No LSST SSO livestream topic exists yet** — the LSST solar-system path
+  is Data Transfer (`b_is_solar_system` block / Light-SSO packets), per
+  design/04. `fink_hostless_candidate_lsst` (no host crossmatch) partially
+  overlaps our selection-B and is worth watching: a P9-class stationary
+  transient would qualify.
+- **ZTF**: `fink_sso_ztf_candidates_ztf` (SSO-shaped movers) and
+  `fink_sso_fink_candidates_ztf` (Fink's own candidates, i.e. unassociated)
+  are live and flowing — the end-to-end testbed for our consumer code.
+
+## Polling (livestream)
+
+```bash
+timeout 120 ~/.venvs/fink/bin/fink_consumer -survey lsst --display -limit 5
+timeout 120 ~/.venvs/fink/bin/fink_consumer -survey ztf  --display -limit 5
+# --save -outdir DIR to keep Avro packets
+```
+
+Queue retention is ~7 days; streams are replayable within it. Verified
+2026-07-17: live LSST hostless alerts (diaObjectId-keyed) and ZTF SSO
+candidates both delivered.
+
+## Data Transfer (the LSST SSO path)
+
+1. Create the job in the portal: https://lsst.fink-portal.org/download —
+   pick nights, apply `b_is_solar_system` (selection A) or negate it +
+   quality cuts (selection B), choose the Light-SSO packet schema.
+2. The job yields a private topic `ftransfer_lsst_<date>_<id>` (lives ~7
+   days). Consume with:
+
+```bash
+~/.venvs/fink/bin/fink_datatransfer -survey lsst \
+  -topic ftransfer_lsst_... -outdir ~/.cache/p9-rubin-watch/alerts/raw \
+  -nconsumers 4 --dump_schemas --verbose
+```
+
+3. Re-partition to the design/07 parquet layout with
+   `scripts/rubin_watch/fink_pull.py` (volume alarm enforced there).
+
+Portal job creation is a browser step (login required); everything after
+the topic name is scriptable.

--- a/rubin_watch/design/04-layer3-broker-intake.md
+++ b/rubin_watch/design/04-layer3-broker-intake.md
@@ -8,7 +8,7 @@ are world-public with no proprietary period; the practical tap is a broker.
 
 | Broker | Role here | Basis |
 |---|---|---|
-| **Fink** (primary) | Data Transfer (batch, by-night, server-side filtered) + later Kafka livestream | most SSO-developed full-stream broker; LSST API/portal gained SSO support 2026; registration = username via email, PLAINTEXT Kafka, `fink-client` pip package |
+| **Fink** (primary) | Data Transfer (batch, by-night, server-side filtered) + later Kafka livestream | most SSO-developed full-stream broker; LSST API/portal gained SSO support 2026; registration = username via email, PLAINTEXT Kafka, `fink-client` pip package (≥ 11 for the LSST era; verified 11.0) |
 | **ALeRCE** (secondary) | per-object API cross-checks (ssObjectId, stamp-classifier movers) | working SSO notebooks; independent classifier for candidate sanity checks |
 | **SNAPS** (watch) | future: dedicated SSO enrichment/outlier alerts | the one solar-system downstream broker; public-access paper Apr 2026, API "coming soon" — integrate when it ships (design/09 OQ-4) |
 | Lasair | none | explicitly does not handle solar-system alerts |

--- a/rubin_watch/design/09-risks-open-questions.md
+++ b/rubin_watch/design/09-risks-open-questions.md
@@ -21,7 +21,7 @@
 |---|---|---|---|
 | OQ-1 | Policy on deriving astrometry from public alert packets and submitting discoveries to the MPC (attribution, duplicate-submission etiquette vs Rubin SSP) | Layer 4 external reporting only | ask on the Rubin community forum + MPC helpdesk *before* any candidate leaves the repo; until answered, candidates stop at internal reports |
 | OQ-2 | Does the user hold Rubin data rights (US astronomer)? | nothing (design avoids RSP) | if yes, ConsDB visit tables upgrade Layer 2 (option 3 → option 1); check at leisure |
-| OQ-3 | Exact Fink LSST server-side filter surface (which of our selection-B cuts run broker-side) | Phase-3 efficiency, not correctness | resolve during registration; measured in the first pull |
+| OQ-3 | ~~Exact Fink LSST server-side filter surface~~ **Answered 2026-07-17**: no LSST SSO livestream topic exists (11 curated topics, SN/extragalactic + uniform-sample + hostless); LSST SSO data flows via Data Transfer jobs only, with `b_is_solar_system`/Light-SSO packets applied job-side. Remaining sub-question: which selection-B quality cuts the DT job builder accepts — measured in the first pull | — | first portal Data Transfer job |
 | OQ-4 | SNAPS API availability (public-access paper Apr 2026, API "coming soon") | Phase 5 only | quarterly check; adopt for SSO enrichment when live |
 | OQ-5 | Published machine-readable completed-visit feed (schedview/almanac) as Layer-2 source 2 | quality upgrade only | one-afternoon spike during Phase 2 |
 | OQ-6 | Negative-flux DIA sources: does Fink transfer carry them with usable reliability scores? | R-4 mitigation from year 2 | test in Phase 3 with a known slow mover (e.g. Sedna: d ≈ 80 AU, in template, dipole signature expected) |
@@ -43,7 +43,10 @@
 
 ## Explicit dependencies on user action
 
-1. **Fink registration** with an exclosure email (Phase 3 gate) — design/04.
+1. ~~Fink registration~~ **Done 2026-07-17** (username matthew, group
+   matthew_cosmicfrontier; connectivity verified both surveys). Remaining
+   user-adjacent step: create the first portal Data Transfer job (browser
+   login) — after that everything is scripted.
 2. OQ-2 data-rights check (optional upgrade).
 3. Frozen-table adoptions and candidate confirmations are human-reviewed
    PRs by design — the automation proposes, the human disposes.

--- a/scripts/rubin_watch/fink_pull.py
+++ b/scripts/rubin_watch/fink_pull.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Fink Data Transfer pull for the Rubin watch (Layer 3, design/04).
 
-Credential-gated: does nothing useful until Fink registration lands
-(`rubin_watch/design/04-layer3-broker-intake.md`). Registration writes
-~/.finkclient/lsst_credentials.yml via `fink_client_register -survey lsst ...`;
-this script refuses to run without it rather than half-working.
+Registration landed 2026-07-17 (see rubin_watch/RUNBOOK-fink.md for the
+verified environment: uv venv at ~/.venvs/fink, fink-client >= 11,
+servers kafka-{lsst,ztf}.fink-broker.org:24499). Credentials live in
+~/.finkclient/{lsst,ztf}_credentials.yml; this script refuses to run
+without them rather than half-working.
 
 Usage:
   fink_pull.py --check-creds
@@ -62,7 +63,11 @@ def pull(topic: str, outdir: pathlib.Path) -> int:
         # Imported lazily: fink-client is only needed on the machine that pulls.
         from fink_client.consumer import AlertConsumer  # noqa: F401
     except ImportError:
-        print("pip install fink-client (>=10, LSST-era) first", file=sys.stderr)
+        print(
+            "fink-client >= 11 required; run under ~/.venvs/fink "
+            "(see rubin_watch/RUNBOOK-fink.md)",
+            file=sys.stderr,
+        )
         return 2
     # Consumption loop lands with the Phase-3 spike once credentials exist:
     # fink_datatransfer is the reference consumer; this script will either


### PR DESCRIPTION
Phase 3 opens. With the credentials that arrived today (fink-client 11.0, both surveys registered):

- **Topic inventories pulled via Kafka metadata** — LSST broker: 2,320 topics, 11 curated livestream streams, and the decisive fact for our design: **no LSST SSO livestream topic exists yet** — the LSST solar-system path is Data Transfer jobs (`b_is_solar_system` / Light-SSO packets), which is exactly the batch mode design/04 made primary. ZTF's `fink_sso_ztf_candidates_ztf` / `fink_sso_fink_candidates_ztf` are live and become our permanent consumer-code testbed.
- **Real alerts consumed through our registration on both surveys**: LSST `fink_hostless_candidate_lsst` (diaObjectId-keyed; no-host-crossmatch — partially overlaps our selection-B concept, flagged as a standing low-volume side channel) and ZTF SSO candidates (mag ~17–18 movers from the 7-day queue).
- New `rubin_watch/RUNBOOK-fink.md` (verified environment: uv venv — system python is PEP-668/ensurepip-broken here — registration, topic discovery via Kafka metadata, polling, Data Transfer consumption); spike report under `reports/rubin-watch/`; design/09 OQ-3 answered and the registration dependency closed; `fink_pull.py` updated to the ≥ 11 reality.

Remaining browser-login step before the volume spike: create the first portal Data Transfer job at lsst.fink-portal.org/download. Everything downstream of the topic name is scripted.