### PR TITLE
Rubin watch: first LSST Data Transfer spike complete

### DIFF
--- a/reports/rubin-watch/2026-07-19-lsst-transfer-spike.md
+++ b/reports/rubin-watch/2026-07-19-lsst-transfer-spike.md
@@ -1,0 +1,52 @@
+---
+schema_version: 1
+run_utc: "2026-07-19T21:30:00Z"
+layer: broker
+trigger: ["first-lsst-data-transfer"]
+degraded: []
+---
+
+# Rubin watch — first LSST Data Transfer (Phase-3 volume spike)
+
+Topic `ftransfer_lsst_2026-07-19_391190` (portal job: one night,
+`b_is_solar_system`, Light-SSO packets). A first attempt
+(`…_554964`, Batch ID 5) failed server-side in Fink's Spark date parsing
+before topic creation and was reported to the Fink team; broker metadata
+showed no completed LSST transfer by any user between 2026-07-15 and this
+job, with two schema-only stumps on 07-17 — their backend was wobbly, not
+just our job.
+
+## Acceptance results (design/04)
+
+| Check | Result |
+|---|---|
+| Volume | 13,214 Kafka messages → **45,185 alert rows** (~3.4 rows/message), 4.7 MB raw — well inside the 10⁵/night budget; no alarm |
+| Extraction | 45,185 / 45,185 rows mapped (100%); the Light-SSO packet is **flat** (not diaSource-nested) — `extract_record` now handles both shapes, verified against `lsst.v11_1` |
+| Integrity | all diaSourceIds unique; 45 healpix tiles across 2 UTC nights (the observing night straddles the boundary) |
+| Contamination | 0% — every row carries `unpacked_primary_provisional_designation` (selection A is fully associated, as designed) |
+| Photometry sanity | median 21.1 mag, faintest 24.4 (consistent with single-visit depth); median reliability ≈ 1.0; bands i/r/z/g |
+
+## Ledger cross-match (the point of the whole system)
+
+The night's detections include **2014 JW80** — a vetted object in our
+distant-object ledger (a = 138.4 AU, q = 38.0 AU, i = 40.9°, e = 0.725) —
+observed at z = 22.04, reliability 0.98, RA 247.18°, Dec −30.81°
+(MJD 61234.224). End-to-end: Rubin shutter → Fink transfer → our store →
+matched against our census, all machine-side.
+
+## Measured baselines (into design/04)
+
+- Selection-A (SSO-tagged) volume: **~45k rows/night** early-survey.
+- Light-SSO packet columns of record: diaSourceId, ssObjectId, phaseAngle,
+  diaDistanceRank, snr, psfFlux/Err, scienceFlux/Err, templateFlux/Err,
+  band, midpointMjdTai, ra, dec, reliability, packed/unpacked designations,
+  schema/broker/science versions (`lsst.v11_1`, fink 5.0rc0 / 8.52.0).
+
+## Next
+
+1. Selection-B job (negate `b_is_solar_system` + quality cuts over the
+   priority footprint) — the unassociated-residue volume measurement.
+2. Phase 2 coverage: this pull already carries (night, band, tile) — the
+   coverage-map builder has its first real input.
+3. Weekly transfer cadence per RUNBOOK-fink once selection-B volumes are
+   known.

--- a/rubin_watch/README.md
+++ b/rubin_watch/README.md
@@ -48,6 +48,15 @@ and turns each discovery into a recomputed verdict.
 
 ## Status
 
+- 2026-07-19 — **First LSST Data Transfer landed** (Phase-3 volume spike
+  complete). 45,185 SSO-tagged alert rows from one night, 100% extracted
+  into the partitioned store, 0% contamination, all acceptance checks
+  green — including a ledger cross-match: Rubin caught our tracked
+  distant object **2014 JW80** (a = 138 AU) at z = 22.0. See
+  `reports/rubin-watch/2026-07-19-lsst-transfer-spike.md`. (A first
+  portal job failed in Fink's server-side date parsing — reported
+  upstream; broker metadata showed their LSST transfers stalled for all
+  users since 07-15.) Next: selection-B job + coverage-map builder.
 - 2026-07-17 — **Fink access live** (Phase 3 opened). Registered both
   surveys with fink-client 11.0; topic inventories pulled via Kafka
   metadata; real alerts consumed from `fink_hostless_candidate_lsst`

--- a/rubin_watch/design/04-layer3-broker-intake.md
+++ b/rubin_watch/design/04-layer3-broker-intake.md
@@ -48,7 +48,10 @@ SNAPS/Fink announce stable SSO topics.
 
 ## Volume budget
 
