### PR TITLE
Programmatic Fink Data Transfer job submission

### DIFF
--- a/rubin_watch/RUNBOOK-fink.md
+++ b/rubin_watch/RUNBOOK-fink.md
@@ -74,11 +74,28 @@ associations (`ss_name`) intact.
 
 ## Data Transfer (the LSST SSO path)
 
-1. Create the job in the portal: https://lsst.fink-portal.org/download —
-   pick nights, apply `b_is_solar_system` (selection A) or negate it +
-   quality cuts (selection B), choose the Light-SSO packet schema.
+Job creation is fully scripted — the portal's submit flow is an
+unauthenticated Dash callback, driven directly by
+`scripts/rubin_watch/fink_submit_job.py` (verified against the portal
+source; first programmatic job: batch 8, 2026-07-20):
+
+```bash
+# selection A (SSO-tagged)
+~/.venvs/fink/bin/python scripts/rubin_watch/fink_submit_job.py   --start 2026-07-16 --stop 2026-07-18   --block b_is_solar_system --content "Light SSO packet"
+
+# selection B (unassociated residue, the slow-mover feed)
+~/.venvs/fink/bin/python scripts/rubin_watch/fink_submit_job.py   --start 2026-07-16 --stop 2026-07-18   --block "NOT b_is_solar_system" --content "Light static packet"   --extra-cond "diaSource.reliability > 0.9;"
+```
+
+Both dates are REQUIRED (a missing stop date crashes the server-side date
+parser — the Batch-5 failure). Negation is the literal label
+`NOT <block>`. One job per invocation; their Spark cluster does the work,
+so keep requests scoped.
+
+1. (Manual fallback: https://lsst.fink-portal.org/download with the same
+   choices.)
 2. The job yields a private topic `ftransfer_lsst_<date>_<id>` (lives ~7
-   days). Consume with:
+   days; allow minutes for the Spark job to start streaming). Consume with:
 
 ```bash
 ~/.venvs/fink/bin/fink_datatransfer -survey lsst \

--- a/rubin_watch/design/09-risks-open-questions.md
+++ b/rubin_watch/design/09-risks-open-questions.md
@@ -43,10 +43,10 @@
 
 ## Explicit dependencies on user action
 
-1. ~~Fink registration~~ **Done 2026-07-17** (username matthew, group
-   matthew_cosmicfrontier; connectivity verified both surveys). Remaining
-   user-adjacent step: create the first portal Data Transfer job (browser
-   login) — after that everything is scripted.
+1. ~~Fink registration~~ **Done 2026-07-17**; ~~portal Data Transfer
+   click~~ **scripted 2026-07-20** (`fink_submit_job.py` drives the
+   portal's unauthenticated Dash submit callback directly — no browser
+   steps remain anywhere in the pipeline).
 2. OQ-2 data-rights check (optional upgrade).
 3. Frozen-table adoptions and candidate confirmations are human-reviewed
    PRs by design — the automation proposes, the human disposes.

--- a/scripts/rubin_watch/fink_submit_job.py
+++ b/scripts/rubin_watch/fink_submit_job.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Submit a Fink LSST Data Transfer job programmatically.
+
+The portal (lsst.fink-portal.org/download) is a Plotly Dash app whose
+submit flow is a single unauthenticated callback POST to
+`/_dash-update-component`; this script drives exactly that callback with
+the same state the browser would send (verified against the portal source,
+astrolabsoftware/lsst.fink-portal.org apps/datatransfer.py). The response
+carries the server-generated topic name (`ftransfer_lsst_...`), which is
+then consumable with our registered Kafka credentials via
+`fink_pull.py --topic`.
+
+Block negation follows the portal's own encoding: the literal label
+"NOT <block>" (two clicks in the UI). Content options: "Full packet",
+"Medium packet", "Light static packet", "Light SSO packet", the LSST
+nested sections, or individual fields.
+
+Selection-B example (the unassociated residue for the slow-mover search):
+  fink_submit_job.py --start 2026-07-16 --stop 2026-07-18 \
+      --block "NOT b_is_solar_system" --content "Light static packet" \
+      --extra-cond "diaSource.reliability > 0.9;"
+
+Etiquette: one job per invocation, exactly what the UI would do; jobs run
+on Fink's Spark cluster, so keep requests scoped (design/08).
+"""
+
+import argparse
+import json
+import sys
+import urllib.request
+
+PORTAL = "https://lsst.fink-portal.org"
+
+
+def fetch_output_spec() -> tuple[str, list]:
+    """Read /_dash-dependencies and return the exact multi-output spec of the
+    submit callback (the notification property carries a build hash that must
+    match verbatim)."""
+    with urllib.request.urlopen(f"{PORTAL}/_dash-dependencies", timeout=30) as r:
+        deps = json.load(r)
+    for d in deps:
+        ins = [f"{i['id']}.{i['property']}" for i in d.get("inputs", [])]
+        if ins == ["submit_datatransfer.n_clicks"]:
+            out = d["output"]
+            # "..a.b...c.d.." -> [(id, prop), ...]
+            parts = [p for p in out.strip(".").split("...") if p]
+            outputs = [
+                {"id": p.split(".")[0], "property": p.split(".", 1)[1]} for p in parts
+            ]
+            return out, outputs
+    raise SystemExit("submit_datatransfer callback not found in dash dependencies")
+
+
+def submit(start: str, stop: str, blocks: list, tags: list, content: list,
+           extra_cond: str | None) -> dict:
+    out_spec, outputs = fetch_output_spec()
+    state = [
+        {"id": "date-range-picker", "property": "value", "value": [start, stop]},
+        {"id": "tag_select", "property": "data", "value": tags},
+        {"id": "blocks_select", "property": "data", "value": blocks},
+        {"id": "field_select", "property": "value", "value": content},
+        {"id": "extra_cond", "property": "value", "value": extra_cond},
+        {"id": "object-catalog", "property": "data", "value": None},
+        {"id": "upload-data", "property": "filename", "value": None},
+        {"id": "ra-column", "property": "value", "value": None},
+        {"id": "dec-column", "property": "value", "value": None},
+        {"id": "radius_xmatch", "property": "value", "value": None},
+        {"id": "id-column", "property": "value", "value": None},
+    ]
+    payload = {
+        "output": out_spec,
+        "outputs": outputs,
+        "inputs": [{"id": "submit_datatransfer", "property": "n_clicks", "value": 1}],
+        "changedPropIds": ["submit_datatransfer.n_clicks"],
+        "state": state,
+    }
+    req = urllib.request.Request(
+        f"{PORTAL}/_dash-update-component",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=120) as r:
+        return json.load(r)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--start", required=True, help="YYYY-MM-DD (both dates required; "
+                    "a missing stop date crashes the server-side date parser)")
+    ap.add_argument("--stop", required=True, help="YYYY-MM-DD")
+    ap.add_argument("--block", action="append", default=[],
+                    help='e.g. "b_is_solar_system" or "NOT b_is_solar_system"; repeatable')
+    ap.add_argument("--tag", action="append", default=[],
+                    help="Fink filter tag; repeatable")
+    ap.add_argument("--content", action="append", default=[],
+                    help='e.g. "Light SSO packet", "Light static packet"; '
+                    "default server-side: Full packet")
+    ap.add_argument("--extra-cond", default=None,
+                    help='semicolon-terminated SQL, e.g. "diaSource.reliability > 0.9;"')
+    args = ap.parse_args()
+
+    resp = submit(args.start, args.stop, args.block, args.tag, args.content,
+                  args.extra_cond)
+    r = resp.get("response", {})
+    topic = r.get("topic_name", {}).get("children")
+    batch = r.get("batch_id", {}).get("children")
+    notes = r.get("notification-container", {})
+    print(json.dumps({"topic": topic, "batch_id": batch}, indent=1))
+    if notes:
+        for n in next(iter(notes.values()), []) if isinstance(notes, dict) else []:
+            msg = n.get("message") if isinstance(n, dict) else n
+            print(f"note: {msg if isinstance(msg, str) else '(rich message)'}",
+                  file=sys.stderr)
+    if not topic:
+        print("no topic returned — inspect full response:", file=sys.stderr)
+        print(json.dumps(resp, indent=1)[:2000], file=sys.stderr)
+        return 2
+    print(f"\nconsume with:\n  fink_pull.py --topic {topic}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Answers "can't you do the portal thing programmatically?" — yes: the portal's submit flow is a single **unauthenticated Dash callback** (`/_dash-update-component`), verified by reading the portal source (astrolabsoftware/lsst.fink-portal.org, `apps/datatransfer.py`: `submit_job` takes n_clicks + form state, launches the Spark job via Livy, returns the topic name — no login gate anywhere in the handler).

`scripts/rubin_watch/fink_submit_job.py` drives exactly that callback with the state the browser would send: date range (both dates required — a missing stop date is what crashed Batch 5 server-side), filter tags, blocks with the portal's literal `NOT <block>` negation encoding, content packets ("Light SSO packet" / "Light static packet" / …), and semicolon-terminated SQL extra conditions. The multi-output spec (including the build-hash-suffixed notification property) is fetched fresh from `/_dash-dependencies` per run so portal redeploys don't break the payload.

**First programmatic submission succeeded**: batch 8, topic `ftransfer_lsst_2026-07-20_322886` — the selection-B job (3 nights, `NOT b_is_solar_system`, `diaSource.reliability > 0.9`, Light static packet) that feeds the slow-mover search. With this, no browser steps remain anywhere in the rubin-watch pipeline; runbook and design/09 updated.