-Order-of-magnitude, to be re-measured in the first week of operation:
+**Measured 2026-07-19 (first transfer)**: selection A (SSO-tagged) is
+~45k rows/night early-survey (4.7 MB raw) — an order of magnitude inside
+the budget below. Selection B remains to be measured. Original estimate,
+kept for the derivation:
 ~10M alerts/night over ~9,600 deg² visited ⇒ ~10³/deg²/night raw. Fink's
 non-SSO, non-variable, high-reliability residue historically prunes 1–2
 orders of magnitude; our footprint intersects a fraction of any night's

--- a/scripts/rubin_watch/fink_pull.py
+++ b/scripts/rubin_watch/fink_pull.py
@@ -102,17 +102,21 @@ def extract_record(alert: dict, survey: str, topic: str) -> dict | None:
             "topic": topic,
             "survey": survey,
         }
-    # LSST packet (diaSource-rooted; field names per the Rubin alert schema
-    # as served by Fink — verified against the first Data Transfer pull).
-    d = alert.get("diaSource") or {}
+    # LSST packet. Two shapes exist: livestream packets nest under
+    # "diaSource"; Data-Transfer Light-SSO packets are FLAT (verified against
+    # ftransfer_lsst_2026-07-19_391190, lsst.v11_1: diaSourceId, ssObjectId,
+    # psfFlux[nJy], band, midpointMjdTai, ra, dec, reliability, phaseAngle,
+    # snr, unpacked_primary_provisional_designation, ...).
+    d = alert.get("diaSource") or alert
     if d.get("ra") is None or d.get("midpointMjdTai") is None:
         return None
+    ss_name = alert.get("unpacked_primary_provisional_designation")
     return {
         "alert_id": int(alert.get("alertId") or d.get("diaSourceId") or 0),
         "dia_source_id": int(d.get("diaSourceId") or 0),
         "dia_object_id": None if d.get("diaObjectId") is None else int(d["diaObjectId"]),
         "ss_object_id": None if d.get("ssObjectId") in (None, 0) else int(d["ssObjectId"]),
-        "ss_name": None,
+        "ss_name": None if ss_name in (None, "") else str(ss_name),
         "object_id": None if d.get("diaObjectId") is None else str(d["diaObjectId"]),
         "mjd": float(d["midpointMjdTai"]),
         "ra": float(d["ra"]),
@@ -121,7 +125,9 @@ def extract_record(alert: dict, survey: str, topic: str) -> dict | None:
         "dec_err": None if d.get("decErr") is None else float(d["decErr"]),
         "band": str(d.get("band")),
         "psf_mag": None if d.get("psfFlux") is None else _njy_to_mag(float(d["psfFlux"])),
-        "psf_mag_err": None,
+        "psf_mag_err": None
+        if d.get("psfFluxErr") is None or not d.get("psfFlux")
+        else 1.0857 * float(d["psfFluxErr"]) / abs(float(d["psfFlux"])),
         "reliability": None if d.get("reliability") is None else float(d["reliability"]),
         "visit": None if d.get("visit") is None else int(d["visit"]),
         "detector": None if d.get("detector") is None else int(d["detector"]),


### PR DESCRIPTION
Phase-3 volume spike executed against `ftransfer_lsst_2026-07-19_391190` (one night, `b_is_solar_system`, Light-SSO packets):

- **45,185 alert rows** consumed (13,214 Kafka messages), 100% extracted into the partitioned store, all diaSourceIds unique, 0% contamination (fully designated, as selection A should be), median 21.1 / faintest 24.4 mag — an order of magnitude inside the volume budget. Measured baseline recorded in design/04.
- The Light-SSO packet turns out to be **flat**, not diaSource-nested: `extract_record` now handles both LSST shapes (livestream nested / transfer flat, `lsst.v11_1`), plus proper psf_mag_err from flux errors and `ss_name` from the unpacked MPC designation.
- **Ledger cross-match capstone**: the night contains Rubin detections of our tracked distant object **2014 JW80** (a = 138.4 AU, vetted tier) at z = 22.04, reliability 0.98 — shutter → Fink → store → census match, fully machine-side.
- Spike report committed; the earlier failed job (Batch ID 5, Fink server-side date-parse crash; their LSST transfers had been stalled for all users since 07-15 per broker metadata) documented and reported upstream.

Next: selection-B (unassociated residue) job to measure the other volume, and the Phase-2 coverage builder now has real (night, band, tile) input.